### PR TITLE
Message queues db setup

### DIFF
--- a/Model/Events.php
+++ b/Model/Events.php
@@ -21,6 +21,5 @@ class Events extends AbstractModel
     protected function _construct()
     {
         $this->_init('Klaviyo\Reclaim\Model\ResourceModel\Events');
-        parent::_construct();
     }
 }

--- a/Model/Events.php
+++ b/Model/Events.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model;
+
+use Magento\Framework\Model\AbstractModel;
+
+class Events extends AbstractModel
+{
+    protected function _construct()
+    {
+        $this->_init('Klaviyo\Reclaim\Model\Resourcemodel\Events');
+        parent::_construct();
+    }
+}

--- a/Model/Events.php
+++ b/Model/Events.php
@@ -4,11 +4,23 @@ namespace Klaviyo\Reclaim\Model;
 
 use Magento\Framework\Model\AbstractModel;
 
+/**
+ * Klaviyo Events Model is used to represent the kl_events table created using db_schema.xml file using declarative schema.
+ * https://devdocs.magento.com/guides/v2.4/extension-dev-guide/declarative-schema/
+ * The Model doesn't have the capability to query the DB directly but is required by the ResourceModel to create Magento DataObject instances
+ *
+ * The kl_events table will be used as an intermediary between the Observers and kl_syncs table
+ * This table records all user activity events to be sent over to the Klaviyo app using Track API
+ * eg. Added to Cart
+ */
 class Events extends AbstractModel
 {
+    /**
+     * Define resource model
+     */
     protected function _construct()
     {
-        $this->_init('Klaviyo\Reclaim\Model\Resourcemodel\Events');
+        $this->_init('Klaviyo\Reclaim\Model\ResourceModel\Events');
         parent::_construct();
     }
 }

--- a/Model/KlaviyoCollection.php
+++ b/Model/KlaviyoCollection.php
@@ -9,6 +9,12 @@ use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
  */
 abstract class KlaviyoCollection extends AbstractCollection
 {
+    /**
+     * Collection Helper method to get rows to be moved to sync table or send over to Klaviyo app
+     * Takes in status to construct the where query and returns 500 rows
+     * @param $status
+     * @return mixed
+     */
     public function getRowsForSync($status)
     {
         $syncCollection = $this->addFieldToFilter('status',$status)
@@ -18,6 +24,13 @@ abstract class KlaviyoCollection extends AbstractCollection
         return $syncCollection;
     }
 
+    /**
+     * Collection Helper method to get rows to be deleted.
+     * Fetches all rows older than 2 days and having status `SYNCED` for sync table, `MOVED` for topic tables
+     * and returns ids of these rows
+     * @param $status
+     * @return mixed
+     */
     public function getIdsToDelete($status)
     {
         $now = new \DateTime('now');
@@ -37,6 +50,12 @@ abstract class KlaviyoCollection extends AbstractCollection
         return $idsToDelete;
     }
 
+    /**
+     * Collection Helper method to update statuses of rows that have been moved or attempted sync to Klaviyo app
+     * Takes in array of ids and what status to update them to as arguments
+     * @param $ids
+     * @param $status
+     */
     public function updateRowStatus($ids, $status)
     {
         if (empty($ids)) {return;}
@@ -48,6 +67,10 @@ abstract class KlaviyoCollection extends AbstractCollection
         );
     }
 
+    /**
+     * Collection Helper method to delete rows that have been deemed fit for removal.
+     * @param $ids
+     */
     public function deleteRows($ids)
     {
         if (empty($ids)) {return;}

--- a/Model/KlaviyoCollection.php
+++ b/Model/KlaviyoCollection.php
@@ -17,8 +17,8 @@ abstract class KlaviyoCollection extends AbstractCollection
      */
     public function getRowsForSync($status)
     {
-        $syncCollection = $this->addFieldToFilter('status',$status)
-            ->addOrder('id',self::SORT_ORDER_ASC)
+        $syncCollection = $this->addFieldToFilter('status', $status)
+            ->addOrder('id', self::SORT_ORDER_ASC)
             ->setPageSize(500);
 
         return $syncCollection;

--- a/Model/KlaviyoCollection.php
+++ b/Model/KlaviyoCollection.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
+/**
+ * Klaviyo abstract collection class used for inheritance
+ */
+abstract class KlaviyoCollection extends AbstractCollection
+{
+    public function getRowsForSync($status)
+    {
+        $syncCollection = $this->addFieldToFilter('status',$status)
+            ->addOrder('id',self::SORT_ORDER_ASC)
+            ->setPageSize(500);
+
+        return $syncCollection;
+    }
+
+    public function getIdsToDelete($status)
+    {
+        $now = new \DateTime('now');
+        $date = $now->sub(new \DateInterval('P2D'))
+            ->format('Y-m-d H:i:s');
+
+        $tableName = $this->getMainTable();
+
+        $idsToDelete = $this->getConnection()->fetchAll( "select id from (
+                                                            select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
+                                                            from $tableName
+                                                            where status = '".$status."'
+                                                            having row_age_in_days > 2
+                                                          ) as age_of_rows;"
+        );
+
+        return $idsToDelete;
+    }
+
+    public function updateRowStatus($ids, $status)
+    {
+        if (empty($ids)) {return;}
+
+        $this->getConnection()->update(
+            $this->getMainTable(),
+            $bind = ['status' => $status],
+            $where = ['id IN(?)' => $ids]
+        );
+    }
+
+    public function deleteRows($ids)
+    {
+        if (empty($ids)) {return;}
+
+        $this->getConnection()->delete(
+            $this->getMainTable(),
+            $where = ['id IN(?)' => $ids]
+        );
+    }
+}

--- a/Model/Products.php
+++ b/Model/Products.php
@@ -21,6 +21,5 @@ class Products extends AbstractModel
     protected function _construct()
     {
         $this->_init('Klaviyo\Reclaim\Model\ResourceModel\Products');
-        parent::_construct();
     }
 }

