### PR TITLE
Fix Unexpected token error for a price >= 1000.

### DIFF
--- a/view/frontend/templates/product/viewed.phtml
+++ b/view/frontend/templates/product/viewed.phtml
@@ -38,8 +38,8 @@ $_imagehelper = $this->helper('Magento\Catalog\Helper\Image');
             Name: "<?php echo $_product->getName(); ?>",
             SKU: "<?php echo $_product->getSku(); ?>",
             URL: "<?php echo $_product->getProductUrl(); ?>",
-            Price: <?php echo number_format($price, 2); ?>,
-            FinalPrice: <?php echo number_format($final_price, 2); ?>,
+            Price: <?php echo number_format($price, 2, '.', ''); ?>,
+            FinalPrice: <?php echo number_format($final_price, 2, '.', ''); ?>,
             <?php if ($_product_image_url) { ?>ImageURL: "<?php echo $_product_image_url; ?>", <?php } ?>
             Categories: <?php echo $this->getProductCategoriesAsJson(); ?>
         };


### PR DESCRIPTION
A price greater than 1000 will trigger an "Unexpected token" error.

Example:
`   Price: 1,337.00,`
