### PR TITLE
Prevent infinite loop during API quote load

### DIFF
--- a/Plugin/Api/CartSearchRepository.php
+++ b/Plugin/Api/CartSearchRepository.php
@@ -11,8 +11,12 @@ use Magento\Quote\Model\CartSearchResults;
 
 class CartSearchRepository
 {
-
     const KL_MASKED_ID = 'kl_masked_id';
+
+    /**
+     * @var bool
+     */
+    private $hasPluginExecuted = false;
 
     /**
      * QuoteId Masker
@@ -51,6 +55,11 @@ class CartSearchRepository
      */
     public function afterGetList(CartRepositoryInterface $subject, CartSearchResults $searchResult)
     {
+        if ($this->hasPluginExecuted) {
+            return $searchResult;
+        }
+
+        $this->hasPluginExecuted = true;
         $quotes = $searchResult->getItems();
 
         foreach ($quotes as $quote) {


### PR DESCRIPTION
Fixes #133 

Guards against infinite loops when loading quotes with coupon codes requiring total recollection.