--- a/Model/Products.php
+++ b/Model/Products.php
@@ -4,6 +4,15 @@ namespace Klaviyo\Reclaim\Model;
 
 use Magento\Framework\Model\AbstractModel;
 
+/**
+ * Klaviyo Products Model is used to represent the kl_products table created using db_schema.xml file using declarative schema.
+ * https://devdocs.magento.com/guides/v2.4/extension-dev-guide/declarative-schema/
+ * The Model doesn't have the capability to query the DB directly but is required by the ResourceModel to create Magento DataObject instances
+ *
+ * The kl_products table will be used as an intermediary between the Observers and kl_syncs table
+ * This table records all product related updates to be sent for sync to the Klaviyo app using webhooks
+ * eg. product/save webhooks
+ */
 class Products extends AbstractModel
 {
     /**

--- a/Model/Products.php
+++ b/Model/Products.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model;
+
+use Magento\Framework\Model\AbstractModel;
+
+class Products extends AbstractModel
+{
+    /**
+     * Define resource model
+     */
+    protected function _construct()
+    {
+        $this->_init('Klaviyo\Reclaim\Model\ResourceModel\Products');
+        parent::_construct();
+    }
+}

--- a/Model/ResourceModel/Events.php
+++ b/Model/ResourceModel/Events.php
@@ -50,21 +50,4 @@ class Events extends AbstractDb
             $where
         );
     }
-
-    public function getIdsToDelete()
-    {
-        $now = new \DateTime('now');
-        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
-
-        $tableName = $this->getMainTable();
-
-        return $this->getConnection()->fetchAll( "select id from (
-                                                            select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
-                                                            from $tableName
-                                                            where status = '".self::MOVED."'
-                                                            having row_age_in_days > 2
-                                                          ) as age_of_rows;"
-        );
-
-    }
 }

--- a/Model/ResourceModel/Events.php
+++ b/Model/ResourceModel/Events.php
@@ -3,15 +3,16 @@
 namespace Klaviyo\Reclaim\Model\ResourceModel;
 
 use Klaviyo\Reclaim\Setup\SchemaInterface;
-use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 /**
  * Klaviyo Events Table ResourceModel.
  *
  * The ResourceModel for any Model has the ability to query and make transactions with its associated table in the database.
- * This queries through the Zend\Db adapter which is connected to the Databse using the etc/env.php file.
+ * This queries through the Zend\Db adapter which is connected to the Database using the etc/env.php file.
  * The ResourceModel requires the Model to create DataObject instances and requires the table name and its idFieldName
  * to be defined.
+ * https://devdocs.magento.com/guides/v2.4/architecture/archi_perspectives/persist_layer.html
  */
 class Events extends AbstractDb
 {

--- a/Model/ResourceModel/Events.php
+++ b/Model/ResourceModel/Events.php
@@ -1,53 +1,25 @@
 <?php
 
-namespace Klaviyo\Reclaim\Model\Resourcemodel;
+namespace Klaviyo\Reclaim\Model\ResourceModel;
 
 use Klaviyo\Reclaim\Setup\SchemaInterface;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
+/**
+ * Klaviyo Events Table ResourceModel.
+ *
+ * The ResourceModel for any Model has the ability to query and make transactions with its associated table in the database.
+ * This queries through the Zend\Db adapter which is connected to the Databse using the etc/env.php file.
+ * The ResourceModel requires the Model to create DataObject instances and requires the table name and its idFieldName
+ * to be defined.
+ */
 class Events extends AbstractDb
 {
-    const MOVED = 'MOVED';
-
+    /**
+     * Define main table
+     */
     protected function _construct()
     {
         $this->_init(SchemaInterface::KL_EVENTS_TOPIC_TABLE, 'id');
-    }
-
-    public function __construct(
-        \Magento\Framework\Model\ResourceModel\Db\Context $context
-    )
-    {
-        parent::__construct($context);
-    }
-
-    public function updateRowsToMoved($ids)
-    {
-        if (empty($ids)) {
-            return;
-        }
-
-        $bind = ['status' => self::MOVED];
-
-        $where = ['id IN(?)' => $ids];
-        $this->getConnection()->update(
-            $this->getMainTable(),
-            $bind,
-            $where
-        );
-    }
-
-    public function deleteMovedRows($ids)
-    {
-        if (empty($ids)) {
-            return;
-        }
-
-        $where = ['id IN(?)' => $ids];
-
-        $this->getConnection()->delete(
-            $this->getMainTable(),
-            $where
-        );
     }
 }

--- a/Model/ResourceModel/Events.php
+++ b/Model/ResourceModel/Events.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model\Resourcemodel;
+
+use Klaviyo\Reclaim\Setup\SchemaInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class Events extends AbstractDb
+{
+    const MOVED = 'MOVED';
+
+    protected function _construct()
+    {
+        $this->_init(SchemaInterface::KL_EVENTS_TOPIC_TABLE, 'id');
+    }
+
+    public function __construct(
+        \Magento\Framework\Model\ResourceModel\Db\Context $context
+    )
+    {
+        parent::__construct($context);
+    }
+
+    public function updateRowsToMoved($ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $bind = ['status' => self::MOVED];
+
+        $where = ['id IN(?)' => $ids];
+        $this->getConnection()->update(
+            $this->getMainTable(),
+            $bind,
+            $where
+        );
+    }
+
+    public function deleteMovedRows($ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $where = ['id IN(?)' => $ids];
+
+        $this->getConnection()->delete(
+            $this->getMainTable(),
+            $where
+        );
+    }
+
+    public function getIdsToDelete()
+    {
+        $now = new \DateTime('now');
+        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
+
+        $tableName = $this->getMainTable();
+
+        return $this->getConnection()->fetchAll( "select id from (
+                                                            select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
+                                                            from $tableName
+                                                            where status = '".self::MOVED."'
+                                                            having row_age_in_days > 2
+                                                          ) as age_of_rows;"
+        );
+
+    }
+}

