### PR TITLE
Adds product/save to message queue

### DIFF
--- a/Api/ReclaimInterface.php
+++ b/Api/ReclaimInterface.php
@@ -28,6 +28,14 @@ interface ReclaimInterface
     public function getWebhookSecret();
 
     /**
+     * Returns the registered webhooks
+     *
+     * @return mixed[]
+     * @api
+     */
+    public function getWebhooks();
+
+    /**
      * Returns the Klaviyo log file
      *
      * @api

--- a/Cron/ProductsTopic.php
+++ b/Cron/ProductsTopic.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Klaviyo\Reclaim\Cron;
+
+use Klaviyo\Reclaim\Helper\Logger;
+use Klaviyo\Reclaim\Model\SyncsFactory;
+use Klaviyo\Reclaim\Model\ResourceModel\Products;
+use Klaviyo\Reclaim\Model\ResourceModel\Products\CollectionFactory;
+
+class ProductsTopic
+{
+    /**
+     * Klaviyo Logger
+     * @var Logger
+     */
+    protected $_klaviyoLogger;
+
+    /**
+     * Klaviyo Products Resource Model
+     * @var Products
+     */
+    protected $_klProduct;
+
+    /**
+     * Klaviyo Products Collection
+     * @var CollectionFactory
+     */
+    protected $_klProductCollectionFactory;
+
+    /**
+     * Klaviyo Syncs Model
+     * @var SyncsFactory
+     */
+    protected $_klSyncFactory;
+
+    /**
+     * @param Logger $klaviyoLogger
+     * @param Products $klProduct
+     * @param SyncsFactory $klSyncFactory
+     * @param CollectionFactory $klProductCollectionFactory
+     */
+    public function __construct(
+        Logger $klaviyoLogger,
+        Products $klProduct,
+        SyncsFactory $klSyncFactory,
+        CollectionFactory $klProductCollectionFactory
+    )
+    {
+        $this->_klaviyoLogger = $klaviyoLogger;
+        $this->_klProduct = $klProduct;
+        $this->_klSyncFactory = $klSyncFactory;
+        $this->_klProductCollectionFactory = $klProductCollectionFactory;
+    }
+
+    public function queueKlProductsForSync()
+    {
+        $klProductsCollection = $this->_klProductCollectionFactory->create();
+        $klProductsToSync = $klProductsCollection->getRowsForSync('NEW')
+            ->addFieldToSelect(['id','payload','status','topic', 'klaviyo_id'])
+            ->getData();
+
+        if (empty($klProductsToSync))
+        {
+            return;
+        }
+
+        $idsToUpdate = [];
+
+        foreach ($klProductsToSync as $klProductToSync)
+        {
+            $klSync = $this->_klSyncFactory->create();
+            $klSync->setData([
+                'payload'=> $klProductToSync['payload'],
+                'topic'=> $klProductToSync['topic'],
+                'klaviyo_id'=>$klProductToSync['klaviyo_id'],
+                'status'=> 'NEW'
+            ]);
+            try {
+                $klSync->save();
+                array_push($idsToUpdate, $klProductToSync['id']);
+            } catch (\Exception $e) {
+                $this->_klaviyoLogger->log(sprintf('Unable to move row: %s', $e));
+            }
+        }
+
+        $klProductsCollection->updateRowStatus($idsToUpdate, 'MOVED');
+    }
+
+    public function clean()
+    {
+        $klProductsCollection = $this->_klProductCollectionFactory->create();
+        $idsToDelete = $klProductsCollection->getIdsToDelete('MOVED');
+
+        $klProductsCollection->deleteRows($idsToDelete);
+    }
+}

--- a/Helper/ScopeSetting.php
+++ b/Helper/ScopeSetting.php
@@ -30,7 +30,8 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
 
     const WEBHOOK_SECRET = 'klaviyo_reclaim_webhook/klaviyo_webhooks/webhook_secret';
     const PRODUCT_DELETE_BEFORE = 'klaviyo_reclaim_webhook/klaviyo_webhooks/using_product_delete_before_webhook';
