### PR TITLE
Use store ids in the ProductDeleteBefore Observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [2.1.1] - 2021-04-21
+
+#### Fixes
+- Use store ids instead of website ids in the ProductDeleteBefore Observer
+
 ### [2.1.0] - 2021-03-22
 
 #### Added
@@ -55,6 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.2.4]: https://github.com/klaviyo/magento2-klaviyo/compare/1.2.3...1.2.4
 [1.2.3]: https://github.com/klaviyo/magento2-klaviyo/compare/1.2.2...1.2.3
 
-  
+
 #### NOTE
 - The CHANGELOG was created on 2020-11-20 and does not contain information about earlier releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-### [2.1.1] - 2021-04-21
+### [2.1.1] - 2021-05-07
 
 #### Fixes
 - Use store ids instead of website ids in the ProductDeleteBefore Observer
+- Check for versions older than 2.0.0 in UpgradeSchema
 
 ### [2.1.0] - 2021-03-22
 
@@ -54,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/2.1.0...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/2.1.1...HEAD
+[2.1.1]: https://github.com/klaviyo/magento2-klaviyo/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/klaviyo/magento2-klaviyo/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/klaviyo/magento2-klaviyo/compare/1.2.4...2.0.0
 [1.2.4]: https://github.com/klaviyo/magento2-klaviyo/compare/1.2.3...1.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-### [2.1.1] - 2021-05-07
+### [2.1.1] - 2021-05-17
 
 #### Fixes
 - Use store ids instead of website ids in the ProductDeleteBefore Observer

--- a/Observer/ProductDeleteBefore.php
+++ b/Observer/ProductDeleteBefore.php
@@ -54,8 +54,8 @@ class ProductDeleteBefore implements ObserverInterface
     public function execute(Observer $observer)
     {
         $product = $observer->getEvent()->getProduct();
-        $websiteIds = $product->getWebsiteIds();
-        $storeIdKlaviyoMap = $this->_klaviyoScopeSetting->getStoreIdKlaviyoAccountSetMap($websiteIds);
+        $storeIds = $product->getStoreIds();
+        $storeIdKlaviyoMap = $this->_klaviyoScopeSetting->getStoreIdKlaviyoAccountSetMap($storeIds);
 
         foreach ($storeIdKlaviyoMap as $klaviyoId => $storeIds) {
             if (empty($storeIds)) {
@@ -72,5 +72,3 @@ class ProductDeleteBefore implements ObserverInterface
         }
     }
 }
-
-

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -19,7 +19,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
-        if (version_compare($context->getVersion(), '2.0.0', '<')) {
+        if (version_compare($context->getVersion(), '2.1.1', '<')) {
             $installer = $setup;
             $installer->startSetup();
 

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -19,7 +19,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
-        if (version_compare($context->getVersion(), '2.0.0', '>')) {
+        if (version_compare($context->getVersion(), '2.0.0', '<')) {
             $installer = $setup;
             $installer->startSetup();
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="2.1.0" schema_version="2.1.0">
+  <module name="Klaviyo_Reclaim" setup_version="2.1.1" schema_version="2.1.1">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
Fixes bug to use store_ids instead of website_ids for delete product webhook.

Also fixes bug where we were looking for versions greater than 2.0.0 in the UpgradeSchema.