--- a/Model/ResourceModel/Events/Collection.php
+++ b/Model/ResourceModel/Events/Collection.php
@@ -2,47 +2,30 @@
 
 namespace Klaviyo\Reclaim\Model\ResourceModel\Events;
 
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Klaviyo\Reclaim\Model\KlaviyoCollection;
 
-class Collection extends AbstractCollection
+/*
+ * Klaviyo Events Collection Class
+ *
+ * Magento Collections are encapsulating the sets of models and related functionality, such as filtering, sorting and paging.
+ * When creating a Resource Collection, you need to specify which model it corresponds to, so that it can instantiate the
+ * appropriate classes after loading a list of records. It is also necessary to know the matching resource model to be able
+ * to access the database. A Resource Collection is necessary to create a set of model instances and operate on them.
+ * Collections are very close to the database layer.
+ */
+
+class Collection extends KlaviyoCollection
 {
-    protected $_idFieldName = 'id';
-
     /**
-     * Define resource model
+     * Define model & resource model
      *
      * @return void
      */
     protected function _construct()
     {
-        $this->_init( 'Klaviyo\Reclaim\Model\Events', 'Klaviyo\Reclaim\Model\ResourceModel\Events' );
-    }
-
-    public function getEventsToUpdate()
-    {
-        $eventsCollection = $this->addFieldToSelect( ['id','event','payload','user_properties'] )
-            ->addFieldToFilter( 'status','New' )
-            ->addOrder( 'created_at', self::SORT_ORDER_ASC )
-            ->setPageSize( 500 );
-
-        return $eventsCollection;
-    }
-
-    public function getIdsToDelete()
-    {
-        $now = new \DateTime('now');
-        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
-
-        $tableName = $this->getMainTable();
-
-        $idsToDelete = $this->getConnection()->fetchAll( "select id from (
-                                                            select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
-                                                            from $tableName
-                                                            where status = '".self::MOVED."'
-                                                            having row_age_in_days > 2
-                                                          ) as age_of_rows;"
+        $this->_init(
+            'Klaviyo\Reclaim\Model\Events',
+            'Klaviyo\Reclaim\Model\ResourceModel\Events'
         );
-
-        return $idsToDelete;
     }
 }

--- a/Model/ResourceModel/Events/Collection.php
+++ b/Model/ResourceModel/Events/Collection.php
@@ -28,4 +28,21 @@ class Collection extends AbstractCollection
         return $eventsCollection;
     }
 
+    public function getIdsToDelete()
+    {
+        $now = new \DateTime('now');
+        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
+
+        $tableName = $this->getMainTable();
+
+        $idsToDelete = $this->getConnection()->fetchAll( "select id from (
+                                                            select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
+                                                            from $tableName
+                                                            where status = '".self::MOVED."'
+                                                            having row_age_in_days > 2
+                                                          ) as age_of_rows;"
+        );
+
+        return $idsToDelete;
+    }
 }