-    
+    const PRODUCT_SAVE_AFTER = 'klaviyo_reclaim_webhook/klaviyo_webhooks/using_product_save_after_webhook';
+
     const KLAVIYO_OAUTH_NAME = 'klaviyo_reclaim_oauth/klaviyo_oauth/integration_name';
 
     protected $_scopeConfig;
@@ -143,6 +144,19 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->getScopeSetting(self::WEBHOOK_SECRET, $storeId);
     }
 
+    public function getWebhooks()
+    {
+        $registeredWebhooks = [];
+
+        $product_delete = $this->getProductDeleteBeforeSetting();
+        $product_save = $this->getProductSaveAfterSetting();
+
+        array_push($registeredWebhooks, ['product/delete', $product_delete)];
+        array_push($registeredWebhooks, ['product/save', $product_save]);
+
+        return $registeredWebhooks;
+    }
+
     public function isEnabled($storeId = null)
     {
         return $this->getScopeSetting(self::ENABLE, $storeId);
@@ -221,7 +235,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
     {
         return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_LIST_ID, $storeId);
     }
-    
+
     public function getConsentAtCheckoutSMSConsentText($storeId = null)
     {
         return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_CONSENT_TEXT, $storeId);
@@ -264,5 +278,9 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->getScopeSetting(self::PRODUCT_DELETE_BEFORE, $storeId);
     }
 
-}
+    public function getProductSaveAfterSetting($storeId = null)
+    {
+        return $this->getScopeSetting(self::PRODUCT_SAVE_AFTER, $storeId);
+    }
 
+}

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -33,14 +33,13 @@ class Webhook extends \Magento\Framework\App\Helper\AbstractHelper
 
     /**
      * @param string $webhookType
-     * @param array $data
+     * @param string $data
      * @param string $klaviyoId
      * @return string
      * @throws Exception
      */
     public function makeWebhookRequest($webhookType, $data, $klaviyoId=null)
     {
-
         if (!$klaviyoId) {
             $klaviyoId = $this->_klaviyoScopeSetting->getPublicApiKey();
         }
@@ -51,12 +50,12 @@ class Webhook extends \Magento\Framework\App\Helper\AbstractHelper
             CURLOPT_URL => $url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_CUSTOMREQUEST => 'POST',
-            CURLOPT_POSTFIELDS => json_encode($data),
+            CURLOPT_POSTFIELDS => $data,
             CURLOPT_USERAGENT => self::USER_AGENT,
             CURLOPT_HTTPHEADER => array(
                 'Content-Type: application/json',
                 'Magento-two-signature: ' . $this->createWebhookSecurity($data),
-                'Content-Length: '. strlen(json_encode($data)),
+                'Content-Length: '. strlen($data),
                 'Topic: ' . $webhookType
             ),
         ]);
@@ -66,24 +65,23 @@ class Webhook extends \Magento\Framework\App\Helper\AbstractHelper
         $err = curl_errno($curl);
 
         if ($err) {
-            $this->_klaviyoLogger->log(sprintf('Unable to send webhook to %s with data: %s', $url, json_encode($data)));
+            $this->_klaviyoLogger->log(sprintf('Unable to send webhook to %s with data: %s', $url, $data));
         }
 
         // Close cURL session handle
         curl_close($curl);
+
         return $response;
     }
 
     /**
-     * @param array data
+     * @param string data
      * @return string
      * @throws Exception
      */
-    private function createWebhookSecurity(array $data)
+    private function createWebhookSecurity(string $data)
     {
         $webhookSecret = $this->_klaviyoScopeSetting->getWebhookSecret();
-        return hash_hmac('sha256', json_encode($data), $webhookSecret);
-
+        return hash_hmac('sha256', $data, $webhookSecret);
     }
 }
-

--- a/Model/Reclaim.php
+++ b/Model/Reclaim.php
@@ -73,6 +73,11 @@ class Reclaim implements ReclaimInterface
         return $this->_klaviyoScopeSetting->getWebhookSecret();
     }
 
