### PR TITLE
202111 update sms consent lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [3.0.10] - 2021-11-10
+
+#### Changed
+- SMS Consent default language
+
 ### [3.0.9] - 2021-09-21
 
 #### Fixed
@@ -21,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [3.0.7] - 2021-08-27
 
 #### Fixed
-- Right trim trailing slash from Custom Media Url setting from Klaviyo Extension 
+- Right trim trailing slash from Custom Media Url setting from Klaviyo Extension
 - Properly escape the public api for onsite tag
 - Handle newsletter subscriptions in all areas
 - Fixing bug with newsletter subscribes for anonymous users (not registered accounts)
@@ -69,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [3.0.0] - 2021-05-25
 
 #### Added
-- Only support Magento 2.3.* + 
+- Only support Magento 2.3.* +
 
 #### Fixed
 - Utilize masked quote ids.
@@ -129,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.9...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.10...HEAD
+[3.0.10]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.9...3.0.10
 [3.0.9]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.8...3.0.9
 [3.0.8]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.7...3.0.8
 [3.0.7]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.6...3.0.7

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "3.0.9",
+    "version": "3.0.10",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -24,7 +24,7 @@
         </klaviyo_reclaim_consent_at_checkout>
         <klaviyo_reclaim_consent_at_checkout>
             <sms_consent>
-                <consent_text>**By checking this box and entering your phone number above, you consent to receive marketing text messages at the number provided from [company name], including messages sent by autodialer. Consent is not a condition of any purchase. Message and data rates may apply. Message frequency varies. Reply HELP for help or STOP to cancel. View our Privacy Policy and Terms of Service.</consent_text>
+                <consent_text>**By checking this box and entering your phone number above, you consent to receive marketing text messages (such as [promotion codes] and [cart reminders]) from [company name] at the number provided, including messages sent by autodialer. Consent is not a condition of any purchase. Message and data rates may apply. Message frequency varies. You can unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available) in one of our messages. View our Privacy Policy [link] and Terms of Service [link].</consent_text>
             </sms_consent>
         </klaviyo_reclaim_consent_at_checkout>
         <klaviyo_reclaim_consent_at_checkout>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="3.0.9" schema_version="3.0.9">
+  <module name="Klaviyo_Reclaim" setup_version="3.0.10" schema_version="3.0.10">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
https://klaviyo.tpondemand.com/entity/91329-update-sms-cac-default-template-language

Updating the SMS consent at checkout default language to say:

**By checking this box and entering your phone number above, you consent to receive marketing text messages (such as [promotion codes] and [cart reminders]) from [company name] at the number provided, including messages sent by autodialer. Consent is not a condition of any purchase. Message and data rates may apply. Message frequency varies. You can unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available) in one of our messages. View our Privacy Policy [link] and Terms of Service [link].