--- a/Model/ResourceModel/Events/Collection.php
+++ b/Model/ResourceModel/Events/Collection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model\ResourceModel\Events;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
+class Collection extends AbstractCollection
+{
+    protected $_idFieldName = 'id';
+
+    /**
+     * Define resource model
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init( 'Klaviyo\Reclaim\Model\Events', 'Klaviyo\Reclaim\Model\ResourceModel\Events' );
+    }
+
+    public function getEventsToUpdate()
+    {
+        $eventsCollection = $this->addFieldToSelect( ['id','event','payload','user_properties'] )
+            ->addFieldToFilter( 'status','New' )
+            ->addOrder( 'created_at', self::SORT_ORDER_ASC )
+            ->setPageSize( 500 );
+
+        return $eventsCollection;
+    }
+
+}

--- a/Model/ResourceModel/Products.php
+++ b/Model/ResourceModel/Products.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model\ResourceModel;
+
+use Klaviyo\Reclaim\Helper\Logger;
+
+class Products extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+{
+    protected $_klaviyoLogger;
+    protected function _construct()
+    {
+        $this->_init('kl_products', 'id');
+    }
+
+    public function __construct(
+        \Magento\Framework\Model\ResourceModel\Db\Context $context,
+        Logger $klaviyoLogger
+    )
+    {
+        parent::__construct($context);
+        $this->_klaviyoLogger = $klaviyoLogger;
+    }
+
+    public function updateRowsToMoved($ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $this->getConnection()->update(
+            $this->getMainTable(),
+            ['status' => 'MOVED'],
+            ['id IN(?)' => $ids]
+        );
+    }
+
+    public function deleteMovedRows($ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $this->getConnection()->delete(
+            $this->getMainTable(),
+            ['id IN(?)' => $ids]
+        );
+    }
+}

--- a/Model/ResourceModel/Products.php
+++ b/Model/ResourceModel/Products.php
@@ -3,14 +3,16 @@
 namespace Klaviyo\Reclaim\Model\ResourceModel;
 
 use Klaviyo\Reclaim\Setup\SchemaInterface;
+
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
-/*
+/**
  * Klaviyo Products Table ResourceModel.
  *
  * The ResourceModel for any Model has the ability to query and make transactions with its associated table in the database.
- * This queries through the Zend\Db adapter which is connected to the Databse using the etc/env.php file.
+ * This queries through the Zend\Db adapter which is connected to the Database using the etc/env.php file.
  * The ResourceModel requires the Model to create DataObject instances and requires the table name and its idFieldName
  * to be defined.
+ * https://devdocs.magento.com/guides/v2.4/architecture/archi_perspectives/persist_layer.html
  */
 class Products extends AbstractDb
 {

--- a/Model/ResourceModel/Products.php
+++ b/Model/ResourceModel/Products.php
@@ -2,47 +2,23 @@
 
 namespace Klaviyo\Reclaim\Model\ResourceModel;
 
-use Klaviyo\Reclaim\Helper\Logger;
-
-class Products extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+use Klaviyo\Reclaim\Setup\SchemaInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+/*
+ * Klaviyo Products Table ResourceModel.
+ *
+ * The ResourceModel for any Model has the ability to query and make transactions with its associated table in the database.
+ * This queries through the Zend\Db adapter which is connected to the Databse using the etc/env.php file.
+ * The ResourceModel requires the Model to create DataObject instances and requires the table name and its idFieldName
+ * to be defined.
+ */
+class Products extends AbstractDb
 {
-    protected $_klaviyoLogger;
+    /**
+     * Define main table
+     */
     protected function _construct()
     {
-        $this->_init('kl_products', 'id');
-    }
-
-    public function __construct(
-        \Magento\Framework\Model\ResourceModel\Db\Context $context,
-        Logger $klaviyoLogger
-    )
-    {
-        parent::__construct($context);
-        $this->_klaviyoLogger = $klaviyoLogger;
-    }
-
-    public function updateRowsToMoved($ids)
-    {
-        if (empty($ids)) {
-            return;
-        }
-
-        $this->getConnection()->update(
-            $this->getMainTable(),
-            ['status' => 'MOVED'],
-            ['id IN(?)' => $ids]
-        );
-    }
-
-    public function deleteMovedRows($ids)
-    {
-        if (empty($ids)) {
-            return;
-        }
-
-        $this->getConnection()->delete(
-            $this->getMainTable(),
-            ['id IN(?)' => $ids]
-        );
+        $this->_init(SchemaInterface::KL_PRODUCTS_TOPIC_TABLE, 'id');
     }
 }

--- a/Model/ResourceModel/Products/Collection.php
+++ b/Model/ResourceModel/Products/Collection.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model\ResourceModel\Products;
+
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+{
+    /**
+     * Define resource model
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init(
+            'Klaviyo\Reclaim\Model\Products',
+            'Klaviyo\Reclaim\Model\ResourceModel\Products'
+        );
+    }
+
+    public function getKlProductsToQueueForSync()
+    {
+        $productsCollection = $this->addFieldToSelect( ['id','payload','status','topic', 'klaviyo_id'] )
+            ->addFieldToFilter( 'status','NEW' )
+            ->addOrder( 'id', self::SORT_ORDER_ASC )
+            ->setPageSize( 5 );
+
+        return $productsCollection;
+    }
+
+    public function getRowsToDelete()
+    {
+        $now = new \DateTime('now');
+        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
+
+        $tableName = $this->getMainTable();
+
+        $rowsToDelete = $this->getConnection()
+            ->fetchAll( "select id from (
+                         select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
+                         from $tableName
+                         where status = 'MOVED'
+                         having row_age_in_days > 2
+                      ) as age_of_rows;"
+            );
+        return $rowsToDelete;
+    }
+}

--- a/Model/ResourceModel/Products/Collection.php
+++ b/Model/ResourceModel/Products/Collection.php
@@ -17,7 +17,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         );
     }
 
-    public function getKlProductsToQueueForSync()
+    public function getProductsToUpdate()
     {
         $productsCollection = $this->addFieldToSelect( ['id','payload','status','topic', 'klaviyo_id'] )
             ->addFieldToFilter( 'status','NEW' )
@@ -27,7 +27,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         return $productsCollection;
     }
 
-    public function getRowsToDelete()
+    public function getIdsToDelete()
     {
         $now = new \DateTime('now');
         $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');

--- a/Model/ResourceModel/Products/Collection.php
+++ b/Model/ResourceModel/Products/Collection.php
@@ -2,10 +2,21 @@
 
 namespace Klaviyo\Reclaim\Model\ResourceModel\Products;
 
-class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+use Klaviyo\Reclaim\Model\KlaviyoCollection;
+
+/*
+ * Klaviyo Products Collection Class
+ *
+ * Magento Collections are encapsulating the sets of models and related functionality, such as filtering, sorting and paging.
+ * When creating a Resource Collection, you need to specify which model it corresponds to, so that it can instantiate the
+ * appropriate classes after loading a list of records. It is also necessary to know the matching resource model to be able
+ * to access the database. A Resource Collection is necessary to create a set of model instances and operate on them.
+ * Collections are very close to the database layer.
+ */
+class Collection extends KlaviyoCollection
 {
     /**
-     * Define resource model
+     * Define model & resource model
      *
      * @return void
      */
@@ -15,33 +26,5 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
             'Klaviyo\Reclaim\Model\Products',
             'Klaviyo\Reclaim\Model\ResourceModel\Products'
         );
-    }
-
-    public function getProductsToUpdate()
-    {
-        $productsCollection = $this->addFieldToSelect( ['id','payload','status','topic', 'klaviyo_id'] )
-            ->addFieldToFilter( 'status','NEW' )
-            ->addOrder( 'id', self::SORT_ORDER_ASC )
-            ->setPageSize( 5 );
-
-        return $productsCollection;
-    }
-
-    public function getIdsToDelete()
-    {
-        $now = new \DateTime('now');
-        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
-
-        $tableName = $this->getMainTable();
-
-        $rowsToDelete = $this->getConnection()
-            ->fetchAll( "select id from (
-                         select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
-                         from $tableName
-                         where status = 'MOVED'
-                         having row_age_in_days > 2
-                      ) as age_of_rows;"
-            );
-        return $rowsToDelete;
     }
 }

