### PR TITLE
Remove jQuery UI to improve performance

### DIFF
--- a/view/frontend/web/js/view/checkout/email.js
+++ b/view/frontend/web/js/view/checkout/email.js
@@ -1,7 +1,6 @@
 define([
   'uiComponent',
   'jquery',
-  'jquery/ui',
   'domReady!'
 ], function (Component) {
   'use strict';


### PR DESCRIPTION
jQuery UI is never used in the email.js, but including it on the **define**, and it starts loading the all UI library (jQuery UI with all Widgets).
As a result, email.js will be run just after all libs with included in **define**.
Also, it creates a performance issue for the checkout page.