### PR TITLE
Private API Key Hashing Fix

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -118,6 +118,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->getScopeSetting(self::PRIVATE_API_KEY);
     }
 
+    public function setPrivateApiKey($value)
+    {
+        return $this->setScopeSetting(self::PRIVATE_API_KEY, $value);
+    }
+
     public function getKlaviyoUsername()
     {
         return $this->getScopeSetting(self::KLAVIYO_USERNAME);

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -1,0 +1,70 @@
+<?php
+namespace Klaviyo\Reclaim\Setup;
+
+use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use \Klaviyo\Reclaim\Helper\Data as DataHelper;
+
+class UpgradeData implements UpgradeDataInterface
+{
+    /**
+     * @var \Magento\Framework\Encryption\EncryptorInterface
+     */
+    protected $_encryptor;
+
+    /**
+     * @var DataHelper
+     */
+    protected $_dataHelper;
+
+    /**
+     * @var \Magento\Framework\App\State 
+     */
+    protected $_state;
+
+    /**
+     * @param DataHelper $dataHelper
+     * @param \Magento\Framework\Encryption\EncryptorInterface $encryptor
+     * @param \Magento\Framework\App\State $state
+     */
+    public function __construct(
+        DataHelper $dataHelper,
+        \Magento\Framework\Encryption\EncryptorInterface $encryptor,
+        \Magento\Framework\App\State $state
+    )
+    {
+        $this->_dataHelper = $dataHelper;
+        $this->_encryptor = $encryptor;
+        $this->_state = $state;
+    }
+
+    public function upgrade(
+        ModuleDataSetupInterface $setup,
+        ModuleContextInterface $context
+    )
+    {
+        try{
+            $this->_state->getAreaCode();
+        }
+        catch (\Magento\Framework\Exception\LocalizedException $ex) {
+            $this->_state->setAreaCode('adminhtml');
+        }
+
+        $setup->startSetup();
+        /**
+         * in release 1.1.7 we started using the encrypted backend model for the private api key
+         * this check ensures that when upgrading to this version the key is stored properly
+         * otherwise we'd be trying to decrypt an unencrypted value elsewhere in the extension code (yikes)
+         */
+        if (version_compare($context->getVersion(), '1.1.7', '<')) {
+            //retrieve current key (unencrypted)
+            $value = $this->_dataHelper->getPrivateApiKey();
+            //encrypt the private key
+            $encrypted = $this->_encryptor->encrypt($value);
+            //set the private key to the encrypted value
+            $this->_dataHelper->setPrivateApiKey($encrypted);
+        }
+        $setup->endSetup();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="1.1.8">
+  <module name="Klaviyo_Reclaim" setup_version="1.1.9">
   </module>
 </config>


### PR DESCRIPTION
Added helper methods and UpgradeData.php file to encrypt private API key when upgrading from versions lower than 1.1.7