### PR TITLE
Record email consent when using subscribe endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### Fixed
+- Email consent now recorded when Klaviyo list opt-in settings are used
+
 ### [2.0.0] - 2021-01-11
 
 #### Added

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -89,6 +89,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         if ($firstName) $properties['$first_name'] = $firstName;
         if ($lastName) $properties['$last_name'] = $lastName;
         if ($source) $properties['$source'] = $source;
+        if ($optInSetting == ScopeSetting::API_SUBSCRIBE) $properties['$consent'] = ['email'];
 
         $propertiesVal = ['profiles' => $properties];
 


### PR DESCRIPTION
Tested and confirmed consent is sent with the subscription request:
![image](https://user-images.githubusercontent.com/30503294/110021556-e45d8580-7cf8-11eb-844c-fc43b769b920.png)

And consent is recorded:
![image](https://user-images.githubusercontent.com/30503294/110021607-f63f2880-7cf8-11eb-98dd-e2b1d860745b.png)

Also confirmed consent is not sent when using the members endpoint:
![image](https://user-images.githubusercontent.com/30503294/110022106-87ae9a80-7cf9-11eb-883c-f30bb32c237b.png)