### PR TITLE
subscriber api endpoint

### DIFF
--- a/Api/ReclaimInterface.php
+++ b/Api/ReclaimInterface.php
@@ -33,6 +33,15 @@ interface ReclaimInterface
      * Returns subscribers by date filter
      *
      * @api
+     * @return mixed
+     */
+
+    public function getSubscribersCount();
+
+    /**
+     * Returns subscribers by date filter
+     *
+     * @api
      * @param mixed $start
      * @param mixed $until
      * @param mixed $store_id

--- a/Api/ReclaimInterface.php
+++ b/Api/ReclaimInterface.php
@@ -30,6 +30,16 @@ interface ReclaimInterface
     public function product($quote_id, $item_id);
 
     /**
+     * Returns product by id range
+     *
+     * @api
+     * @param mixed $quote_id
+     * @param mixed $item_id
+     * @return mixed
+     */
+    public function productinspector($start_id, $end_id);
+
+    /**
      * Returns subscribers by date filter
      *
      * @api

--- a/Api/ReclaimInterface.php
+++ b/Api/ReclaimInterface.php
@@ -29,6 +29,28 @@ interface ReclaimInterface
      */
     public function product($quote_id, $item_id);
 
+    /**
+     * Returns subscribers by date filter
+     *
+     * @api
+     * @param mixed $start
+     * @param mixed $until
+     * @param mixed $storeId
+     * @return mixed
+     */
+    public function customersubscription($start, $until, $storeId=null);
+
+    /**
+     * Returns subscirbers by id
+     *
+     * @api
+     * @param mixed $start_id
+     * @param mixed $end_id
+     * @param mixed $storeId
+     * @return mixed
+     */
+    public function historicalcustomersubscription($start_id, $end_id, $storeId=null);
+
      /**
      * Returns product by id range
      * @api 

--- a/Api/ReclaimInterface.php
+++ b/Api/ReclaimInterface.php
@@ -35,10 +35,10 @@ interface ReclaimInterface
      * @api
      * @param mixed $start
      * @param mixed $until
-     * @param mixed $storeId
+     * @param mixed $store_id
      * @return mixed
      */
-    public function customersubscription($start, $until, $storeId=null);
+    public function getSubscribersByDateRange($start, $until, $store_id=null);
 
     /**
      * Returns subscirbers by id
@@ -46,18 +46,9 @@ interface ReclaimInterface
      * @api
      * @param mixed $start_id
      * @param mixed $end_id
-     * @param mixed $storeId
+     * @param mixed $store_id
      * @return mixed
      */
-    public function historicalcustomersubscription($start_id, $end_id, $storeId=null);
-
-     /**
-     * Returns product by id range
-     * @api 
-     * @param mixed $start_id
-     * @param mixed $end_id
-     * @return mixed
-     */
-    public function productinspector($start_id, $end_id);
+    public function getSubscribersById($start_id, $end_id, $store_id=null);
 
 }

--- a/Model/Reclaim.php
+++ b/Model/Reclaim.php
@@ -17,6 +17,7 @@ class Reclaim implements ReclaimInterface
     public $response;
 
     const MAX_QUERY_DAYS = 10;
+    const SUBSCRIBER_BATCH_SIZE = 500;
 
     public function __construct(
         \Magento\Framework\ObjectManagerInterface $objectManager, 
@@ -29,11 +30,9 @@ class Reclaim implements ReclaimInterface
         $this->quoteFactory = $quoteFactory;
         $this->_objectManager = $objectManager;
         $this->_subscriber= $subscriber;
-        $this->subscriberCollection = $subscriberCollection;
+        $this->_subscriberCollection = $subscriberCollection;
         $this->_klaviyoHelper = $klaviyoHelper;
-
     }
