### PR TITLE
made consent at checkout compatible with aheadworks-onestep checkout

### DIFF
--- a/view/frontend/layout/onestepcheckout_index_index.xml
+++ b/view/frontend/layout/onestepcheckout_index_index.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="content">
+            <block class="Klaviyo\Reclaim\Block\Initialize" template="Klaviyo_Reclaim::analytics/initialize.phtml" />
+        </referenceBlock>
+        <referenceBlock name="checkout.root">
+            <arguments>
+                <argument name="jsLayout" xsi:type="array">
+                    <item name="components" xsi:type="array">
+                        <item name="checkout" xsi:type="array">
+                            <item name="children" xsi:type="array">
+                                <item name="steps" xsi:type="array">
+                                    <item name="children" xsi:type="array">
+                                        <item name="klaviyo-checkout-step" xsi:type="array">
+                                            <item name="component" xsi:type="string">Klaviyo_Reclaim/js/view/checkout/email</item>
+                                        </item>
+                                    </item>
+                                </item>
+                            </item>
+                        </item>
+                    </item>
+                </argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>


### PR DESCRIPTION
If we have Aheadworks-one step checkout (https://aheadworks.com/one-step-checkout-extension-for-magento-2) configured and enabled then it doesn't reflect "Consent at Checkout" (stores > configurations > Klaviyo > Consent at Checkout ) configurations.

In this pull request, Layout of Aheadworks-one step checkout is added so that it shows klaviyo modules content based on backend configurations.