### PR TITLE
fix invalid return type

### DIFF
--- a/Api/ReclaimInterface.php
+++ b/Api/ReclaimInterface.php
@@ -7,7 +7,7 @@ interface ReclaimInterface
      * Returns a list of stores with extended information
      *
      * @api
-     * @return JSON
+     * @return mixed
      */
     public function stores();
 }

--- a/Model/Reclaim.php
+++ b/Model/Reclaim.php
@@ -8,7 +8,7 @@ class Reclaim implements ReclaimInterface
      * Returns all stores with extended descriptions
      *
      * @api
-     * @return JSON
+     * @return mixed
      */
     public function stores()
     {


### PR DESCRIPTION
We are currently using an invalid return type. https://devdocs.magento.com/guides/v2.3/extension-dev-guide/service-contracts/service-to-web-service.html

Valid scalar types include: mixed (or anyType), bool (or boolean), str (or string), integer (or int), float, and double.