### PR TITLE
Use Magento URL builder to build URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [Unreleased]
+#### Fixed
+- URL construction works when store URL has subdirectories
 
 ### [3.0.7] - 2021-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [Unreleased]
 #### Fixed
 - URL construction works when store URL has subdirectories
+- Remove reference to deprecated _learnq functionality
 
 ### [3.0.7] - 2021-08-27
 

--- a/view/frontend/templates/checkout/cart.phtml
+++ b/view/frontend/templates/checkout/cart.phtml
@@ -5,7 +5,7 @@
            'mage/url'
         ], function (jQuery, url) {
           jQuery.ajax({
-              url: url.build('/reclaim/checkout/reload'),
+              url: url.build('reclaim/checkout/reload'),
               method: 'POST',
               data: {}
           });

--- a/view/frontend/templates/checkout/cart.phtml
+++ b/view/frontend/templates/checkout/cart.phtml
@@ -1,10 +1,11 @@
 <?php if ( $this->isKlaviyoEnabled() && $this->getPublicApiKey() ): ?>
     <script>
         require([
-           'jquery'
-        ], function (jQuery) {
+           'jquery',
+           'mage/url'
+        ], function (jQuery, url) {
           jQuery.ajax({
-              url: window.location.protocol + '//' + window.location.hostname + '/reclaim/checkout/reload',
+              url: url.build('/reclaim/checkout/reload'),
               method: 'POST',
               data: {}
           });

--- a/view/frontend/web/js/view/checkout/email.js
+++ b/view/frontend/web/js/view/checkout/email.js
@@ -42,7 +42,7 @@ define([
         }
 
         self._email = jQuery(this).val();
-        if (!window._learnq.identify().email) {
+        if (!window._learnq.isIdentified()) {
           window._learnq.push(['identify', {
             '$email': self._email
           }]);

--- a/view/frontend/web/js/view/checkout/email.js
+++ b/view/frontend/web/js/view/checkout/email.js
@@ -1,8 +1,9 @@
 define([
   'uiComponent',
+  'mage/url',
   'jquery',
   'domReady!'
-], function (Component, $) {
+], function (Component, url, $) {
   'use strict';
   // initialize the customerData prior to returning the component
   var _klaviyoCustomerData = window.customerData;
@@ -50,15 +51,8 @@ define([
       });
     },
     postUserEmail: function (customer_email) {
-      var path = window.location.pathname;
-      if (path.slice(-1) == '/') {
-        path = path.slice(0, -1);
-      }
-
-      var url = window.location.protocol + '//' + window.location.host + path.substring(0, path.lastIndexOf("/"));
-
       $.ajax({
-        url: url + '/reclaim/checkout/email',
+        url: url.build('reclaim/checkout/email'),
         method: 'POST',
         data: {
           'email': customer_email


### PR DESCRIPTION
Implements change suggested in #94 and also implements this URL builder on cart.phtml template

Also replaces reference to deprecated _learnq functionality (`_learnq.identify.$email`) with an equivalent (`_learnq.isIdentified()`)