+    public function getWebhooks()
+    {
+        return $this->_klaviyoScopeSetting->getWebhooks();
+    }
+
     /**
      * Returns the Klaviyo log file
      *

--- a/Observer/ProductSaveAfter.php
+++ b/Observer/ProductSaveAfter.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Klaviyo\Reclaim\Observer;
+
+use Exception;
+use Klaviyo\Reclaim\Helper\ScopeSetting;
+use Klaviyo\Reclaim\Helper\Webhook;
+use Klaviyo\Reclaim\Helper\Logger;
+use Klaviyo\Reclaim\Model\ProductsFactory;
+
+use Magento\Catalog\Model\CategoryFactory;
+use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+
+class ProductSaveAfter implements ObserverInterface
+{
+    /**
+     * Klaviyo scope setting helper
+     * @var ScopeSetting $klaviyoScopeSetting
+     */
+    protected $_klaviyoScopeSetting;
+
+    /**
+     * Klaviyo logger helper
+     * @var \Klaviyo\Reclaim\Helper\Logger $klaviyoLogger
+     */
+    protected $_klaviyoLogger;
+
+    /**
+     * @var Webhook $webhookHelper
+     */
+    protected $_webhookHelper;
+    protected $_categoryFactory;
+    protected $_klProductFactory;
+    protected $_stockRegistry;
+    protected $product_category_names = [];
+
+    /**
+     * @param Webhook $webhookHelper
+     * @param ScopeSetting $klaviyoScopeSetting
+     * @param CategoryFactory $categoryFactory
+     * @param ProductsFactory $klProductFactory
+     * @param StockRegistryInterface $stockRegistry
+     * @param Logger $klaviyoLogger
+     */
+    public function __construct(
+        Webhook $webhookHelper,
+        ScopeSetting $klaviyoScopeSetting,
+        CategoryFactory $categoryFactory,
+        ProductsFactory $klProductFactory,
+        StockRegistryInterface $stockRegistry,
+        Logger $klaviyoLogger
+    ) {
+        $this->_webhookHelper = $webhookHelper;
+        $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
+        $this->_categoryFactory = $categoryFactory;
+        $this->_klProductFactory = $klProductFactory;
+        $this->_klaviyoLogger = $klaviyoLogger;
+        $this->_stockRegistry = $stockRegistry;
+    }
+
+    /**
+     * customer register event handler
+     *
+     * @param Observer $observer
+     * @return void
+     * @throws Exception
+     */
+    public function execute(Observer $observer)
+    {
+        $product = $observer->getEvent()->getProduct();
+        $storeIds = $product->getStoreIds();
+        $storeIdKlaviyoMap = $this->_klaviyoScopeSetting->getStoreIdKlaviyoAccountSetMap($storeIds);
+
+        foreach ($storeIdKlaviyoMap as $klaviyoId => $storeIds) {
+            if (empty($storeIds)) {
+                continue;
+            }
+
+            if ($this->_klaviyoScopeSetting->getWebhookSecret() && $this->_klaviyoScopeSetting->getProductSaveAfterSetting($storeIds[0])) {
+
+              $normalizedProduct = $this->normalizeProduct($product);
+              $data = [
+                "status"=>"NEW",
+                "topic"=>"product/save",
+                "klaviyo_id"=>$klaviyoId,
+                "payload"=>json_encode($normalizedProduct)
+              ];
+              $klProduct = $this->_klProductFactory->create();
+              $klProduct->setData($data);
+              $klProduct->save();
+
+              // $this->_klaviyoLogger->log( print_r("Created new row?", true));
+
+              // $this->_webhookHelper->makeWebhookRequest('product/save', $normalizedProduct, $klaviyoId);
+            }
+        }
+    }
+
+    private function normalizeProduct($product=null)
+    {
+      if ($product == null) {
+        return;
+      }
+
+      $product_id = $product->getId();
+
+      // remove thumnbail image url?
+
+      $product_info = array(
+        'product' => array(
+          'store_ids' => $product->getStoreIds(),
+          'ID' => $product_id,
+          'TypeID' => $product->getTypeId(),
+          'Name' => $product->getName(),
+          'qty' => $this->_stockRegistry->getStockItem($product_id)->getQty(),
+          'Visibility' => $product->getVisibility(),
+          'IsInStock' => $product->isInStock(),
+          'Status' => $product->getStatus(),
+          'CreatedAt' => $product->getCreatedAt(),
+          'UpdatedAt' => $product->getUpdatedAt(),
+          'FirstImageURL' => $product->getImage(),
+          'ThumbnailImageURL' => $product->getThumbnail(),
+          'metadata' => array(
+            'price' => $product->getPrice(),
+            'sku' => $product->getSku()
+          ),
+          'categories' => []
+        )
+      );
+
+      if ($product->getSpecialPrice()) {
+        $product_info['metadata']['special_price'] = $product->getSpecialPrice();
+        $product_info['metadata']['special_from_date'] = $product->getSpecialFromDate();
+        $product_info['metadata']['special_to_date'] = $product->getSpecialToDate();
+      }
+
+      $product_category_ids = $product->getCategoryIds();
+      $category_factory = $this->_categoryFactory->create();
+      foreach ($product_category_ids as $category_id) {
+        $category = $category_factory->load($category_id);
+        $product_info['categories'][$category_id] = $category->getName();
+      }
+
+      return $product_info;
+    }
+}

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -5,6 +5,9 @@
     <event name="catalog_product_delete_before">
         <observer name="klaviyo_reclaim" instance="Klaviyo\Reclaim\Observer\ProductDeleteBefore" />
     </event>
