### PR TITLE
revert revert Media URLS & Fix Schema & fix checkout email

### DIFF
--- a/Api/ReclaimInterface.php
+++ b/Api/ReclaimInterface.php
@@ -7,7 +7,7 @@ interface ReclaimInterface
      * Returns a list of stores with extended information
      *
      * @api
-     * @return mixed
+     * @return mixed[]
      */
     public function stores();
 
@@ -23,9 +23,9 @@ interface ReclaimInterface
      * Returns product information
      *
      * @api
-     * @param mixed $quote_id
-     * @param mixed $item_id
-     * @return mixed
+     * @param int $quote_id
+     * @param int $item_id
+     * @return mixed[]
      */
     public function product($quote_id, $item_id);
 
@@ -35,7 +35,7 @@ interface ReclaimInterface
      * @api
      * @param int $product_id
      * @param int $store_id
-     * @return mixed
+     * @return mixed[]
      */
     public function productVariantInventory($product_id, $store_id=0);
 
@@ -43,9 +43,9 @@ interface ReclaimInterface
      * Returns product by id range
      *
      * @api
-     * @param mixed $quote_id
-     * @param mixed $item_id
-     * @return mixed
+     * @param int $quote_id
+     * @param int $item_id
+     * @return mixed[]
      */
     public function productinspector($start_id, $end_id);
 
@@ -53,7 +53,7 @@ interface ReclaimInterface
      * Returns subscribers by date filter
      *
      * @api
-     * @return mixed
+     * @return mixed[]
      */
 
     public function getSubscribersCount();
@@ -62,10 +62,10 @@ interface ReclaimInterface
      * Returns subscribers by date filter
      *
      * @api
-     * @param mixed $start
-     * @param mixed $until
-     * @param mixed $store_id
-     * @return mixed
+     * @param string $start
+     * @param string $until
+     * @param int $store_id
+     * @return mixed[]
      */
     public function getSubscribersByDateRange($start, $until, $store_id=null);
 
@@ -73,10 +73,10 @@ interface ReclaimInterface
      * Returns subscirbers by id
      *
      * @api
-     * @param mixed $start_id
-     * @param mixed $end_id
-     * @param mixed $store_id
-     * @return mixed
+     * @param string $start_id
+     * @param string $end_id
+     * @param int $store_id
+     * @return mixed[]
      */
     public function getSubscribersById($start_id, $end_id, $store_id=null);
 

--- a/Controller/Checkout/Email.php
+++ b/Controller/Checkout/Email.php
@@ -26,6 +26,11 @@ class Email extends \Magento\Framework\App\Action\Action
         $quote = $this->_objectManager->create('Magento\Checkout\Model\Cart')->getQuote();
 
         $customer_email = $this->getRequest()->getParam('email');
+        // add email validation
+        if (!filter_var($customer_email, FILTER_VALIDATE_EMAIL)) {
+            return;
+        }
+
         $quote->setCustomerEmail($customer_email);
         $quote->save();
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -16,6 +16,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const ENABLE = 'klaviyo_reclaim_general/general/enable';
     const PUBLIC_API_KEY = 'klaviyo_reclaim_general/general/public_api_key';
     const PRIVATE_API_KEY = 'klaviyo_reclaim_general/general/private_api_key';
+    const CUSTOM_MEDIA_URL = 'klaviyo_reclaim_general/general/custom_media_url';
     const NEWSLETTER = 'klaviyo_reclaim_newsletter/newsletter/newsletter';
 
     public function __construct(
@@ -74,6 +75,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getPrivateApiKey()
     {
         return $this->getScopeSetting(self::PRIVATE_API_KEY);
+    }
+
+    public function getCustomMediaURL()
+    {
+        return $this->getScopeSetting(self::CUSTOM_MEDIA_URL);
     }
 
     public function getNewsletter()

--- a/Model/Reclaim.php
+++ b/Model/Reclaim.php
@@ -284,16 +284,23 @@ class Reclaim implements ReclaimInterface
         return $storeIdFilter;
     }
 
-    public function _getImages($product){
+    public function _getImages($product)
+    {
         $images = $product->getMediaGalleryImages();
         $image_array = array();
+        
         foreach($images as $image) {
-            $image_url = $image->getUrl();
-            if ($image_url){
-                $image_array[] = $image_url;
-            }
+            $image_array[] = $this->handleMediaURL($image);
         }
         return $image_array;
+    }
+    public function handleMediaURL($image)
+    {
+        $custom_media_url = $this->_klaviyoHelper->getCustomMediaURL();
+        if ($custom_media_url){
+            return $custom_media_url . "/media/catalog/product" . $image->getFile();
+        }
+        return $image->getUrl();
     }
     public function _getStockItem($productId)
     {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "autoload": {
         "files": [
             "registration.php"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "1.0.9",
+    "version": "1.1.0",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,6 +21,10 @@
                 <field id="private_api_key" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Private Klaviyo API Key</label>
                 </field>
+                <field id="custom_media_url" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                     <label>Custom Media URL</label>
+                    <validate>validate-url</validate>
+                </field>
             </group>
         </section>
 

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Klaviyo_Reclaim" setup_version="1.0.8">
+    <module name="Klaviyo_Reclaim" setup_version="1.0.9">
     </module>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Klaviyo_Reclaim" setup_version="1.0.9">
+    <module name="Klaviyo_Reclaim" setup_version="1.1.0">
     </module>
 </config>


### PR DESCRIPTION
creates:
![image](https://user-images.githubusercontent.com/16033088/61812769-2c74b080-ae12-11e9-9f60-5f69ee23b633.png)

If someone has a custom media url route, they can specify it here, it will then allow the products api endpoint to utilize that custom url

also, making sure it's a valid url 
![image](https://user-images.githubusercontent.com/16033088/61817708-29cb8880-ae1d-11e9-8433-6d1b4055e8db.png)


handles issues #32 #33 