### PR TITLE
Unnecessary logger file creation

### DIFF
--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -72,13 +72,6 @@ class InstallData implements InstallDataInterface
         }
 
         $setup->startSetup();
-
-        //Klaviyo log file creation
-        $path = $this->_klaviyoLogger->getPath();
-        if (!file_exists($path)) {
-            fopen($path, 'w');
-        }
-        chmod($path, 0644);
         
         //Klaviyo role creation
         $role = $this->roleFactory->create();


### PR DESCRIPTION
Magento core handles log file creation, and creating/chmodding the log file in this install script is not only incorrect but can cause integration test failure