### PR TITLE
Message queues -  Added to Cart observers and Cron logic

### DIFF
--- a/Cron/EventsTopic.php
+++ b/Cron/EventsTopic.php
@@ -53,7 +53,7 @@ class EventsTopic
     }
 
     /**
-     *
+     * Gets 500 rows from the kl_events table and move to the kl_sync table
      */
     public function moveRowsToSync()
     {
@@ -91,6 +91,9 @@ class EventsTopic
         $eventsCollection->updateRowStatus($idsMoved, 'MOVED');
     }
 
+    /**
+     * Deletes rows moved to the kl_syncs table that are older than 2 days
+     */
     public function deleteMovedRows()
     {
         // Delete rows that have been moved to sync table

--- a/Cron/EventsTopic.php
+++ b/Cron/EventsTopic.php
@@ -22,7 +22,7 @@ class EventsTopic
     protected $_quoteIdMaskResource;
 
     /**
-     * Klaviyo Events Collection Facd ..ctory
+     * Klaviyo Events Collection Factory
      * @var CollectionFactory
      */
     protected $_eventsCollectionFactory;
@@ -63,14 +63,14 @@ class EventsTopic
             ->addFieldToSelect(['id','event','payload','user_properties'])
             ->getData();
 
-        if (empty( $eventsData )){
+        if (empty($eventsData)){
             return;
         }
 
         $idsMoved = [];
 
         // Capture all events that have been moved and add data to Sync table
-        foreach ( $eventsData as $event ){
+        foreach ($eventsData as $event){
             //TODO: This can probably be done as one bulk update instead of individual inserts
             $sync = $this->_klSyncFactory->create();
             $sync->setData([
@@ -108,10 +108,10 @@ class EventsTopic
      * @param array $payload
      * @return false|string
      */
-    public function replaceQuoteIdwithMaskedQuoteId( array $payload )
+    public function replaceQuoteIdwithMaskedQuoteId(array $payload)
     {
         $decoded_payload = json_decode($payload, true);
-        $maskedQuoteId = $this->_quoteIdMaskResource->getMaskedQuoteId(( $decoded_payload['QuoteId'] ));
+        $maskedQuoteId = $this->_quoteIdMaskResource->getMaskedQuoteId(($decoded_payload['QuoteId']));
         unset($decoded_payload['QuoteId']);
 
         return $payload = json_encode(array_merge(

--- a/Cron/EventsTopic.php
+++ b/Cron/EventsTopic.php
@@ -156,7 +156,7 @@ class EventsTopic
     }
 
     /**
-     * Retrieve categoryNames using from category factory using Ids
+     * Retrieve categoryNames from category factory using Ids
      * @param array $categoryIds
      * @return array
      */

--- a/Cron/EventsTopic.php
+++ b/Cron/EventsTopic.php
@@ -132,7 +132,7 @@ class EventsTopic
     public function replaceQuoteIdAndCategoryIds(string $payload): array
     {
         $decoded_payload = json_decode($payload, true);
-        $maskedQuoteId = $this->_quoteIdMaskResource->getMaskedQuoteId(($decoded_payload['QuoteId']));
+        $maskedQuoteId = $this->_quoteIdMaskResource->getMaskedQuoteId($decoded_payload['QuoteId']);
         $decoded_payload['MaskedQuoteId'] = $maskedQuoteId;
         unset($decoded_payload['QuoteId']);
 

--- a/Cron/EventsTopic.php
+++ b/Cron/EventsTopic.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Klaviyo\Reclaim\Cron;
+
+use Klaviyo\Reclaim\Helper\Logger;
+use Klaviyo\Reclaim\Model\SyncsFactory;
+use Klaviyo\Reclaim\Model\Quote\QuoteIdMask;
+use Klaviyo\Reclaim\Model\Resourcemodel\Events\CollectionFactory;
+
+class EventsTopic
+{
+    /**
+     * Klaviyo Logger
+     * @var Logger
+     */
+    protected $_klaviyoLogger;
+
+    /**
+     * Klaviyo QuoteIdMask ResourceModel
+     * @var QuoteIdMask
+     */
+    protected $_quoteIdMaskResource;
+
+    /**
+     * Klaviyo Events Collection Facd ..ctory
+     * @var CollectionFactory
+     */
+    protected $_eventsCollectionFactory;
+
+    /**
+     * Klaviyo Sync Factory
+     * @var SyncsFactory
+     */
+    protected $_klSyncFactory;
+
+    /**
+     * @param Logger $klaviyoLogger
+     * @param CollectionFactory $eventsCollectionFactory
+     * @param SyncsFactory $klSyncFactory
+     * @param QuoteIdMask $quoteIdMaskResource
+     */
+    public function __construct(
+        Logger $klaviyoLogger,
+        CollectionFactory $eventsCollectionFactory,
+        SyncsFactory $klSyncFactory,
+        QuoteIdMask $quoteIdMaskResource
+    )
+    {
+        $this->_klaviyoLogger = $klaviyoLogger;
+        $this->_eventsCollectionFactory = $eventsCollectionFactory;
+        $this->_klSyncFactory = $klSyncFactory;
+        $this->_quoteIdMaskResource = $quoteIdMaskResource;
+    }
+
+    /**
+     * Cron method used by klaviyo_events_topic cron job
+     * Reads rows from kl_events table and writes to the kl_sync table
+     */
+    public function moveRowsToSync()
+    {
+        // New Events to be moved to kl_sync table and update status of these to Moved, limit 500
+        $eventsCollection = $this->_eventsCollectionFactory->create();
+        $eventsData = $eventsCollection->getRowsForSync('NEW')
+            ->addFieldToSelect(['id','event','payload','user_properties'])
+            ->getData();
+
+        if (empty( $eventsData )){
+            return;
+        }
+
+        $idsMoved = [];
+
+        // Capture all events that have been moved and add data to Sync table
+        foreach ( $eventsData as $event ){
+            //TODO: This can probably be done as one bulk update instead of individual inserts
+            $sync = $this->_klSyncFactory->create();
+            $sync->setData([
+                'status' => 'NEW',
+                'topic' => $event['event'],
+                'user_properties' => $event['user_properties'],
+                'payload' => $this->addMaskedQuoteIdToEventPayload(json_decode($event['payload'], true))
+            ]);
+            try {
+                $sync->save();
+                array_push($idsMoved, $event['id']);
+            } catch (\Exception $e) {
+                $this->_klaviyoLogger->log(sprintf("Unable to move row: %s", $e));
+            }
+        }
+
+        // Update Status of rows in kl_events table to Moved
+        $eventsCollection->updateRowStatus($idsMoved, 'MOVED');
+    }
+
+    /**
+     * Cron method used by the klaviyo_events_cleanup cron job
+     * Delete all rows marked as MOVED and older than 2 days in the kl_events table
+     */
+    public function deleteMovedRows()
+    {
+        // Delete rows that have been moved to sync table
+        $eventsCollection = $this->_eventsCollectionFactory->create();
+        $idsToDelete = $eventsCollection->getIdsToDelete('MOVED');
+
+        $eventsCollection->deleteRows($idsToDelete);
+    }
+
+    /**
+     * Helper method to get MaskedQuoteId from quote_id_mask table and replace QuoteId in payload
+     * This needs to be done here since MaskedQuoteId is unavailable when rows are recorded in kl_events table
+     * @param $payload
+     * @return false|string
+     */
+    public function addMaskedQuoteIdToEventPayload( $payload )
+    {
+        $maskedQuoteId = $this->_quoteIdMaskResource->getMaskedQuoteId(( $payload['QuoteId'] ));
+        unset($payload['QuoteId']);
+
+        return $payload = json_encode(array_merge(
+            $payload,
+            array('MaskedQuoteId' => $maskedQuoteId)
+        ));
+    }
+
+}

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -61,7 +61,7 @@ class KlSyncs
     public function sync()
     {
         $syncCollection = $this->_syncCollectionFactory->create();
-        $groupedRows = $this->getGroupedRows( $syncCollection->getRowsForSync('NEW')->getData() );
+        $groupedRows = $this->getGroupedRows($syncCollection->getRowsForSync('NEW')->getData());
 
         $this->sendUpdatesToApp($groupedRows);
 
@@ -93,7 +93,7 @@ class KlSyncs
     public function retry()
     {
         $syncCollection = $this->_syncCollectionFactory->create();
-        $groupedRows = $this->getGroupedRows( $syncCollection->getRowsForSync('RETRY')->getData() );
+        $groupedRows = $this->getGroupedRows($syncCollection->getRowsForSync('RETRY')->getData());
 
         $this->sendUpdatesToApp($groupedRows, true);
 
@@ -138,11 +138,11 @@ class KlSyncs
                     );
                     if (!$response) {$response = '0';}
 
-                    array_push( $responseManifest["$response"], $row['id']);
+                    array_push($responseManifest["$response"], $row['id']);
                 }
             }
         }
-        $this->updateRowStatuses( $responseManifest, $isRetry );
+        $this->updateRowStatuses($responseManifest, $isRetry);
     }
 
     /**
@@ -150,7 +150,7 @@ class KlSyncs
      * @param array $responseManifest
      * @param bool $isRetry
      */
-    private function updateRowStatuses( array $responseManifest, bool $isRetry )
+    private function updateRowStatuses(array $responseManifest, bool $isRetry)
     {
         $syncCollection = $this->_syncCollectionFactory->create();
         $syncCollection->updateRowStatus($responseManifest['1'], 'SYNCED');
@@ -167,7 +167,7 @@ class KlSyncs
      * @param array $allRows
      * @return array
      */
-    private function getGroupedRows( array $allRows )
+    private function getGroupedRows(array $allRows)
     {
         $groupedRows = [];
         foreach ($allRows as $row)

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -69,7 +69,7 @@ class KlSyncs
     }
 
     /**
-     * Cleanup Cron job removing rows marked as SYNCED from kl_sync table and older than 2 days
+     * Cleanup Cron job removing rows marked as SYNCED from kl_sync table
      */
     public function clean()
     {
@@ -80,7 +80,7 @@ class KlSyncs
 
         $klSyncTableSize = $syncCollection->count();
         if ($klSyncTableSize > 10000 ){
-            $this->_klaviyoLogger->log("Klaviyo Clean Sync: kl_sync table size greater than 10000, currently sitting at $klSyncTableSize");
+            $this->_klaviyoLogger->log("WARNING: kl_sync table size greater than 10000, currently sitting at $klSyncTableSize");
         }
 
         return;
@@ -103,11 +103,11 @@ class KlSyncs
     /**
      * Sends Webhook or Track API requests based on the topic of each row
      * and creates a response manifest to updates row status
-     * @param $groupedRows
+     * @param array $groupedRows
      * @param bool $isRetry
      * @throws Exception
      */
-    private function sendUpdatesToApp($groupedRows, bool $isRetry = false)
+    private function sendUpdatesToApp(array $groupedRows, bool $isRetry = false)
     {
         $webhookTopics = ['product/save']; //List of topics that use webhooks
         $trackApiTopics = ['Added To Cart']; //List of topics that use the Track API
@@ -147,10 +147,10 @@ class KlSyncs
 
     /**
      * Update statues of rows to SYNCED, RETRY and FAILED based on response and if Retry cron run
-     * @param $responseManifest
-     * @param $isRetry
+     * @param array $responseManifest
+     * @param bool $isRetry
      */
-    private function updateRowStatuses( $responseManifest, $isRetry )
+    private function updateRowStatuses( array $responseManifest, bool $isRetry )
     {
         $syncCollection = $this->_syncCollectionFactory->create();
         $syncCollection->updateRowStatus($responseManifest['1'], 'SYNCED');
@@ -160,15 +160,14 @@ class KlSyncs
         } else {
             $syncCollection->updateRowStatus($responseManifest['0'], 'RETRY');
         }
-
     }
 
     /**
      * Groups rows from kl_sync table based on topics
-     * @param $allRows
+     * @param array $allRows
      * @return array
      */
-    private function getGroupedRows( $allRows )
+    private function getGroupedRows( array $allRows )
     {
         $groupedRows = [];
         foreach ($allRows as $row)
@@ -185,5 +184,4 @@ class KlSyncs
 
         return $groupedRows;
     }
-
 }

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -133,8 +133,7 @@ class KlSyncs
                     $response = $this->_dataHelper->klaviyoTrackEvent(
                         $row['topic'],
                         json_decode($row['user_properties'], true ),
-                        json_decode($row['payload'], true ),
-                        strtotime($row['created_at'])
+                        json_decode($row['payload'], true )
                     );
                     if (!$response) {$response = '0';}
 

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Klaviyo\Reclaim\Cron;
+
+use Exception;
+
+use Klaviyo\Reclaim\Helper\Logger;
+use Klaviyo\Reclaim\Helper\Webhook;
+use Klaviyo\Reclaim\Helper\Data;
+use Klaviyo\Reclaim\Model\ResourceModel\Syncs\CollectionFactory;
+
+class KlSyncs
+{
+    /**
+     * Klaviyo Logger
+     * @var Logger
+     */
+    protected $_klaviyoLogger;
+
+    /**
+     * Products Collection Factory
+     * @var CollectionFactory
+     */
+    protected $_syncCollectionFactory;
+
+    /**
+     * Klaviyo Webhook helper
+     * @var Webhook
+     */
+    protected $_webhookHelper;
+
+    /**
+     * Klaviyo Data Helper
+     * @var Data
+     */
+    protected $_dataHelper;
+
+    /**
+     * @param Logger $klaviyoLogger
+     * @param CollectionFactory $syncCollectionFactory
+     * @param Data $datahelper
+     * @param Webhook $webhookHelper
+     */
+    public function __construct(
+        Logger $klaviyoLogger,
+        CollectionFactory $syncCollectionFactory,
+        Data $datahelper,
+        Webhook $webhookHelper
+    )
+    {
+        $this->_klaviyoLogger = $klaviyoLogger;
+        $this->_syncCollectionFactory = $syncCollectionFactory;
+        $this->_dataHelper = $datahelper;
+        $this->_webhookHelper = $webhookHelper;
+    }
+
+    /**
+     * Sync Cron job sending webhooks and events to Klaviyo
+     * @throws Exception
+     */
+    public function sync()
+    {
+        $syncCollection = $this->_syncCollectionFactory->create();
+        $groupedRows = $this->getGroupedRows( $syncCollection->getRowsForSync('NEW')->getData() );
+
+        $this->sendUpdatesToApp($groupedRows);
+
+        return;
+    }
+
+    /**
+     * Cleanup Cron job removing rows marked as SYNCED from kl_sync table and older than 2 days
+     */
+    public function clean()
+    {
+        $syncCollection = $this->_syncCollectionFactory->create();
+        $idsToDelete = $syncCollection->getIdsToDelete('SYNCED');
+
+        $syncCollection->deleteRows($idsToDelete);
+
+        $klSyncTableSize = $syncCollection->count();
+        if ($klSyncTableSize > 10000 ){
+            $this->_klaviyoLogger->log("Klaviyo Clean Sync: kl_sync table size greater than 10000, currently sitting at $klSyncTableSize");
+        }
+
+        return;
+    }
+
+    /**
+     * Retry Cron job retries all rows marked for retry in kl_sync table
+     * @throws Exception
+     */
+    public function retry()
+    {
+        $syncCollection = $this->_syncCollectionFactory->create();
+        $groupedRows = $this->getGroupedRows( $syncCollection->getRowsForSync('RETRY')->getData() );
+
+        $this->sendUpdatesToApp($groupedRows, true);
+
+        return;
+    }
+
+    /**
+     * Sends Webhook or Track API requests based on the topic of each row
+     * and creates a response manifest to updates row status
+     * @param $groupedRows
+     * @param bool $isRetry
+     * @throws Exception
+     */
+    private function sendUpdatesToApp($groupedRows, bool $isRetry = false)
+    {
+        $webhookTopics = ['product/save']; //List of topics that use webhooks
+        $trackApiTopics = ['Added To Cart']; //List of topics that use the Track API
+
+        $responseManifest = ['1' => [], '0' => []];
+
+        foreach($groupedRows as $topic => $rows){
+            if (in_array($topic, $webhookTopics) && !empty($rows)) {
+                foreach($rows as $row) {
+                    $response = $this->_webhookHelper->makeWebhookRequest(
+                        $row['topic'],
+                        $row['payload'],
+                        $row['klaviyo_id']
+                    );
+                    if (!$response) {$response = '0';}
+
+                    array_push( $responseManifest["$response"], $row['id']);
+                }
+            }
+
+            if (in_array($topic, $trackApiTopics) && !empty($rows)) {
+                foreach($rows as $row) {
+                    $response = $this->_dataHelper->klaviyoTrackEvent(
+                        $row['topic'],
+                        json_decode($row['user_properties'], true ),
+                        json_decode($row['payload'], true ),
+                        strtotime($row['created_at'])
+                    );
+                    if (!$response) {$response = '0';}
+
+                    array_push( $responseManifest["$response"], $row['id']);
+                }
+            }
+        }
+        $this->updateRowStatuses( $responseManifest, $isRetry );
+    }
+
+    /**
+     * Update statues of rows to SYNCED, RETRY and FAILED based on response and if Retry cron run
+     * @param $responseManifest
+     * @param $isRetry
+     */
+    private function updateRowStatuses( $responseManifest, $isRetry )
+    {
+        $syncCollection = $this->_syncCollectionFactory->create();
+        $syncCollection->updateRowStatus($responseManifest['1'], 'SYNCED');
+
+        if ($isRetry){
+            $syncCollection->updateRowStatus($responseManifest['0'], 'FAILED');
+        } else {
+            $syncCollection->updateRowStatus($responseManifest['0'], 'RETRY');
+        }
+
+    }
+
+    /**
+     * Groups rows from kl_sync table based on topics
+     * @param $allRows
+     * @return array
+     */
+    private function getGroupedRows( $allRows )
+    {
+        $groupedRows = [];
+        foreach ($allRows as $row)
+        {
+            if (array_key_exists($row['topic'], $groupedRows))
+            {
+                array_push($groupedRows[$row['topic']], $row);
+            }
+            else
+            {
+                $groupedRows[$row['topic']] = [$row];
+            }
+        }
+
+        return $groupedRows;
+    }
+
+}

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -64,8 +64,6 @@ class KlSyncs
         $groupedRows = $this->getGroupedRows($syncCollection->getRowsForSync('NEW')->getData());
 
         $this->sendUpdatesToApp($groupedRows);
-
-        return;
     }
 
     /**
@@ -82,8 +80,6 @@ class KlSyncs
         if ($klSyncTableSize > 10000 ){
             $this->_klaviyoLogger->log("WARNING: kl_sync table size greater than 10000, currently sitting at $klSyncTableSize");
         }
-
-        return;
     }
 
     /**
@@ -96,8 +92,6 @@ class KlSyncs
         $groupedRows = $this->getGroupedRows($syncCollection->getRowsForSync('RETRY')->getData());
 
         $this->sendUpdatesToApp($groupedRows, true);
-
-        return;
     }
 
     /**
@@ -154,11 +148,7 @@ class KlSyncs
         $syncCollection = $this->_syncCollectionFactory->create();
         $syncCollection->updateRowStatus($responseManifest['1'], 'SYNCED');
 
-        if ($isRetry){
-            $syncCollection->updateRowStatus($responseManifest['0'], 'FAILED');
-        } else {
-            $syncCollection->updateRowStatus($responseManifest['0'], 'RETRY');
-        }
+        $syncCollection->updateRowStatus($responseManifest['0'], $isRetry ? 'FAILED' : 'RETRY');
     }
 
     /**
@@ -171,12 +161,9 @@ class KlSyncs
         $groupedRows = [];
         foreach ($allRows as $row)
         {
-            if (array_key_exists($row['topic'], $groupedRows))
-            {
+            if (array_key_exists($row['topic'], $groupedRows)) {
                 array_push($groupedRows[$row['topic']], $row);
-            }
-            else
-            {
+            } else {
                 $groupedRows[$row['topic']] = [$row];
             }
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -4,7 +4,6 @@ namespace Klaviyo\Reclaim\Helper;
 use \Klaviyo\Reclaim\Helper\ScopeSetting;
 use \Magento\Framework\App\Helper\Context;
 use \Klaviyo\Reclaim\Helper\Logger;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -162,7 +162,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     protected function unwrap_params($params) {
-        return json_decode(base64_decode(urldecode(substr($params,5))), true);
+        return base64_decode(urldecode(substr($params,5)));
     }
 
     protected function make_request($path, $params) {
@@ -170,7 +170,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $response = file_get_contents($url);
 
         if ($response == '0'){
-            $dataString = print_r($this->unwrap_params($params),true);
+            $dataString = $this->unwrap_params($params);
             $this->_klaviyoLogger->log("Unable to send event to Track API with data: $dataString");
         }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -27,7 +27,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * Variable used for storage of klAddedToCartPayload between observers
      * @var
      */
-    public $tempPayload;
+    private $observerAtcPayload;
 
     public function __construct(
         Context $context,
@@ -37,6 +37,18 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         parent::__construct($context);
         $this->_klaviyoLogger = $klaviyoLogger;
         $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
+    }
+
+    public function getObserverPayload(){
+       return $this->observerAtcPayload;
+    }
+
+    public function setObserverPayload($data){
+        $this->observerAtcPayload = $data;
+    }
+
+    public function unsetObserverPayload(){
+        unset($this->observerAtcPayload);
     }
 
     public function getKlaviyoLists($api_key=null){

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -23,6 +23,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     protected $_klaviyoScopeSetting;
 
+    /**
+     * Variable used for storage of klAddedToCartPayload between observers
+     * @var
+     */
+    public $tempPayload;
+
     public function __construct(
         Context $context,
         Logger $klaviyoLogger,

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -39,15 +39,15 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
     }
 
-    public function getObserverPayload(){
+    public function getObserverAtcPayload(){
        return $this->observerAtcPayload;
     }
 
-    public function setObserverPayload($data){
+    public function setObserverAtcPayload($data){
         $this->observerAtcPayload = $data;
     }
 
-    public function unsetObserverPayload(){
+    public function unsetObserverAtcPayload(){
         unset($this->observerAtcPayload);
     }
 

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -97,7 +97,7 @@ class SalesQuoteProductAddAfter implements ObserverInterface
         }
 
         // Storing payload in the DataHelper object for SalesQuoteSaveAfter Observer since quoteId is not set at this point for guest checkouts
-        $this->_dataHelper->tempPayload = $klAddedToCartPayload;
+        $this->_dataHelper->setObserverPayload($klAddedToCartPayload);
     }
 
     /**

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -37,8 +37,8 @@ class SalesQuoteProductAddAfter implements ObserverInterface
 
     public function execute(Observer $observer)
     {
-        $quote = $observer->getData('items')[0]->getQuote();
         $addedItems = $observer->getData('items');
+        $quote = $addedItems[0]->getQuote();
 
         // Create a list of Simple Product Ids being added as part of a bundle.
         // We collect the Item name and Qty added to cart, to be sent as AddedItemBundleOptions with the payload.
@@ -56,9 +56,7 @@ class SalesQuoteProductAddAfter implements ObserverInterface
                 array_push($childrenIds, $item->getId());
             }
 
-            if (in_array( $item->getId(), $childrenIds )){
-                continue;
-            } else {
+            if (!in_array($item->getId(), $childrenIds)){
                 $this->klAddedToCartItemData($quote, $item);
             }
         }

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -97,7 +97,7 @@ class SalesQuoteProductAddAfter implements ObserverInterface
         }
 
         // Storing payload in the DataHelper object for SalesQuoteSaveAfter Observer since quoteId is not set at this point for guest checkouts
-        $this->_dataHelper->setObserverPayload($klAddedToCartPayload);
+        $this->_dataHelper->setObserverAtcPayload($klAddedToCartPayload);
     }
 
     /**

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -78,7 +78,7 @@ class SalesQuoteProductAddAfter implements ObserverInterface
         ];
 
         $klAddedToCartPayload = array_merge(
-            $this->klBuildCartData( $quote, $addedItem ),
+            $this->klBuildCartData($quote, $addedItem),
             $addedItemData
         );
 

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -1,0 +1,161 @@
+<?php
+
+
+namespace Klaviyo\Reclaim\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Catalog\Model\CategoryFactory;
+use Magento\Checkout\Model\Session;
+
+class SalesQuoteProductAddAfter implements ObserverInterface
+{
+    /**
+     * Magento Category Factory
+     * @var CategoryFactory $_categoryFactory
+     */
+    protected $_categoryFactory;
+
+    /**
+     * Magento Checkout Session data
+     * @var Session $_checkoutSession
+     */
+    protected $_checkoutSession;
+
+    /**
+     * SalesQuoteProductAddAfter constructor.
+     * @param CategoryFactory $categoryFactory
+     * @param Session $checkoutsession
+     */
+    public function __construct(
+        CategoryFactory $categoryFactory,
+        Session $checkoutsession
+    )
+    {
+        $this->_categoryFactory = $categoryFactory;
+        $this->_checkoutSession = $checkoutsession;
+    }
+
+    public function execute(Observer $observer)
+    {
+        $quote = $observer->getData('items')[0]->getQuote();
+        $addedItems = $observer->getData('items');
+
+        foreach ( $addedItems as $item ){
+            $this->klAddedToCartItemData( $quote, $item );
+        }
+    }
+
+    /**
+     * Build Added to Cart payload for current Added item
+     * @param $quote
+     * @param $addedItem
+     */
+    public function klAddedToCartItemData( $quote, $addedItem )
+    {
+        $addedProduct = $addedItem->getProduct();
+        $addedItemData = array(
+            'AddedItemCategories' => (array) $this->getCategoryName( $addedProduct->getCategoryIds() ),
+            'AddedItemDescription' => (string) strip_tags( $addedProduct->getDescription() ),
+            'AddedItemImageUrlKey' => (string) $addedProduct->getData('small_image'),
+            'AddedItemPrice' => (float) $addedProduct->get_price(),
+            'AddedItemQuantity' => (int) $addedItem->getQty(),
+            'AddedItemProductID' => (int) $addedProduct->getId(),
+            'AddedItemProductName' => (string) $addedItem->getName(),
+            'AddedItemSku' => (string) $addedProduct->getSku(),
+            'AddedItemUrl' => (string) $addedProduct->getProductUrl()
+        );
+
+        $klAddedToCartPayload = array_merge(
+            $this->klBuildCartData( $quote, $addedItem ),
+            $addedItemData
+        );
+
+        // Creating a custom session variable in the checkout session since quoteId is not set at this point for guest checkouts
+        $this->getCheckoutSession()->setKlAddedToCartKey( $klAddedToCartPayload );
+    }
+
+    /**
+     * Helper function to add items from cart to Added to Cart payload
+     * @param $quote
+     * @param $addedItem
+     * @return array
+     */
+    public function klBuildCartData( $quote, $addedItem )
+    {
+        $cartItems = $quote->getItems() ? $quote->getitems() : array();
+        $cartQty = 0;
+        $items = array();
+        $cartItemNames = array();
+        $cartItemCategories = array();
+
+        foreach( $cartItems as $item ) {
+            $product = $item->getProduct();
+            $cartItemId = $product->getId();
+            $itemCategories = $this->getCategoryName( $product->getCategoryIds() );
+            $itemName = $item->getName();
+            $currentProduct = array(
+                'Categories' => (array) $itemCategories,
+                'ImageUrlKey' => (string) $product->getData('small_image'),
+                'ProductId' => (int) $cartItemId,
+                'Price' => (float) $product->getPrice(),
+                'Title' => (string) $itemName,
+                'Description' => (string) strip_tags( $product->getDescription() ),
+                'Url' => (string) $product->getProductUrl(),
+                'Quantity' => (int) $item->getQty()
+            );
+            $cartQty += $item->getQty();
+            array_push( $items, $currentProduct );
+            array_push( $cartItemNames, $itemName );
+            $cartItemCategories = $this->uniqueArrayOfStrings( $cartItemCategories, $itemCategories );
+        }
+
+        return array(
+            '$value' => (float) $quote->getBaseGrandTotal() + $addedItem->getPrice(),
+            'ItemNames' => (array) $cartItemNames,
+            'Items' => (array) $items,
+            'ItemCount' => (int) $cartQty,
+            'Categories' => (array) $cartItemCategories,
+            '$service' => 'magento_two'
+        );
+    }
+
+    /**
+     * Retrieves category names from category IDs
+     * @param array $categoryIds
+     * @return array
+     */
+    public function getCategoryName( array $categoryIds )
+    {
+        $categoryNames = [];
+        foreach ( $categoryIds as $id ) {
+            $category = $this->_categoryFactory->create()->load( $id );
+            $categoryName = $category->getName();
+            array_push( $categoryNames, $categoryName );
+        }
+
+        return $categoryNames;
+    }
+
+    /**
+     * Helper function to ensure no duplicates in array
+     * @param $array_one
+     * @param $array_two
+     * @return array
+     */
+    public function uniqueArrayOfStrings( $array_one, $array_two ): array
+    {
+        return array_values( array_unique(
+            array_merge( $array_one, $array_two ),
+            SORT_REGULAR
+        )) ;
+    }
+
+    /**
+     * Returns active checkout session
+     * @return Session
+     */
+    public function getCheckoutSession(){
+        return $this->_checkoutSession;
+    }
+}

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -1,48 +1,59 @@
 <?php
 
-
 namespace Klaviyo\Reclaim\Observer;
+
+use Klaviyo\Reclaim\Helper\Data;
 
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Catalog\Model\CategoryFactory;
-use Magento\Checkout\Model\Session;
 
 class SalesQuoteProductAddAfter implements ObserverInterface
 {
     /**
+     * Klaviyo Data Helper
+     * @var Data
+     */
+    protected $_dataHelper;
+
+    /**
      * Magento Category Factory
-     * @var CategoryFactory $_categoryFactory
+     * @var CategoryFactory
      */
     protected $_categoryFactory;
 
     /**
-     * Magento Checkout Session data
-     * @var Session $_checkoutSession
-     */
-    protected $_checkoutSession;
-
-    /**
-     * SalesQuoteProductAddAfter constructor.
+     * @param Data $dataHelper
      * @param CategoryFactory $categoryFactory
-     * @param Session $checkoutsession
      */
     public function __construct(
-        CategoryFactory $categoryFactory,
-        Session $checkoutsession
+        Data $dataHelper,
+        CategoryFactory $categoryFactory
     )
     {
+        $this->_dataHelper = $dataHelper;
         $this->_categoryFactory = $categoryFactory;
-        $this->_checkoutSession = $checkoutsession;
     }
 
     public function execute(Observer $observer)
     {
         $quote = $observer->getData('items')[0]->getQuote();
         $addedItems = $observer->getData('items');
+        $childrenIds = [];
 
         foreach ($addedItems as $item){
-            $this->klAddedToCartItemData($quote, $item);
+            if ($item->getProductType() == 'bundle') {
+                $children = $item->getChildren();
+                foreach ($children as $child){
+                    array_push($childrenIds, $child->getId());
+                }
+            }
+
+            if (in_array( $item->getId(), $childrenIds )){
+                return;
+            } else {
+                $this->klAddedToCartItemData($quote, $item);
+            }
         }
     }
 
@@ -54,25 +65,32 @@ class SalesQuoteProductAddAfter implements ObserverInterface
     public function klAddedToCartItemData($quote, $addedItem)
     {
         $addedProduct = $addedItem->getProduct();
-        $addedItemData = array(
+        $addedItemData = [
             'AddedItemCategories' => (array) $this->getCategoryName($addedProduct->getCategoryIds()),
-            'AddedItemDescription' => (string) strip_tags($addedProduct->getDescription()),
-            'AddedItemImageUrlKey' => (string) $addedProduct->getData('small_image'),
-            'AddedItemPrice' => (float) $addedProduct->get_price(),
+            'AddedItemDescription' => (string) strip_tags($addedProduct->getDescription() ?? $addedItem->getDescription()),
+            'AddedItemImageUrlKey' => (string) stripslashes($addedProduct->getData('small_image')),
+            'AddedItemPrice' => (float) $addedProduct->getFinalPrice(),
             'AddedItemQuantity' => (int) $addedItem->getQty(),
             'AddedItemProductID' => (int) $addedProduct->getId(),
-            'AddedItemProductName' => (string) $addedItem->getName(),
+            'AddedItemProductName' => (string) $addedProduct->getName(),
             'AddedItemSku' => (string) $addedProduct->getSku(),
-            'AddedItemUrl' => (string) $addedProduct->getProductUrl()
-        );
+            'AddedItemUrl' => (string) stripslashes($addedProduct->getProductUrl())
+        ];
 
         $klAddedToCartPayload = array_merge(
             $this->klBuildCartData( $quote, $addedItem ),
             $addedItemData
         );
 
-        // Creating a custom session variable in the checkout session since quoteId is not set at this point for guest checkouts
-        $this->getCheckoutSession()->setKlAddedToCartKey( $klAddedToCartPayload );
+        if ($addedItem->getProductType() == 'bundle'){
+            $klAddedToCartPayload = array_merge(
+                $klAddedToCartPayload,
+                ['AddedItemBundleOptions' => $this->getBundleProductOptions($addedItem)]
+            );
+        }
+
+        // Storing payload in the DataHelper object for SalesQuoteSaveAfter Observer since quoteId is not set at this point for guest checkouts
+        $this->_dataHelper->tempPayload = $klAddedToCartPayload;
     }
 
     /**
@@ -83,48 +101,43 @@ class SalesQuoteProductAddAfter implements ObserverInterface
      */
     public function klBuildCartData($quote, $addedItem)
     {
-        $cartItems = $quote->getItems() ?? array();
+        $cartItems = $quote->getAllVisibleItems() ?? [];
         $cartQty = 0;
-        $items = array();
-        $cartItemNames = array();
-        $cartItemCategories = array();
+        $items = [];
+        $cartItemNames = [];
+        $cartItemCategories = [];
 
         foreach($cartItems as $item) {
             $product = $item->getProduct();
             $cartItemId = $product->getId();
             $itemCategories = $this->getCategoryName($product->getCategoryIds());
             $itemName = $item->getName();
-            $currentProduct = array(
+            $currentProduct = [
                 'Categories' => (array) $itemCategories,
-                'ImageUrlKey' => (string) $product->getData('small_image'),
+                'ImageUrlKey' => (string) stripslashes($product->getData('small_image')),
                 'ProductId' => (int) $cartItemId,
-                'Price' => (float) $product->getPrice(),
+                'Price' => (float) $product->getFinalPrice(),
                 'Title' => (string) $itemName,
-                'Description' => (string) strip_tags($product->getDescription()),
-                'Url' => (string) $product->getProductUrl(),
+                'Description' => (string) strip_tags($product->getDescription() ?? $item->getDescription()),
+                'Url' => (string) stripslashes($product->getProductUrl()),
                 'Quantity' => (int) $item->getQty()
-            );
+            ];
             $cartQty += $item->getQty();
             array_push($items, $currentProduct);
             array_push($cartItemNames, $itemName);
             $cartItemCategories = $this->uniqueArrayOfStrings($cartItemCategories, $itemCategories);
         }
 
-        return array(
+        return [
             '$value' => (float) $quote->getBaseGrandTotal() + $addedItem->getPrice(),
             'ItemNames' => (array) $cartItemNames,
             'Items' => (array) $items,
             'ItemCount' => (int) $cartQty,
             'Categories' => (array) $cartItemCategories
-        );
+        ];
     }
 
-    /**
-     * Retrieves category names from category IDs
-     * @param array $categoryIds
-     * @return array
-     */
-    public function getCategoryName(array $categoryIds)
+    public function getCategoryName($categoryIds)
     {
         $categoryFactory = $this->_categoryFactory->create();
         $categoryNames = [];
@@ -152,10 +165,25 @@ class SalesQuoteProductAddAfter implements ObserverInterface
     }
 
     /**
-     * Returns active checkout session
-     * @return Session
+     * Helper function to get Simple Product Quantities and Names for Bundled Product added to cart
+     * @param $addedItem
+     * @return array
      */
-    public function getCheckoutSession(){
-        return $this->_checkoutSession;
+    public function getBundleProductOptions($addedItem)
+    {
+        $productOptions = $addedItem->getChildren();
+        $bundleOptionsData = [];
+
+        foreach ($productOptions as $option){
+            $productName = $option->getName();
+            $productQty = $option->getQty();
+            array_push($bundleOptionsData,
+                [
+                    'Option Name' => $productName,
+                    'Option Qty' => $productQty
+                ]);
+        }
+
+        return $bundleOptionsData;
     }
 }

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -41,8 +41,8 @@ class SalesQuoteProductAddAfter implements ObserverInterface
         $quote = $observer->getData('items')[0]->getQuote();
         $addedItems = $observer->getData('items');
 
-        foreach ( $addedItems as $item ){
-            $this->klAddedToCartItemData( $quote, $item );
+        foreach ($addedItems as $item){
+            $this->klAddedToCartItemData($quote, $item);
         }
     }
 
@@ -51,12 +51,12 @@ class SalesQuoteProductAddAfter implements ObserverInterface
      * @param $quote
      * @param $addedItem
      */
-    public function klAddedToCartItemData( $quote, $addedItem )
+    public function klAddedToCartItemData($quote, $addedItem)
     {
         $addedProduct = $addedItem->getProduct();
         $addedItemData = array(
-            'AddedItemCategories' => (array) $this->getCategoryName( $addedProduct->getCategoryIds() ),
-            'AddedItemDescription' => (string) strip_tags( $addedProduct->getDescription() ),
+            'AddedItemCategories' => (array) $this->getCategoryName($addedProduct->getCategoryIds()),
+            'AddedItemDescription' => (string) strip_tags($addedProduct->getDescription()),
             'AddedItemImageUrlKey' => (string) $addedProduct->getData('small_image'),
             'AddedItemPrice' => (float) $addedProduct->get_price(),
             'AddedItemQuantity' => (int) $addedItem->getQty(),
@@ -81,18 +81,18 @@ class SalesQuoteProductAddAfter implements ObserverInterface
      * @param $addedItem
      * @return array
      */
-    public function klBuildCartData( $quote, $addedItem )
+    public function klBuildCartData($quote, $addedItem)
     {
-        $cartItems = $quote->getItems() ? $quote->getitems() : array();
+        $cartItems = $quote->getItems() ?? array();
         $cartQty = 0;
         $items = array();
         $cartItemNames = array();
         $cartItemCategories = array();
 
-        foreach( $cartItems as $item ) {
+        foreach($cartItems as $item) {
             $product = $item->getProduct();
             $cartItemId = $product->getId();
-            $itemCategories = $this->getCategoryName( $product->getCategoryIds() );
+            $itemCategories = $this->getCategoryName($product->getCategoryIds());
             $itemName = $item->getName();
             $currentProduct = array(
                 'Categories' => (array) $itemCategories,
@@ -100,14 +100,14 @@ class SalesQuoteProductAddAfter implements ObserverInterface
                 'ProductId' => (int) $cartItemId,
                 'Price' => (float) $product->getPrice(),
                 'Title' => (string) $itemName,
-                'Description' => (string) strip_tags( $product->getDescription() ),
+                'Description' => (string) strip_tags($product->getDescription()),
                 'Url' => (string) $product->getProductUrl(),
                 'Quantity' => (int) $item->getQty()
             );
             $cartQty += $item->getQty();
-            array_push( $items, $currentProduct );
-            array_push( $cartItemNames, $itemName );
-            $cartItemCategories = $this->uniqueArrayOfStrings( $cartItemCategories, $itemCategories );
+            array_push($items, $currentProduct);
+            array_push($cartItemNames, $itemName);
+            $cartItemCategories = $this->uniqueArrayOfStrings($cartItemCategories, $itemCategories);
         }
 
         return array(
@@ -115,8 +115,7 @@ class SalesQuoteProductAddAfter implements ObserverInterface
             'ItemNames' => (array) $cartItemNames,
             'Items' => (array) $items,
             'ItemCount' => (int) $cartQty,
-            'Categories' => (array) $cartItemCategories,
-            '$service' => 'magento_two'
+            'Categories' => (array) $cartItemCategories
         );
     }
 
@@ -125,13 +124,14 @@ class SalesQuoteProductAddAfter implements ObserverInterface
      * @param array $categoryIds
      * @return array
      */
-    public function getCategoryName( array $categoryIds )
+    public function getCategoryName(array $categoryIds)
     {
+        $categoryFactory = $this->_categoryFactory->create();
         $categoryNames = [];
         foreach ( $categoryIds as $id ) {
-            $category = $this->_categoryFactory->create()->load( $id );
+            $category = $categoryFactory->load($id);
             $categoryName = $category->getName();
-            array_push( $categoryNames, $categoryName );
+            array_push($categoryNames, $categoryName);
         }
 
         return $categoryNames;
@@ -143,10 +143,10 @@ class SalesQuoteProductAddAfter implements ObserverInterface
      * @param $array_two
      * @return array
      */
-    public function uniqueArrayOfStrings( $array_one, $array_two ): array
+    public function uniqueArrayOfStrings($array_one, $array_two): array
     {
-        return array_values( array_unique(
-            array_merge( $array_one, $array_two ),
+        return array_values(array_unique(
+            array_merge($array_one, $array_two),
             SORT_REGULAR
         )) ;
     }

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -50,7 +50,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
     {
         // Checking if the cookie is set here, if not it will return undefined and break the code
         if ( !isset($_COOKIE['__kla_id'] )) { return; }
-        $kl_decoded_cookie = json_decode(base64_decode($_COOKIE['__kla_id']), true );
+        $kl_decoded_cookie = json_decode(base64_decode($_COOKIE['__kla_id']), true);
 
         // Get the custom variable set in the DataHelper object via the SalesQuoteProductAddAfter observer.
         // Check if the public key and Added to Cart payload are set

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -55,7 +55,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Get the custom variable set in the DataHelper object via the SalesQuoteProductAddAfter observer.
         // Check if the public key and Added to Cart payload are set
         $public_key = $this->_scopeSetting->getPublicApiKey();
-        $klAddedToCartPayload = $this->_dataHelper->tempPayload;
+        $klAddedToCartPayload = $this->_dataHelper->getObserverPayload();
         if ( !isset($klAddedToCartPayload) or !isset($public_key)) { return; }
 
         // Make sure we have an identifier for the customer set in the cookie
@@ -82,6 +82,6 @@ class SalesQuoteSaveAfter implements ObserverInterface
         $eventsData->save();
 
         //Unset the custom variable set in DataHelper Object
-        unset($this->_dataHelper->tempPayload);
+        $this->_dataHelper->unsetObserverPayload();
     }
 }

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -69,31 +69,31 @@ class SalesQuoteSaveAfter implements ObserverInterface
         $public_key = $this->_scopeSetting->getPublicApiKey();
         if ( !isset( $public_key ) ) { return; }
 
-        if ( ! isset( $_COOKIE['__kla_id'] )) { return; }
+        if ( !isset($_COOKIE['__kla_id'] )) { return; }
 
-        $kl_decoded_cookie = json_decode( base64_decode( $_COOKIE['__kla_id'] ), true );
+        $kl_decoded_cookie = json_decode(base64_decode($_COOKIE['__kla_id']), true );
         if ( !isset( $kl_decoded_cookie ) ) { return; }
 
-        if ( isset( $kl_decoded_cookie['$exchange_id'] )) {
+        if ( isset($kl_decoded_cookie['$exchange_id'])) {
             $kl_user_properties = array('$exchange_id' => $kl_decoded_cookie['$exchange_id']);
-        } elseif ( isset( $kl_decoded_cookie['$email'] )) {
+        } elseif (isset($kl_decoded_cookie['$email'])) {
             $kl_user_properties = array('$email' => $kl_decoded_cookie['$email']);
         } else { return; }
 
         // Setting QuoteId at this point since the MaskedQuoteId is not updated when this event is dispatched,
         // MaskedQuoteId is set into the payload while the EventsTopic cron job moves rows into the Sync table
         $quote = $observer->getData('quote');
-        $klAddedToCartPayload = array_merge( $klAddedToCartPayload, array( 'QuoteId' => $quote->getId() ) );
+        $klAddedToCartPayload = array_merge($klAddedToCartPayload, array('QuoteId' => $quote->getId()));
 
         $newEvent = [
             'status' => 'NEW',
-            'user_properties' => json_encode( $kl_user_properties ),
+            'user_properties' => json_encode($kl_user_properties),
             'event'=> 'Added To Cart',
-            'payload' => json_encode( $klAddedToCartPayload )
+            'payload' => json_encode($klAddedToCartPayload)
         ];
 
         // Creating a new row in the kl_events table
-        $eventsData = $this->_eventsModel->setData( $newEvent );
+        $eventsData = $this->_eventsModel->setData($newEvent);
         $eventsData->save();
 
         //Unset the custom variable set in the checkout session

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -24,7 +24,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
     protected $_dataHelper;
 
     /**
-     * Added To Cart Model
+     * Events Model
      * @var Events
      */
     protected $_eventsModel;

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -1,36 +1,27 @@
 <?php
 
-
 namespace Klaviyo\Reclaim\Observer;
 
 use Klaviyo\Reclaim\Helper\Data;
 use Klaviyo\Reclaim\Helper\ScopeSetting;
 use Klaviyo\Reclaim\Model\Events;
-use Klaviyo\Reclaim\Plugin\Api\CartSearchRepository;
 
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Magento\Checkout\Model\Session;
 
 class SalesQuoteSaveAfter implements ObserverInterface
 {
     /**
      * Klaviyo Scope setting Helper
-     * @var ScopeSetting $_scopeSetting
+     * @var ScopeSetting
      */
     protected $_scopeSetting;
 
     /**
-     * Klaviyo Cart Search Interface
-     * @var  CartSearchRepository $_cartSearchRepository
-     */
-    protected $_cartSearchRepository;
-
-    /**
      * Magento Checkout Session
-     * @var Session $_checkoutsession
+     * @var Data
      */
-    protected $_checkoutsession;
+    protected $_dataHelper;
 
     /**
      * Added To Cart Model
@@ -39,51 +30,45 @@ class SalesQuoteSaveAfter implements ObserverInterface
     protected $_eventsModel;
 
     /**
-     * SalesQuoteSaveAfter Constructor
-     * @param Data $dataHelper
+     * SalesQuoteSaveAfter constructor
      * @param ScopeSetting $scopeSetting
-     * @param CartSearchRepository $cartSearchRepository
-     * @param Session $checkoutsession
+     * @param Data $dataHelper
      * @param Events $eventsModel
      */
     public function __construct(
         ScopeSetting $scopeSetting,
-        CartSearchRepository $cartSearchRepository,
-        Session $checkoutsession,
+        Data $dataHelper,
         Events $eventsModel
     )
     {
         $this->_scopeSetting = $scopeSetting;
-        $this->_cartSearchRepository = $cartSearchRepository;
-        $this->_checkoutsession = $checkoutsession;
+        $this->_dataHelper = $dataHelper;
         $this->_eventsModel = $eventsModel;
     }
 
-    public function execute( Observer $observer )
+    public function execute(Observer $observer)
     {
-        // Get the custom variable set in the checkout session via the SalesQuoteProductAddAfter observer.
-        $klAddedToCartPayload = $this->getCheckoutSession()->getKlAddedToCartKey();
-        if ( !isset( $klAddedToCartPayload ) ) { return; }
-
-        // Make sure Public key is set and the user is cookied before proceeding
-        $public_key = $this->_scopeSetting->getPublicApiKey();
-        if ( !isset( $public_key ) ) { return; }
-
+        // Checking if the cookie is set here, if not it will return undefined and break the code
         if ( !isset($_COOKIE['__kla_id'] )) { return; }
-
         $kl_decoded_cookie = json_decode(base64_decode($_COOKIE['__kla_id']), true );
-        if ( !isset( $kl_decoded_cookie ) ) { return; }
 
+        // Get the custom variable set in the DataHelper object via the SalesQuoteProductAddAfter observer.
+        // Check if the public key and Added to Cart payload are set
+        $public_key = $this->_scopeSetting->getPublicApiKey();
+        $klAddedToCartPayload = $this->_dataHelper->tempPayload;
+        if ( !isset($klAddedToCartPayload) or !isset($public_key)) { return; }
+
+        // Make sure we have an identifier for the customer set in the cookie
         if ( isset($kl_decoded_cookie['$exchange_id'])) {
-            $kl_user_properties = array('$exchange_id' => $kl_decoded_cookie['$exchange_id']);
+            $kl_user_properties = ['$exchange_id' => $kl_decoded_cookie['$exchange_id']];
         } elseif (isset($kl_decoded_cookie['$email'])) {
-            $kl_user_properties = array('$email' => $kl_decoded_cookie['$email']);
+            $kl_user_properties = ['$email' => $kl_decoded_cookie['$email']];
         } else { return; }
 
         // Setting QuoteId at this point since the MaskedQuoteId is not updated when this event is dispatched,
         // MaskedQuoteId is set into the payload while the EventsTopic cron job moves rows into the Sync table
         $quote = $observer->getData('quote');
-        $klAddedToCartPayload = array_merge($klAddedToCartPayload, array('QuoteId' => $quote->getId()));
+        $klAddedToCartPayload = array_merge($klAddedToCartPayload, ['QuoteId' => $quote->getId()]);
 
         $newEvent = [
             'status' => 'NEW',
@@ -96,12 +81,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
         $eventsData = $this->_eventsModel->setData($newEvent);
         $eventsData->save();
 
-        //Unset the custom variable set in the checkout session
-        $this->getCheckoutSession()->unsKlAddedToCartKey();
-    }
-
-    public function getCheckoutSession()
-    {
-        return $this->_checkoutsession;
+        //Unset the custom variable set in DataHelper Object
+        unset($this->_dataHelper->tempPayload);
     }
 }

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -1,0 +1,107 @@
+<?php
+
+
+namespace Klaviyo\Reclaim\Observer;
+
+use Klaviyo\Reclaim\Helper\Data;
+use Klaviyo\Reclaim\Helper\ScopeSetting;
+use Klaviyo\Reclaim\Model\Events;
+use Klaviyo\Reclaim\Plugin\Api\CartSearchRepository;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Checkout\Model\Session;
+
+class SalesQuoteSaveAfter implements ObserverInterface
+{
+    /**
+     * Klaviyo Scope setting Helper
+     * @var ScopeSetting $_scopeSetting
+     */
+    protected $_scopeSetting;
+
+    /**
+     * Klaviyo Cart Search Interface
+     * @var  CartSearchRepository $_cartSearchRepository
+     */
+    protected $_cartSearchRepository;
+
+    /**
+     * Magento Checkout Session
+     * @var Session $_checkoutsession
+     */
+    protected $_checkoutsession;
+
+    /**
+     * Added To Cart Model
+     * @var Events
+     */
+    protected $_eventsModel;
+
+    /**
+     * SalesQuoteSaveAfter Constructor
+     * @param Data $dataHelper
+     * @param ScopeSetting $scopeSetting
+     * @param CartSearchRepository $cartSearchRepository
+     * @param Session $checkoutsession
+     * @param Events $eventsModel
+     */
+    public function __construct(
+        ScopeSetting $scopeSetting,
+        CartSearchRepository $cartSearchRepository,
+        Session $checkoutsession,
+        Events $eventsModel
+    )
+    {
+        $this->_scopeSetting = $scopeSetting;
+        $this->_cartSearchRepository = $cartSearchRepository;
+        $this->_checkoutsession = $checkoutsession;
+        $this->_eventsModel = $eventsModel;
+    }
+
+    public function execute( Observer $observer )
+    {
+        // Get the custom variable set in the checkout session via the SalesQuoteProductAddAfter observer.
+        $klAddedToCartPayload = $this->getCheckoutSession()->getKlAddedToCartKey();
+        if ( !isset( $klAddedToCartPayload ) ) { return; }
+
+        // Make sure Public key is set and the user is cookied before proceeding
+        $public_key = $this->_scopeSetting->getPublicApiKey();
+        if ( !isset( $public_key ) ) { return; }
+
+        if ( ! isset( $_COOKIE['__kla_id'] )) { return; }
+
+        $kl_decoded_cookie = json_decode( base64_decode( $_COOKIE['__kla_id'] ), true );
+        if ( !isset( $kl_decoded_cookie ) ) { return; }
+
+        if ( isset( $kl_decoded_cookie['$exchange_id'] )) {
+            $kl_user_properties = array('$exchange_id' => $kl_decoded_cookie['$exchange_id']);
+        } elseif ( isset( $kl_decoded_cookie['$email'] )) {
+            $kl_user_properties = array('$email' => $kl_decoded_cookie['$email']);
+        } else { return; }
+
+        // Setting QuoteId at this point since the MaskedQuoteId is not updated when this event is dispatched,
+        // MaskedQuoteId is set into the payload while the EventsTopic cron job moves rows into the Sync table
+        $quote = $observer->getData('quote');
+        $klAddedToCartPayload = array_merge( $klAddedToCartPayload, array( 'QuoteId' => $quote->getId() ) );
+
+        $newEvent = [
+            'status' => 'NEW',
+            'user_properties' => json_encode( $kl_user_properties ),
+            'event'=> 'Added To Cart',
+            'payload' => json_encode( $klAddedToCartPayload )
+        ];
+
+        // Creating a new row in the kl_events table
+        $eventsData = $this->_eventsModel->setData( $newEvent );
+        $eventsData->save();
+
+        //Unset the custom variable set in the checkout session
+        $this->getCheckoutSession()->unsKlAddedToCartKey();
+    }
+
+    public function getCheckoutSession()
+    {
+        return $this->_checkoutsession;
+    }
+}

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -55,7 +55,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Get the custom variable set in the DataHelper object via the SalesQuoteProductAddAfter observer.
         // Check if the public key and Added to Cart payload are set
         $public_key = $this->_scopeSetting->getPublicApiKey();
-        $klAddedToCartPayload = $this->_dataHelper->getObserverPayload();
+        $klAddedToCartPayload = $this->_dataHelper->getObserverAtcPayload();
         if ( !isset($klAddedToCartPayload) or !isset($public_key)) { return; }
 
         // Make sure we have an identifier for the customer set in the cookie
@@ -82,6 +82,6 @@ class SalesQuoteSaveAfter implements ObserverInterface
         $eventsData->save();
 
         //Unset the custom variable set in DataHelper Object
-        $this->_dataHelper->unsetObserverPayload();
+        $this->_dataHelper->unsetObserverAtcPayload();
     }
 }

--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+    <group id="klaviyo_syncs">
+        <schedule_generate_every>1</schedule_generate_every>
+        <schedule_ahead_for>4</schedule_ahead_for>
+        <schedule_lifetime>2</schedule_lifetime>
+        <history_cleanup_every>10</history_cleanup_every>
+        <history_success_lifetime>120</history_success_lifetime>
+        <history_failure_lifetime>4320</history_failure_lifetime>
+        <use_separate_process>1</use_separate_process>
+    </group>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="klaviyo_syncs">
+        <job name="klaviyo_webhook/event_sync" instance="Klaviyo\Reclaim\Cron\klSyncs" method="sync">
+            <schedule>*/5 * * * *</schedule>
+        </job>
+        <job name="klaviyo_webhook/event_cleanup" instance="Klaviyo\Reclaim\Cron\klSyncs" method="clean">
+            <schedule>59 23 * * *</schedule>
+        </job>
+        <job name="klaviyo_webhook/event_retry" instance="Klaviyo\Reclaim\Cron\KlSyncs" method="retry">
+            <schedule>0 */6 * * *</schedule>
+        </job>
+        <job name="klaviyo_events_topic" instance="Klaviyo\Reclaim\Cron\EventsTopic" method="moveRowsToSync">
+            <schedule>*/5 * * * *</schedule>
+        </job>
+        <job name="klaviyo_events_cleanup" instance="Klaviyo\Reclaim\Cron\EventsTopic" method="deleteMovedRows">
+            <schedule>59 23 * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -3,8 +3,9 @@
     <table name="kl_sync" resource="default" engine="innodb" comment="Klaviyo Sync table">
         <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true"
                 comment="Primary key"/>
+        <column xsi:type="text" name="user_properties" nullable="true" comment="User Properties"/>
         <column xsi:type="text" name="payload" nullable="true" comment="Event payload"/>
-        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, MOVED)"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, SYNCED, RETRY, FAILED)"/>
         <column xsi:type="varchar" name="topic" nullable="false" length="255" comment="Klaviyo Topic name"/>
         <column xsi:type="text" name="klaviyo_id" nullable="true" comment="Klaviyo ID"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Creation time"/>
@@ -29,7 +30,7 @@
         <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true"
                 comment="Primary key"/>
         <column xsi:type="text" name="payload" nullable="true" comment="Event payload"/>
-        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, SYNCED, RETRY, FAILED)"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="30" comment="Status of row (NEW, MOVED)"/>
         <column xsi:type="varchar" name="topic" nullable="false" length="255" comment="Klaviyo webhook topic"/>
         <column xsi:type="text" name="klaviyo_id" nullable="true" comment="Klaviyo ID"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Creation time"/>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="sales_model_service_quote_submit_before">
         <observer name="custom_fields_sales_address_save" instance="Klaviyo\Reclaim\Observer\SaveOrderMarketingConsent" />
     </event>
-
     <event name="newsletter_subscriber_save_commit_after">
         <observer name="klaviyo_reclaim" instance="Klaviyo\Reclaim\Observer\NewsletterSubscribeObserver" />
+    </event>
+    <event name="sales_quote_product_add_after">
+        <observer name="klaviyo_reclaim_atc" instance="Klaviyo\Reclaim\Observer\SalesQuoteProductAddAfter" />
+    </event>
+    <event name="sales_quote_save_after" >
+        <observer name="klaviyo_reclaim_atc" instance="Klaviyo\Reclaim\Observer\SalesQuoteSaveAfter" />
     </event>
 </config>


### PR DESCRIPTION
2 Observers are being used to record the Added to Cart events to the kl_events table
1. SalesQuoteProductAddAfter >> This is triggered by Magento when a product is added to a quote (cart) by a user and this captures multiple scenarios:
  a. Product added from it's page
  b. Product added from wishlist
  c. Re-Order of product

At this point, the SalesQuoteProductAddAfter observer will construct the payload for the event and creates a session variable

The SalesQuoteSaveAfter event is triggered when the Quote is saved and this enables us to get the QuoteId and send over with the payload to be able to reconstruct the cart later. This observer will read from the checkout session variable from the previous observer, attach the quote Id and then write to the kl_event table


The cron jobs require the crontab.xml, cron_groups.xml files for setup. We have created a new group in cron_groups.xml for all klaviyo_syncs
The crontab.xml file is where all cron jobs are listed and associated with different methods to be run