### PR TITLE
Removed CSP setting

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,15 +12,5 @@
                 <password backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
             </klaviyo_user>
         </klaviyo_reclaim_user>
-                <csp>	
-            <mode>	
-                <storefront>	
-                    <report_only>1</report_only>	
-                </storefront>	
-                <admin>	
-                    <report_only>1</report_only>	
-                </admin>	
-            </mode>	
-        </csp>
     </default>
 </config>


### PR DESCRIPTION
Setting CSP settings in an extension not maintained by a merchant can cause un-intended issues. Leaving the CSP settings up to the merchant is a better approach.