### PR TITLE
copied over changes from ihor's PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+#### Added
+- Add an ability to pass the Store ID during track event
 
 ### [3.0.5] - 2021-06-08
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -128,7 +128,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         return $response;
     }
 
-    public function klaviyoTrackEvent($event, $customer_properties=array(), $properties=array(), $timestamp=NULL)
+    public function klaviyoTrackEvent($event, $customer_properties = [], $properties = [], $timestamp = null, $storeId = null)
     {
         if ((!array_key_exists('$email', $customer_properties) || empty($customer_properties['$email']))
             && (!array_key_exists('$id', $customer_properties) || empty($customer_properties['$id']))) {
@@ -136,7 +136,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             return 'You must identify a user by email or ID.';
         }
         $params = array(
-            'token' => $this->_klaviyoScopeSetting->getPublicApiKey(),
+            'token' => $this->_klaviyoScopeSetting->getPublicApiKey($storeId),
             'event' => $event,
             'properties' => $properties,
             'customer_properties' => $customer_properties


### PR DESCRIPTION
Use case - we would like to send some events to Klaviyo in the cron job for a specific store (different stores synced to different Klaviyo accounts).
Right now, we can't specify to which Klavityo account we should send this event.

This PR brings an ability to send the event to a specific Klaviyo account (specified on store level).