### PR TITLE
adding code changes to handle infinite loop issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [3.0.8] - 2021-09-02
+
+#### Fixed
+- Fixes infinite loop issue produced by [Magento bug](https://github.com/magento/magento2/issues/33675)
+
 ### [3.0.7] - 2021-08-27
 
 #### Fixed
@@ -117,7 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.7...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.8...HEAD
+[3.0.8]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.7...3.0.8
 [3.0.7]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.6...3.0.7
 [3.0.6]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.5...3.0.6
 [3.0.5]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.4...3.0.5

--- a/Model/Quote/QuoteIdMask.php
+++ b/Model/Quote/QuoteIdMask.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Klaviyo\Reclaim\Model\Quote;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+/**
+ * QuoteIdMask Resource model
+ * @codeCoverageIgnore
+ */
+class QuoteIdMask extends AbstractDb
+{
+    /**
+     * Main table and field initialization
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init('quote_id_mask', 'entity_id');
+    }
+
+    /**
+     * Retrieves masked quote id
+     *
+     * Uses direct DB query due to performance reasons
+     *
+     * @param int $quoteId
+     * @return string|null
+     */
+    public function getMaskedQuoteId(int $quoteId): ?string
+    {
+        $connection = $this->getConnection();
+        $mainTable = $this->getMainTable();
+        $field = $connection->quoteIdentifier(sprintf('%s.%s', $mainTable, 'quote_id'));
+
+        $select = $connection->select()
+            ->from($mainTable, ['masked_id'])
+            ->where($field . '=?', $quoteId);
+
+        $result = $connection->fetchOne($select);
+
+        return $result ?: null;
+    }
+}

--- a/Plugin/Api/CartSearchRepository.php
+++ b/Plugin/Api/CartSearchRepository.php
@@ -3,10 +3,9 @@
 
 namespace Klaviyo\Reclaim\Plugin\Api;
 
-
+use Klaviyo\Reclaim\Model\Quote\QuoteIdMask as QuoteIdMaskResource;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\CartExtensionFactory;
-use Magento\Quote\Model\QuoteIdToMaskedQuoteId;
 use Magento\Quote\Model\CartSearchResults;
 
 class CartSearchRepository
@@ -15,12 +14,12 @@ class CartSearchRepository
     const KL_MASKED_ID = 'kl_masked_id';
 
     /**
-     * QuoteId Masker
+     * Quote Id Mask Resource
      *
-     * @var QuoteIdToMaskedQuoteId
+     * @var QuoteIdMaskResource
      */
-    private $quoteIdMask;
-
+    private $quoteIdMaskResource;
+    
     /**
      * Cart Extension Attributes Factory
      *
@@ -32,14 +31,14 @@ class CartSearchRepository
      * CartRepositoryPlugin constructor
      *
      * @param CartExtensionFactory $extensionFactory
-     * @param QuoteIdToMaskedQuoteId $quoteIdToMaskedQuoteId
+     * @param QuoteIdMaskResource $quoteIdMaskResource
      */
     public function __construct(
         CartExtensionFactory $extensionFactory,
-        QuoteIdToMaskedQuoteId $quoteIdToMaskedQuoteId
+        QuoteIdMaskResource $quoteIdMaskResource
     ){
         $this->extensionFactory = $extensionFactory;
-        $this->quoteIdMask = $quoteIdToMaskedQuoteId;
+        $this->quoteIdMaskResource = $quoteIdMaskResource;
     }
     /**
      * Add "kl_masked_id" extension attribute to order data object to make it accessible in API data
@@ -54,7 +53,7 @@ class CartSearchRepository
         $quotes = $searchResult->getItems();
 
         foreach ($quotes as $quote) {
-            $maskedId = $this->getMaskedIdFromQuoteId($quote->getId());
+            $maskedId = $this->quoteIdMaskResource->getMaskedQuoteId($quote->getId());
             $extensionAttributes = $quote->getExtensionAttributes();
             $extensionAttributes = $extensionAttributes ? $extensionAttributes : $this->extensionFactory->create();
             $extensionAttributes->setData(self::KL_MASKED_ID, $maskedId);
@@ -64,13 +63,4 @@ class CartSearchRepository
         return $searchResult;
     }
 
-    public function getMaskedIdFromQuoteId($quoteId)
-    {
-        try {
-            $quoteId = $this->quoteIdMask->execute($quoteId);
-        } catch (NoSuchEntityException $e) {
-            $quoteId = "";
-        }
-        return $quoteId;
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "3.0.7",
+    "version": "3.0.8",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="3.0.7" schema_version="3.0.7">
+  <module name="Klaviyo_Reclaim" setup_version="3.0.8" schema_version="3.0.8">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
This pertains to github issue [here](https://github.com/klaviyo/magento2-klaviyo/issues/133) and implements some of the logic [here](https://github.com/magento/magento2/pull/33324) as its still unreleased code.  

It addresses the bug where if a quote with a coupon has `trigger_recollect = 1` then any api calls to retrieve the quote will hang forever. Instead of relying on the magento libraries to retrieve the masked quote id, we implement code to retrieve it ourselves from the DB