--- a/Model/ResourceModel/Syncs.php
+++ b/Model/ResourceModel/Syncs.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model\ResourceModel;
+
+class Syncs extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+{
+    const SYNCED = 'SYNCED';
+
+    /**
+     * Define main table
+     */
+    protected function _construct()
+    {
+        $this->_init('kl_sync', 'id');
+    }
+
+    public function updateRowsToSynced($ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $this->getConnection()->update(
+            $this->getMainTable(),
+            ['status' => 'SYNCED'],
+            $where = ['id IN(?)' => $ids]
+        );
+    }
+
+    public function updateRowsToRetry($ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $this->getConnection()->update(
+            $this->getMainTable(),
+            ['status' => 'RETRY'],
+            $where = ['id IN(?)' => $ids]
+        );
+    }
+
+    public function updateRowsToFailed($ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $this->getConnection()->update(
+            $this->getMainTable(),
+            ['status' => 'FAILED'],
+            $where = ['id IN(?)' => $ids]
+        );
+    }
+
+    public function deleteSyncedRows($ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $this->getConnection()->delete(
+            $this->getMainTable(),
+            $where = ['id IN(?)' => $ids]
+        );
+    }
+
+    public function deleteFailedRows($ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $where = ['id IN(?)' => $ids];
+
+        $this->getConnection()->delete(
+            $this->getMainTable(),
+            $where
+        );
+    }
+
+    public function getIdsToDelete()
+    {
+        $now = new \DateTime('now');
+        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
+
+        $tableName = $this->getMainTable();
+
+        return $this->getConnection()->fetchAll( "select id from (
+                                                            select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
+                                                            from $tableName
+                                                            where status = '".self::SYNCED."'
+                                                            having row_age_in_days > 2
+                                                          ) as age_of_rows;"
+        );
+
+    }
+}

--- a/Model/ResourceModel/Syncs.php
+++ b/Model/ResourceModel/Syncs.php
@@ -78,21 +78,4 @@ class Syncs extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $where
         );
     }
-
-    public function getIdsToDelete()
-    {
-        $now = new \DateTime('now');
-        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
-
-        $tableName = $this->getMainTable();
-
-        return $this->getConnection()->fetchAll( "select id from (
-                                                            select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
-                                                            from $tableName
-                                                            where status = '".self::SYNCED."'
-                                                            having row_age_in_days > 2
-                                                          ) as age_of_rows;"
-        );
-
-    }
 }

--- a/Model/ResourceModel/Syncs.php
+++ b/Model/ResourceModel/Syncs.php
@@ -3,14 +3,16 @@
 namespace Klaviyo\Reclaim\Model\ResourceModel;
 
 use Klaviyo\Reclaim\Setup\SchemaInterface;
