### PR TITLE
Fix JS error on checkout page when Klaviyo module disabled

### DIFF
--- a/view/frontend/web/js/view/checkout/email.js
+++ b/view/frontend/web/js/view/checkout/email.js
@@ -34,6 +34,10 @@ define([
       var self = this;
       console.log('Klaviyo_Reclaim - Binding to #customer-email');
       jQuery('#maincontent').delegate('#customer-email', 'change', function (event) {
+        if (!window._learnq || !window._learnq.identify) {
+          return;
+        }
+        
         self._email = jQuery(this).val();
         if (!window._learnq.identify().email) {
           window._learnq.push(['identify', {

--- a/view/frontend/web/js/view/checkout/email.js
+++ b/view/frontend/web/js/view/checkout/email.js
@@ -29,12 +29,15 @@ define([
         return true;
       }
     },
+    isKlaviyoActive: function() {
+      return !!(window._learnq && window._learnq.identify);
+    },
     bindEmailListener: function () {
       // jquery overrides this, so let's create an instance of the parent
       var self = this;
       console.log('Klaviyo_Reclaim - Binding to #customer-email');
       jQuery('#maincontent').delegate('#customer-email', 'change', function (event) {
-        if (!window._learnq || !window._learnq.identify) {
+        if (!self.isKlaviyoActive()) {
           return;
         }
         


### PR DESCRIPTION
When we disabled Klaviyo extension in the admin - we started getting following JS error on checkout page while editing email address field:
![image](https://user-images.githubusercontent.com/1873745/72247330-5064c200-35fd-11ea-85dd-f4e6148c228c.png)

I investigated this issue and found that there is no check if Klaviyo is available. 

In addition to that - Klaviyo still saves email to quote, even when module is not enabled.

My PR checks if Klaviyo global variable (`window._learnq`) is not available - do not try to track or send requests about saving email to quote.