### PR TITLE
Handle newsletter subscriptions in all areas

### DIFF
--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -2,9 +2,6 @@
     <event name="config_data_save_before">
         <observer name="klaviyo_reclaim" instance="Klaviyo\Reclaim\Observer\PrivateApiKeyObserver" />
     </event>
-    <event name="newsletter_subscriber_save_commit_after">
-        <observer name="klaviyo_reclaim" instance="Klaviyo\Reclaim\Observer\NewsletterSubscribeObserver" />
-    </event>
     <event name="catalog_product_delete_before">
         <observer name="klaviyo_reclaim" instance="Klaviyo\Reclaim\Observer\ProductDeleteBefore" />
     </event>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -4,4 +4,8 @@
     <event name="sales_model_service_quote_submit_before">
         <observer name="custom_fields_sales_address_save" instance="Klaviyo\Reclaim\Observer\SaveOrderMarketingConsent" />
     </event>
+
+    <event name="newsletter_subscriber_save_commit_after">
+        <observer name="klaviyo_reclaim" instance="Klaviyo\Reclaim\Observer\NewsletterSubscribeObserver" />
+    </event>
 </config>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,5 +1,0 @@
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="newsletter_subscriber_save_commit_after">
-        <observer name="klaviyo_reclaim" instance="Klaviyo\Reclaim\Observer\NewsletterSubscribeObserver" />
-    </event>
-</config>


### PR DESCRIPTION
Pre-history:  we have a custom Checkout extension that has built-in functionality for subscribing to the newsletter. This subscription happening on the same request as "place order". This request usually happening in the `webapi_rest` area. As a result, in Magento, we have subscribers, but in Klaviyo, this information isn't getting sent, so **we're losing subscribers**.

My Pull Request changing handling [all possible areas](https://devdocs.magento.com/guides/v2.4/architecture/archi_perspectives/components/modules/mod_and_areas.html), including `webapi_rest`, `webapi_soap`, `graphql` and `crontab`,  as well as existing `frontend` and `adminhtml`.