-
 
     /**
      * Returns extension version
@@ -137,6 +136,12 @@ class Reclaim implements ReclaimInterface
 
     }
 
+    public function getSubscribersCount()
+    {
+        $subscriberCount =$this->_subscriberCollection->create()->count();
+        return $subscriberCount;
+    }
+
     public function getSubscribersById($start_id, $end_id, $storeId=null)
     {
         if (!$start_id || !$end_id ){ 
@@ -147,9 +152,13 @@ class Reclaim implements ReclaimInterface
             throw new NotFoundException(__('end_id should be larger than start_id'));
         }
 
+        if (($end_id - $start_id) > self::SUBSCRIBER_BATCH_SIZE){
+            throw new NotFoundException(__('Max batch size is 500'));
+        }
+
         $storeIdFilter = $this->_storeFilter($storeId);
 
-        $subscriberCollection =$this->subscriberCollection->create()
+        $subscriberCollection =$this->_subscriberCollection->create()
             ->addFieldToFilter('subscriber_id', ['gteq' => (int)$start_id])
             ->addFieldToFilter('subscriber_id', ['lteq' => (int)$end_id])
             ->addFieldToFilter('store_id', [$storeIdFilter => $storeId]);
@@ -169,18 +178,22 @@ class Reclaim implements ReclaimInterface
         // $until = '2019-04-25 18:00:00';
         // $start = '2019-04-25 00:00:00';
 
-        // don't want any big queries, we limit to 10 days
         $until_date = strtotime($until);
         $start_date = strtotime($start);
+        if (!$until_date || !$start_date){
+            throw new NotFoundException(__('Please use a valid date format YYYY-MM-DD HH:MM:SS'));
+        }
+
+        // don't want any big queries, we limit to 10 days
         $datediff = $until_date - $start_date;
 
         if (abs(round($datediff / (60 * 60 * 24))) > self::MAX_QUERY_DAYS){
-            throw new NotFoundException(__('Please don\'t query for more than 10 days'));
+            throw new NotFoundException(__('Cannot query more than 10 days'));
         }
 
         $storeIdFilter = $this->_storeFilter($storeId);
         
-        $subscriberCollection =$this->subscriberCollection->create()
+        $subscriberCollection =$this->_subscriberCollection->create()
             ->addFieldToFilter('change_status_at', ['gteq' => $start])
             ->addFieldToFilter('change_status_at', ['lteq' => $until])
             ->addFieldToFilter('store_id', [$storeIdFilter => $storeId]);

--- a/Model/Reclaim.php
+++ b/Model/Reclaim.php
@@ -137,11 +137,14 @@ class Reclaim implements ReclaimInterface
 
     }
 
-    public function historicalcustomersubscription($start_id, $end_id, $storeId=null)
+    public function getSubscribersById($start_id, $end_id, $storeId=null)
     {
-
         if (!$start_id || !$end_id ){ 
             throw new NotFoundException(__('Please provide start_id and end_id'));
+        }
+
+        if ($start_id > $end_id){
+            throw new NotFoundException(__('end_id should be larger than start_id'));
         }
 
         $storeIdFilter = $this->_storeFilter($storeId);
@@ -151,20 +154,16 @@ class Reclaim implements ReclaimInterface
             ->addFieldToFilter('subscriber_id', ['lteq' => (int)$end_id])
             ->addFieldToFilter('store_id', [$storeIdFilter => $storeId]);
 
-        $subscriberCollection =$this->subscriberCollection->create()
-            ->addFieldToFilter('subscriber_id', ['gt' => 1]);
-
         $response = $this->_packageSubscribers($subscriberCollection);
 
         return $response;
     }
 
-    public function customersubscription($start, $until, $storeId=null)
+    public function getSubscribersByDateRange($start, $until, $storeId=null)
     {
         
         if (!$start || !$until ){ 
-            throw new NotFoundException(__('Please provide start_id and end_id'));
-            return array('error' => 'Please provide start and until');
+            throw new NotFoundException(__('Please provide start and until param'));
         }
         // start and until date formats
         // $until = '2019-04-25 18:00:00';
@@ -173,13 +172,11 @@ class Reclaim implements ReclaimInterface
         // don't want any big queries, we limit to 10 days
         $until_date = strtotime($until);
         $start_date = strtotime($start);
-        $datediff = $now - $start_date;
+        $datediff = $until_date - $start_date;
 
         if (abs(round($datediff / (60 * 60 * 24))) > self::MAX_QUERY_DAYS){
             throw new NotFoundException(__('Please don\'t query for more than 10 days'));
         }
-
-        
 
         $storeIdFilter = $this->_storeFilter($storeId);
         

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Klaviyo_Reclaim" setup_version="1.0.6">
+    <module name="Klaviyo_Reclaim" setup_version="1.0.7">
     </module>
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -18,16 +18,22 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
+    <route url="/V1/klaviyo/reclaim/customers/subscriptions/count" method="GET">
+        <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="getSubscribersCount"/>
+        <resources>
+            <resource ref="Magento_Customer::group"/>
+        </resources>
+    </route>
     <route url="/V1/klaviyo/reclaim/customers/subscriptions/periodic" method="GET">
         <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="getSubscribersByDateRange"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Magento_Customer::group"/>
         </resources>
     </route>
     <route url="/V1/klaviyo/reclaim/customers/subscriptions/historical" method="GET">
         <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="getSubscribersById"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Magento_Customer::group"/>
         </resources>
     </route>
     <route url="/V1/klaviyo/reclaim/" method="GET">

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -18,6 +18,18 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
+    <route url="/V1/klaviyo/reclaim/customers/subscriptions/periodic" method="GET">
+        <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="customersubscription"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+    <route url="/V1/klaviyo/reclaim/customers/subscriptions/historical" method="GET">
+        <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="historicalcustomersubscription"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
     <route url="/V1/klaviyo/reclaim/" method="GET">
         <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="reclaim"/>
         <resources>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -19,13 +19,13 @@
         </resources>
     </route>
     <route url="/V1/klaviyo/reclaim/customers/subscriptions/periodic" method="GET">
-        <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="customersubscription"/>
+        <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="getSubscribersByDateRange"/>
         <resources>
             <resource ref="anonymous"/>
         </resources>
     </route>
     <route url="/V1/klaviyo/reclaim/customers/subscriptions/historical" method="GET">
-        <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="historicalcustomersubscription"/>
+        <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="getSubscribersById"/>
         <resources>
             <resource ref="anonymous"/>
         </resources>

--- a/module.xml
+++ b/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Klaviyo_Reclaim" setup_version="1.0.6">
+    <module name="Klaviyo_Reclaim" setup_version="1.0.7">
     </module>
     <sequence>
         <module name="Magento_Checkout"/>


### PR DESCRIPTION
It appears we don't get customers who subscriber as a guest as the hooks don't fire.  this is to expose 2 api endpoints to be able to query this data.  

1. for historical sync by id's (batching)
2. for periodic date pull (since param)


Endpoints:


```
@param mixed $start
@param mixed $until
@param mixed $store_id
```
/V1/klaviyo/reclaim/customers/subscriptions/periodic
Ex
```
rest/V1/klaviyo/reclaim/customers/subscriptions/periodic?start=2019-04-25%20:00:00&until=2019-04-25%2018:00:00:00
```




```
@param mixed $start_id	   
@param mixed $end_id	     
@param mixed $store_id
```

/V1/klaviyo/reclaim/customers/subscriptions/historical

```
http://magento2.local:8888/rest/V1/klaviyo/reclaim/customers/subscriptions/historical?start_id=1&end_id=10
```