### PR TITLE
Allow URL parameters to persist through cart redirect

### DIFF
--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -43,7 +43,7 @@ class Cart extends \Magento\Framework\App\Action\Action
         }
 
         $redirect = $this->resultRedirectFactory->create();
-        $redirect->setPath('checkout/cart',['_query'=>$params]);
+        $redirect->setPath('checkout/cart', ['_query'=>$params]);
         return $redirect;
     }
 }

--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -43,11 +43,7 @@ class Cart extends \Magento\Framework\App\Action\Action
         }
 
         $redirect = $this->resultRedirectFactory->create();
-        if (sizeof($params) > 0) {
-            $redirect->setPath('checkout/cart',['_query'=>$params]);
-        } else {
-            $redirect->setPath('checkout/cart');
-        }
+        $redirect->setPath('checkout/cart',['_query'=>$params]);
         return $redirect;
     }
 }

--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -32,6 +32,8 @@ class Cart extends \Magento\Framework\App\Action\Action
     public function execute()
     {
         $quoteId = $this->request->getParam('quote_id');
+        $params = $this->request->getParams();
+        unset($params['quote_id']);
 
         try {
           $quote = $this->quoteRepository->get($quoteId);
@@ -41,7 +43,11 @@ class Cart extends \Magento\Framework\App\Action\Action
         }
 
         $redirect = $this->resultRedirectFactory->create();
-        $redirect->setPath('checkout/cart');
+        if (sizeof($params) > 0) {
+            $redirect->setPath('checkout/cart',['_query'=>$params]);
+        } else {
+            $redirect->setPath('checkout/cart');
+        }
         return $redirect;
     }
 }

--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -33,7 +33,7 @@ class Cart extends \Magento\Framework\App\Action\Action
     {
         $params = $this->request->getParams();
         $quoteId = $params['quote_id'];
-        unset($params['quote_id']);
+        unset($quoteId);
 
         try {
           $quote = $this->quoteRepository->get($quoteId);

--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -31,8 +31,8 @@ class Cart extends \Magento\Framework\App\Action\Action
      */
     public function execute()
     {
-        $quoteId = $this->request->getParam('quote_id');
         $params = $this->request->getParams();
+        $quoteId = $params['quote_id'];
         unset($params['quote_id']);
 
         try {

--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -33,7 +33,7 @@ class Cart extends \Magento\Framework\App\Action\Action
     {
         $params = $this->request->getParams();
         $quoteId = $params['quote_id'];
-        unset($quoteId);
+        unset($params['quote_id']);
 
         try {
           $quote = $this->quoteRepository->get($quoteId);

--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -43,7 +43,7 @@ class Cart extends \Magento\Framework\App\Action\Action
         }
 
         $redirect = $this->resultRedirectFactory->create();
-        $redirect->setPath('checkout/cart', ['_query'=>$params]);
+        $redirect->setPath('checkout/cart', ['_query' => $params]);
         return $redirect;
     }
 }


### PR DESCRIPTION
If the URL has parameters other than the quote ID, allow those parameters to persist through the cart redirect. If there are no other parameters in the URL, redirect normally.