+
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
-/*
+/**
  * Klaviyo Syncs Table ResourceModel.
  *
  * The ResourceModel for any Model has the ability to query and make transactions with its associated table in the database.
- * This queries through the Zend\Db adapter which is connected to the Databse using the etc/env.php file.
+ * This queries through the Zend\Db adapter which is connected to the Database using the etc/env.php file.
  * The ResourceModel requires the Model to create DataObject instances and requires the table name and its idFieldName
  * to be defined.
+ * https://devdocs.magento.com/guides/v2.4/architecture/archi_perspectives/persist_layer.html
  */
 class Syncs extends AbstractDb
 {

--- a/Model/ResourceModel/Syncs.php
+++ b/Model/ResourceModel/Syncs.php
@@ -2,80 +2,23 @@
 
 namespace Klaviyo\Reclaim\Model\ResourceModel;
 
-class Syncs extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+use Klaviyo\Reclaim\Setup\SchemaInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+/*
+ * Klaviyo Syncs Table ResourceModel.
+ *
+ * The ResourceModel for any Model has the ability to query and make transactions with its associated table in the database.
+ * This queries through the Zend\Db adapter which is connected to the Databse using the etc/env.php file.
+ * The ResourceModel requires the Model to create DataObject instances and requires the table name and its idFieldName
+ * to be defined.
+ */
+class Syncs extends AbstractDb
 {
-    const SYNCED = 'SYNCED';
-
     /**
      * Define main table
      */
     protected function _construct()
     {
-        $this->_init('kl_sync', 'id');
-    }
-
-    public function updateRowsToSynced($ids)
-    {
-        if (empty($ids)) {
-            return;
-        }
-
-        $this->getConnection()->update(
-            $this->getMainTable(),
-            ['status' => 'SYNCED'],
-            $where = ['id IN(?)' => $ids]
-        );
-    }
-
-    public function updateRowsToRetry($ids)
-    {
-        if (empty($ids)) {
-            return;
-        }
-
-        $this->getConnection()->update(
-            $this->getMainTable(),
-            ['status' => 'RETRY'],
-            $where = ['id IN(?)' => $ids]
-        );
-    }
-
-    public function updateRowsToFailed($ids)
-    {
-        if (empty($ids)) {
-            return;
-        }
-
-        $this->getConnection()->update(
-            $this->getMainTable(),
-            ['status' => 'FAILED'],
-            $where = ['id IN(?)' => $ids]
-        );
-    }
-
-    public function deleteSyncedRows($ids)
-    {
-        if (empty($ids)) {
-            return;
-        }
-
-        $this->getConnection()->delete(
-            $this->getMainTable(),
-            $where = ['id IN(?)' => $ids]
-        );
-    }
-
-    public function deleteFailedRows($ids)
-    {
-        if (empty($ids)) {
-            return;
-        }
-
-        $where = ['id IN(?)' => $ids];
-
-        $this->getConnection()->delete(
-            $this->getMainTable(),
-            $where
-        );
+        $this->_init(SchemaInterface::KL_SYNC_TABLE, 'id');
     }
 }

--- a/Model/ResourceModel/Syncs/Collection.php
+++ b/Model/ResourceModel/Syncs/Collection.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model\ResourceModel\Syncs;
+
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+{
+    /**
+     * Define model & resource model
+     */
+    protected function _construct()
+    {
+        $this->_init(
+            'Klaviyo\Reclaim\Model\Syncs',
+            'Klaviyo\Reclaim\Model\ResourceModel\Syncs'
+        );
+
+    }
+
+    public function getRowsForSync()
+    {
+        $syncCollection = $this->addFieldToFilter( 'status','NEW' )
+            ->addOrder( 'id', self::SORT_ORDER_ASC )
+            ->setPageSize( 100 );
+
+        return $syncCollection;
+    }
+
+    public function getRowsForRetrySync()
+    {
+        $syncCollection = $this->addFieldToFilter( 'status','RETRY' )
+            ->addOrder( 'id', self::SORT_ORDER_ASC )
+            ->setPageSize( 100 );
+
+        return $syncCollection;
+    }
+
+}

--- a/Model/ResourceModel/Syncs/Collection.php
+++ b/Model/ResourceModel/Syncs/Collection.php
@@ -2,7 +2,18 @@
 
 namespace Klaviyo\Reclaim\Model\ResourceModel\Syncs;
 
-class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+use Klaviyo\Reclaim\Model\KlaviyoCollection;
+
+/*
+ * Klaviyo Syncs Collection Class
+ *
+ * Magento Collections are encapsulating the sets of models and related functionality, such as filtering, sorting and paging.
+ * When creating a Resource Collection, you need to specify which model it corresponds to, so that it can instantiate the
+ * appropriate classes after loading a list of records. It is also necessary to know the matching resource model to be able
+ * to access the database. A Resource Collection is necessary to create a set of model instances and operate on them.
+ * Collections are very close to the database layer.
+ */
+class Collection extends KlaviyoCollection
 {
     /**
      * Define model & resource model
@@ -13,43 +24,5 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
             'Klaviyo\Reclaim\Model\Syncs',
             'Klaviyo\Reclaim\Model\ResourceModel\Syncs'
         );
-
-    }
-
-    public function getRowsForSync()
-    {
-        $syncCollection = $this->addFieldToFilter( 'status','NEW' )
-            ->addOrder( 'id', self::SORT_ORDER_ASC )
-            ->setPageSize( 100 );
-
-        return $syncCollection;
-    }
-
-    public function getRowsForRetrySync()
-    {
-        $syncCollection = $this->addFieldToFilter( 'status','RETRY' )
-            ->addOrder( 'id', self::SORT_ORDER_ASC )
-            ->setPageSize( 100 );
-
-        return $syncCollection;
-    }
-
-    public function getIdsToDelete()
-    {
-        $now = new \DateTime('now');
-        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
-
-        $tableName = $this->getMainTable();
-
-        $idsToDelete = $this->getConnection()->fetchAll( "select id from (
-                                                            select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
-                                                            from $tableName
-                                                            where status = '".self::SYNCED."'
-                                                            having row_age_in_days > 2
-                                                          ) as age_of_rows;"
-        );
-
-        return $idsToDelete;
-
     }
 }

--- a/Model/ResourceModel/Syncs/Collection.php
+++ b/Model/ResourceModel/Syncs/Collection.php
@@ -34,4 +34,22 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         return $syncCollection;
     }
 
+    public function getIdsToDelete()
+    {
+        $now = new \DateTime('now');
+        $date = $now->sub( new \DateInterval('P2D') )->format('Y-m-d H:i:s');
+
+        $tableName = $this->getMainTable();
+
+        $idsToDelete = $this->getConnection()->fetchAll( "select id from (
+                                                            select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
+                                                            from $tableName
+                                                            where status = '".self::SYNCED."'
+                                                            having row_age_in_days > 2
+                                                          ) as age_of_rows;"
+        );
+
+        return $idsToDelete;
+
+    }
 }

--- a/Model/Syncs.php
+++ b/Model/Syncs.php
@@ -4,6 +4,15 @@ namespace Klaviyo\Reclaim\Model;
 
 use Magento\Framework\Model\AbstractModel;
 
+/***
+ * Klaviyo Syncs Model is used to represent the kl_syncs table created using db_schema.xml file using declarative schema.
+ * https://devdocs.magento.com/guides/v2.4/extension-dev-guide/declarative-schema/
+ * The Model doesn't have the capability to query the DB directly but is required by the ResourceModel to create Magento DataObject instances
+ *
+ * The kl_syncs table will be read from by cron jobs to send product/order updates and track events to the Klaviyo app.
+ * This table is updated by each individual topic syncs, and rows are added to this table to sync to the app using the
+ * klaviyo_webhook/event_sync cron job which runs every 5 minutes
+ */
 class Syncs extends AbstractModel
 {
     /**

--- a/Model/Syncs.php
+++ b/Model/Syncs.php
@@ -4,7 +4,7 @@ namespace Klaviyo\Reclaim\Model;
 
 use Magento\Framework\Model\AbstractModel;
 
-/***
+/**
  * Klaviyo Syncs Model is used to represent the kl_syncs table created using db_schema.xml file using declarative schema.
  * https://devdocs.magento.com/guides/v2.4/extension-dev-guide/declarative-schema/
  * The Model doesn't have the capability to query the DB directly but is required by the ResourceModel to create Magento DataObject instances
@@ -21,6 +21,5 @@ class Syncs extends AbstractModel
     protected function _construct()
     {
         $this->_init('Klaviyo\Reclaim\Model\ResourceModel\Syncs');
-        parent::_construct();
     }
 }

--- a/Model/Syncs.php
+++ b/Model/Syncs.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model;
+
+use Magento\Framework\Model\AbstractModel;
+
+class Syncs extends AbstractModel
+{
+    /**
+     * Define resource model
+     */
+    protected function _construct()
+    {
+        $this->_init('Klaviyo\Reclaim\Model\ResourceModel\Syncs');
+        parent::_construct();
+    }
+}

--- a/Setup/SchemaInterface.php
+++ b/Setup/SchemaInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Klaviyo\Reclaim\Setup;
+
+interface SchemaInterface
+{
+    const KL_EVENTS_TOPIC_TABLE = 'kl_events';
+    const KL_PRODUCTS_TOPIC_TABLE = 'kl_products';
+    const KL_SYNC_TABLE = 'kl_sync';
+}

--- a/Setup/SchemaInterface.php
+++ b/Setup/SchemaInterface.php
@@ -1,7 +1,9 @@
 <?php
 
 namespace Klaviyo\Reclaim\Setup;
-
+/**
+ * Provides a list of all Klaviyo tables in the Magento Database.
+ */
 interface SchemaInterface
 {
     const KL_EVENTS_TOPIC_TABLE = 'kl_events';

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="kl_sync" resource="default" engine="innodb" comment="Klaviyo Sync table">
+        <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true"
+                comment="Primary key"/>
+        <column xsi:type="text" name="payload" nullable="true" comment="Event payload"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, SYNCED...)"/>
+        <column xsi:type="varchar" name="topic" nullable="false" length="255" comment="Klaviyo Topic name"/>
+        <column xsi:type="text" name="klaviyo_id" nullable="true" length="100" comment="Klaviyo ID"/>
+        <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Creation time"/>
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="true" default="CURRENT_TIMESTAMP" comment="Update time"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="id"/>
+        </constraint>
+        <index referenceId="KL_SYNC_STATUS">
+            <column name="status"/>
+        </index>
+        <index referenceId="KL_SYNC_TOPIC">
+            <column name="topic"/>
+        </index>
+        <index referenceId="KL_SYNC_CREATED_AT">
+            <column name="created_at"/>
+        </index>
+        <index referenceId="KL_SYNC_UPDATED_AT">
+            <column name="updated_at"/>
+        </index>
+    </table>
+    <table name="kl_products" resource="default" engine="innodb" comment="Klaviyo Products topic table">
+        <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true"
+                comment="Primary key"/>
+        <column xsi:type="text" name="payload" nullable="true" comment="Event payload"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, FAILED...)"/>
+        <column xsi:type="varchar" name="topic" nullable="false" length="255" comment="Klaviyo webhook topic"/>
+        <column xsi:type="text" name="klaviyo_id" nullable="true" length="100" comment="Klaviyo ID"/>
+        <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Creation time"/>
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="true" default="CURRENT_TIMESTAMP" comment="Update time"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="id"/>
+        </constraint>
+        <index referenceId="KL_PRODUCTS_STATUS">
+            <column name="status"/>
+        </index>
+        <index referenceId="KL_PRODUCTS_TOPIC">
+            <column name="topic"/>
+        </index>
+        <index referenceId="KL_PRODUCTS_CREATED_AT">
+            <column name="created_at"/>
+        </index>
+        <index referenceId="KL_PRODUCTS_UPDATED_AT">
+            <column name="updated_at"/>
+        </index>
+    </table>
+    <table name="kl_events" resource="default" engine="innodb" comment="Klaviyo Events topic table">
+        <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true"
+                comment="Primary key"/>
+        <column xsi:type="varchar" name="status" nullable="true" length="30" comment="Status of row (New, Moved)"/>
+        <column xsi:type="varchar" name="event" nullable="true" length="255" comment="Klaviyo Event name"/>
+        <column xsi:type="text" name="user_properties" nullable="true" comment="User properties"/>
+        <column xsi:type="text" name="payload" nullable="true" comment="Event payload"/>
+        <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Creation time"/>
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="true" default="CURRENT_TIMESTAMP" comment="Update time"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="id"/>
+        </constraint>
+        <index referenceId="KL_EVENTS_STATUS">
+            <column name="status"/>
+        </index>
+        <index referenceId="KL_EVENTS_CREATED_AT">
+            <column name="created_at"/>
+        </index>
+        <index referenceId="KL_EVENTS_UPDATED_AT">
+            <column name="updated_at"/>
+        </index>
+    </table>
+</schema>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -4,9 +4,9 @@
         <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true"
                 comment="Primary key"/>
         <column xsi:type="text" name="payload" nullable="true" comment="Event payload"/>
-        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, SYNCED...)"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, MOVED)"/>
         <column xsi:type="varchar" name="topic" nullable="false" length="255" comment="Klaviyo Topic name"/>
