### PR TITLE
Malformed JSON error when price has a comma in it (Products over $1k)

### DIFF
--- a/view/frontend/templates/product/viewed.phtml
+++ b/view/frontend/templates/product/viewed.phtml
@@ -38,8 +38,8 @@ $_imagehelper = $this->helper('Magento\Catalog\Helper\Image');
             Name: "<?php echo $_product->getName(); ?>",
             SKU: "<?php echo $_product->getSku(); ?>",
             URL: "<?php echo $_product->getProductUrl(); ?>",
-            Price: <?php echo number_format($price, 2); ?>,
-            FinalPrice: <?php echo number_format($final_price, 2); ?>,
+            Price: <?php echo number_format($price, 2, '.', ''); ?>,
+            FinalPrice: <?php echo number_format($final_price, 2, '.', ''); ?>,
             <?php if ($_product_image_url) { ?>ImageURL: "<?php echo $_product_image_url; ?>", <?php } ?>
             Categories: <?php echo $this->getProductCategoriesAsJson(); ?>
         };


### PR DESCRIPTION
"Unable to parse JSON-LD tag. Malformed JSON found..." reported in chrome developer console whenever a product is viewed that has a comma in the price  (Products over $1k). There's prob a better way to approach this aside from `number_format` but just added a quick hotfix.