### PR TITLE
fix UTM tracking after cart reclaim

### DIFF
--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -41,7 +41,7 @@ class Cart extends \Magento\Framework\App\Action\Action
         }
 
         $redirect = $this->resultRedirectFactory->create();
-        $redirect->setPath('checkout/cart');
+        $redirect->setPath('checkout/cart', ['_current' => true]);
         return $redirect;
     }
 }


### PR DESCRIPTION
Currently UTM params are lost in the process of redirecting which makes it hard to see who has gone through the abandoned cart flow in third-party analytics solutions. We also lose the _ke param which stops Klaviyo from tracking the post-reclaim customer journey if they are reclaimed from a different device. 

This simple fix causes any URL params to be passed into the redirected URL. 