### PR TITLE
Changes getCount to getSize

### DIFF
--- a/Model/Reclaim.php
+++ b/Model/Reclaim.php
@@ -198,7 +198,7 @@ class Reclaim implements ReclaimInterface
 
     public function getSubscribersCount()
     {
-        $subscriberCount =$this->_subscriberCollection->create()->count();
+        $subscriberCount =$this->_subscriberCollection->create()->getSize();
         return $subscriberCount;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Klaviyo_Reclaim" setup_version="1.1.3">
+    <module name="Klaviyo_Reclaim" setup_version="1.1.4">
     </module>
 </config>


### PR DESCRIPTION
A little context here: A customer's M2 sync was failing due to memory limits, and I initially asked him to increase his PHP memory limit. He said he didn't want to do that, and instead came up with another suggestion. He ended up making the change in this PR on his fork, and reported that the sync started working once he switched to his version of the extension. Some context here:

https://webkul.com/blog/optimizing-magento-magento2-part-1/