+    <event name="catalog_product_save_after">
+        <observer name="klaviyo_reclaim" instance="Klaviyo\Reclaim\Observer\ProductSaveAfter"/>
+    </event>
     <event name="admin_system_config_changed_section_klaviyo_reclaim_oauth">
         <observer name="custom_admin_system_config_changed_section_klaviyo_reclaim_oauth" instance="Klaviyo\Reclaim\Observer\KlaviyoOAuthObserver"/>
     </event>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -158,6 +158,11 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>This will remove deleted products from the Klaviyo catalog.</comment>
                 </field>
+                <field id="using_product_save_after_webhook" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Use Product Save Webhook?</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>This will update or create saved products in the Klaviyo catalog.</comment>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -16,5 +16,11 @@
         <job name="klaviyo_events_cleanup" instance="Klaviyo\Reclaim\Cron\EventsTopic" method="deleteMovedRows">
             <schedule>59 23 * * *</schedule>
         </job>
+        <job name="klaviyo_products_topic" instance="Klaviyo\Reclaim\Cron\ProductsTopic" method="queueKlProductsForSync">
+            <schedule>*/5 * * * *</schedule>
+        </job>
+        <job name="klaviyo_product_cleanup" instance="Klaviyo\Reclaim\Cron\ProductsTopic" method="clean">
+            <schedule>59 23 * * *</schedule>
+        </job>
     </group>
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -54,6 +54,12 @@
             <resource ref="Magento_Backend::admin"/>
         </resources>
     </route>
+    <route url="/V1/klaviyo/reclaim/webhooks" method="GET">
+        <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="getWebhooks"/>
+        <resources>
+            <resource ref="Magento_Backend::admin"/>
+        </resources>
+    </route>
     <route url="/V1/klaviyo/reclaim/log" method="GET">
         <service class="Klaviyo\Reclaim\Api\ReclaimInterface" method="getLog"/>
         <resources>


### PR DESCRIPTION
- Adds a getWebhooks method/endpoint to the Reclaim interface for
querying the customizable webhooks.
- Adds the observer that runs when a product is saved.
- Adds the Cron class for managing product data that needs to be synced
to Klaviyo.
- Admin HTML for configuring the webhook.
- Modify the webhook helper so we only encode the json once.