### PR TITLE
Add ability to retrieve config values for specified store id

### DIFF
--- a/Helper/ScopeSetting.php
+++ b/Helper/ScopeSetting.php
@@ -138,14 +138,14 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
             ->getOne(self::MODULE_NAME)['setup_version'];
     }
 
-    public function getWebhookSecret()
+    public function getWebhookSecret($storeId = null)
     {
-        return $this->getScopeSetting(self::WEBHOOK_SECRET);
+        return $this->getScopeSetting(self::WEBHOOK_SECRET, $storeId);
     }
 
-    public function isEnabled()
+    public function isEnabled($storeId = null)
     {
-        return $this->getScopeSetting(self::ENABLE);
+        return $this->getScopeSetting(self::ENABLE, $storeId);
     }
 
     public function getPublicApiKey($storeId = null)
@@ -153,9 +153,9 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->getScopeSetting(self::PUBLIC_API_KEY, $storeId);
     }
 
-    public function getPrivateApiKey()
+    public function getPrivateApiKey($storeId = null)
     {
-        return $this->getScopeSetting(self::PRIVATE_API_KEY);
+        return $this->getScopeSetting(self::PRIVATE_API_KEY, $storeId);
     }
 
     public function setPrivateApiKey($value)
@@ -163,73 +163,78 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->setScopeSetting(self::PRIVATE_API_KEY, $value);
     }
 
-    public function isLoggerEnabled()
+    public function isLoggerEnabled($storeId = null)
     {
-        return $this->getScopeSetting(self::USING_KLAVIYO_LOGGER);
+        return $this->getScopeSetting(self::USING_KLAVIYO_LOGGER, $storeId);
     }
 
-    public function getKlaviyoOauthName()
+    public function getKlaviyoOauthName($storeId = null)
     {
-        return $this->getScopeSetting(self::KLAVIYO_OAUTH_NAME);
+        return $this->getScopeSetting(self::KLAVIYO_OAUTH_NAME, $storeId);
     }
 
-    public function getCustomMediaURL()
+    public function getCustomMediaURL($storeId = null)
     {
-        return $this->getScopeSetting(self::CUSTOM_MEDIA_URL);
+        return $this->getScopeSetting(self::CUSTOM_MEDIA_URL, $storeId);
     }
 
-    public function getNewsletter()
+    public function getNewsletter($storeId = null)
     {
-        return $this->getScopeSetting(self::NEWSLETTER);
+        return $this->getScopeSetting(self::NEWSLETTER, $storeId);
     }
 
-    public function getOptInSetting()
+    public function getOptInSetting($storeId = null)
     {
-        if ($this->getScopeSetting(self::USING_KLAVIYO_LIST_OPT_IN)) {
+        if ($this->getScopeSetting(self::USING_KLAVIYO_LIST_OPT_IN, $storeId)) {
             return self::API_SUBSCRIBE;
         } else {
             return self::API_MEMBERS;
         }
     }
 
+    public function getConsentAtCheckoutEmailIsActive($storeId = null)
+    {
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_EMAIL_IS_ACTIVE, $storeId);
+    }
 
-    public function getConsentAtCheckoutEmailIsActive()
+    public function getConsentAtCheckoutEmailListId($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_EMAIL_IS_ACTIVE);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_EMAIL_LIST_ID, $storeId);
     }
-    public function getConsentAtCheckoutEmailListId()
+
+    public function getConsentAtCheckoutEmailText($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_EMAIL_LIST_ID);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_EMAIL_CONSENT_TEXT, $storeId);
     }
-    public function getConsentAtCheckoutEmailText()
-    {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_EMAIL_CONSENT_TEXT);
-    }
-    public function getConsentAtCheckoutEmailSortOrder()
+
+    public function getConsentAtCheckoutEmailSortOrder($storeId = null)
     {
         return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_EMAIL_SORT_ORDER);
     }
 
+    public function getConsentAtCheckoutSMSIsActive($storeId = null)
+    {
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_IS_ACTIVE, $storeId);
+    }
 
-    public function getConsentAtCheckoutSMSIsActive()
+    public function getConsentAtCheckoutSMSListId($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_IS_ACTIVE);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_LIST_ID, $storeId);
     }
-    public function getConsentAtCheckoutSMSListId()
+    
+    public function getConsentAtCheckoutSMSConsentText($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_LIST_ID);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_CONSENT_TEXT, $storeId);
     }
-    public function getConsentAtCheckoutSMSConsentText()
+
+    public function getConsentAtCheckoutSMSConsentSortOrder($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_CONSENT_TEXT);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_SORT_ORDER, $storeId);
     }
-    public function getConsentAtCheckoutSMSConsentSortOrder()
+
+    public function getConsentAtCheckoutSMSConsentLabelText($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_SORT_ORDER);
-    }
-    public function getConsentAtCheckoutSMSConsentLabelText()
-    {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_LABEL_TEXT);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_LABEL_TEXT, $storeId);
     }
 
 


### PR DESCRIPTION
Right now, we don't have the ability to retrieve info about Klaviyo from a different store. This is really useful, for instance, in the cron jobs, when we can process multiple accounts.