-        <column xsi:type="text" name="klaviyo_id" nullable="true" length="100" comment="Klaviyo ID"/>
+        <column xsi:type="text" name="klaviyo_id" nullable="true" comment="Klaviyo ID"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Creation time"/>
         <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="true" default="CURRENT_TIMESTAMP" comment="Update time"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
@@ -29,9 +29,9 @@
         <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true"
                 comment="Primary key"/>
         <column xsi:type="text" name="payload" nullable="true" comment="Event payload"/>
-        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, FAILED...)"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, SYNCED, RETRY, FAILED)"/>
         <column xsi:type="varchar" name="topic" nullable="false" length="255" comment="Klaviyo webhook topic"/>
-        <column xsi:type="text" name="klaviyo_id" nullable="true" length="100" comment="Klaviyo ID"/>
+        <column xsi:type="text" name="klaviyo_id" nullable="true" comment="Klaviyo ID"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Creation time"/>
         <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="true" default="CURRENT_TIMESTAMP" comment="Update time"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
@@ -53,7 +53,7 @@
     <table name="kl_events" resource="default" engine="innodb" comment="Klaviyo Events topic table">
         <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true"
                 comment="Primary key"/>
-        <column xsi:type="varchar" name="status" nullable="true" length="30" comment="Status of row (New, Moved)"/>
+        <column xsi:type="varchar" name="status" nullable="true" length="30" comment="Status of row (NEW, MOVED)"/>
         <column xsi:type="varchar" name="event" nullable="true" length="255" comment="Klaviyo Event name"/>
         <column xsi:type="text" name="user_properties" nullable="true" comment="User properties"/>
         <column xsi:type="text" name="payload" nullable="true" comment="Event payload"/>


### PR DESCRIPTION
Starting 2.3, Magento decided to deprecate InstallSchema/UpgradeSchema, InstallData/UpgradeData scripts to using a db_schema.xml file and call it [declarative schema](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/declarative-schema/). 
If any of our customers are using a version older than 2.3.4, they can't upgrade M2 extensions to post 3.0.5, so we decided to go ahead with implementing this approach to add new tables. 

Magento suggests creating Models for each table to carry out CRUD operations on table. So each of the three tables have their own Model,ResourceModel and Collection classes.

The structure of such Models should be as follows:
```
extension_root
`-- Models
    |-- New_table.php
    `-- ResourceModel
        |-- New_table.php
        `-- New_table
            `-- Collection.php
```