### PR TITLE
Fix incorrect links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/2.1.0...HEAD
-[2.0.0]: https://github.com/klaviyo/magento2-klaviyo/compare/2.0.0...2.1.0
+[2.1.0]: https://github.com/klaviyo/magento2-klaviyo/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/klaviyo/magento2-klaviyo/compare/1.2.4...2.0.0
 [1.2.4]: https://github.com/klaviyo/magento2-klaviyo/compare/1.2.3...1.2.4
 [1.2.3]: https://github.com/klaviyo/magento2-klaviyo/compare/1.2.2...1.2.3


### PR DESCRIPTION
The links in the changelog are not correct.
![image](https://user-images.githubusercontent.com/1873745/113103523-0c60db80-9208-11eb-8833-3d6105e107fa.png)

❌ Release [2.1.0](https://github.com/klaviyo/magento2-klaviyo/blob/master/CHANGELOG.md#210---2021-03-22) don't have  any link
❌ Release [2.0.0 ](https://github.com/klaviyo/magento2-klaviyo/blob/master/CHANGELOG.md#200---2021-01-11) goes to https://github.com/klaviyo/magento2-klaviyo/compare/2.0.0...2.1.0

My PR fixes it, so it will become to this:

✔ Release [2.1.0](https://github.com/klaviyo/magento2-klaviyo/blob/master/CHANGELOG.md#210---2021-03-22) goes to https://github.com/klaviyo/magento2-klaviyo/compare/2.0.0...2.1.0
✔ Release [2.0.0 ](https://github.com/klaviyo/magento2-klaviyo/blob/master/CHANGELOG.md#200---2021-01-11) goes to https://github.com/klaviyo/magento2-klaviyo/compare/1.2.4...2.0.0