### PR TITLE
Fix to Expose SMS Consent For Logged In Users with Default Address Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [Unreleased]
-#### Fixed
-- URL construction works when store URL has subdirectories
-- Remove reference to deprecated _learnq functionality
 
 ### [3.0.9] - 2021-09-21
 
 #### Fixed
 - SMS Consent checkbox for logged in users with default address set
+- URL construction works when store URL has subdirectories
+- Remove reference to deprecated _learnq functionality
 
 ### [3.0.8] - 2021-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - URL construction works when store URL has subdirectories
 - Remove reference to deprecated _learnq functionality
 
+### [3.0.9] - 2021-09-21
+
+#### Fixed
+- SMS Consent checkbox for logged in users with default address set
+
 ### [3.0.8] - 2021-09-02
 
 #### Fixed
@@ -125,7 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.8...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.9...HEAD
+[3.0.9]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.8...3.0.9
 [3.0.8]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.7...3.0.8
 [3.0.7]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.6...3.0.7
 [3.0.6]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.5...3.0.6

--- a/Plugin/CheckoutLayoutPlugin.php
+++ b/Plugin/CheckoutLayoutPlugin.php
@@ -39,8 +39,8 @@ class CheckoutLayoutPlugin
 
     public function afterProcess(\Magento\Checkout\Block\Checkout\LayoutProcessor $processor, $jsLayout)
     {
-        if ($this->_klaviyoScopeSetting->getConsentAtCheckoutSMSIsActive()) {
-
+        if ($this->_klaviyoScopeSetting->getConsentAtCheckoutSMSIsActive())
+        {
             $smsConsentCheckbox = [
                 'component' => 'Magento_Ui/js/form/element/abstract',
                 'config' => [

--- a/Plugin/CheckoutLayoutPlugin.php
+++ b/Plugin/CheckoutLayoutPlugin.php
@@ -14,10 +14,36 @@ class CheckoutLayoutPlugin
         $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
     }
 
+    /**
+     * Checks if logged in user has a default address set, if not returns false.
+     *
+     * @param Magento\Framework\App\ObjectManager $objectManager
+     * @param Magento\Customer\Model\Session $customerSession
+     *
+     * @return Magento\Customer\Model\Address|false
+     */
+    public function _getDefaultAddressIfSetForCustomer(
+        \Magento\Framework\App\ObjectManager $objectManager,
+        \Magento\Customer\Model\Session $customerSession
+    ) {
+        $address = false;
+        if ($customerSession->isLoggedIn()) {
+            $customerData = $customerSession->getCustomer()->getData();
+            $customerFactory = $objectManager->get('\Magento\Customer\Model\CustomerFactory')->create();
+            $customerId = $customerData["entity_id"];
+            $customer = $customerFactory->load($customerId);
+            $address = $customer->getDefaultShippingAddress();
+        }
+        return $address;
+    }
+
     public function afterProcess(\Magento\Checkout\Block\Checkout\LayoutProcessor $processor, $jsLayout)
     {
-        if ($this->_klaviyoScopeSetting->getConsentAtCheckoutSMSIsActive())
-        {
+        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+        $customerSession = $objectManager->get('Magento\Customer\Model\Session');
+
+        if ($this->_klaviyoScopeSetting->getConsentAtCheckoutSMSIsActive()) {
+
             $smsConsentCheckbox = [
                 'component' => 'Magento_Ui/js/form/element/abstract',
                 'config' => [
@@ -38,12 +64,33 @@ class CheckoutLayoutPlugin
                 'id' => 'kl_sms_consent',
             ];
 
-            $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shipping-address-fieldset']['children']['kl_sms_consent'] = $smsConsentCheckbox;
+            $address = $this->_getDefaultAddressIfSetForCustomer($objectManager, $customerSession);
+
+            if (!$address)
+                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shipping-address-fieldset']['children']['kl_sms_consent'] = $smsConsentCheckbox;
+            else {
+
+                // extra un-editable field with saved phone number to display to logged in users with default address set
+                $smsConsentTelephone = [
+                    'component' => 'Magento_Ui/js/form/element/abstract',
+                    'config' =>
+                        [
+                            'customScope' => 'shippingAddress',
+                            'template' => 'ui/form/field',
+                            'elementTmpl' => 'ui/form/element/input',
+                        ],
+                    'label' => 'Phone Number',
+                    'provider' => 'checkoutProvider',
+                    'sortOrder' => '120',
+                    'disabled' => true,
+                    'visible' => true,
+                    'value' => $address->getTelephone()
+                ];
+
+                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_sms_phone_number'] = $smsConsentTelephone;
+                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_sms_consent'] = $smsConsentCheckbox;
+            }
         }
-        // Open to ideas here, since we don't overwrite the customer-email section
-        // we need to distinguish if the customer is logged in or not, object manager is an easy way to do so
-        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        $customerSession = $objectManager->get('Magento\Customer\Model\Session');
 
         if (!$customerSession->isLoggedIn() && $this->_klaviyoScopeSetting->getConsentAtCheckoutEmailIsActive())
         {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "3.0.8",
+    "version": "3.0.9",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="3.0.8" schema_version="3.0.8">
+  <module name="Klaviyo_Reclaim" setup_version="3.0.9" schema_version="3.0.9">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
Problem Statement:
Usually When an user adds a product to the shopping cart and proceeds with the checkout process.  The checkbox for SMS consent would appear just below the field for Phone Number as illustrated below:

![image2](https://user-images.githubusercontent.com/38661954/134087626-6376a9bc-8782-472e-ba19-6a8988355abc.png)

If the user happens to be logged in and has default address set, user is not given the opportunity to enter address details like we saw for the first example.  Instead you see a uneditable box with the address info as illustrated below:

![image1](https://user-images.githubusercontent.com/38661954/134087549-33b3fbd8-83b0-4ec3-bb3b-2e1310d3e291.png)

Solution:
Expose just between the default address and where user has to select the shipping method the redundant field for Phone Number with SMS consent checkbox underneath:

![image3](https://user-images.githubusercontent.com/38661954/134087796-3f6c0646-6400-4f31-a34b-7ac86e6d0d2c.png)

