### PR TITLE
Rebuild cart for Logged-in users, whitelist klaviyo scripts, identify logged in users correctly

### DIFF
--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -46,7 +46,7 @@ class Cart extends \Magento\Framework\App\Action\Action
 
         unset($params['quote_id']);
 
-        // Check if the quote_id has kx_identifier, if yes, retreive active quote for customer, if not get QuoteId from masked QuoteId
+        // Check if the quote_id has kx_identifier, if yes, retrieve active quote for customer, if not get QuoteId from masked QuoteId
         if (strpos($quoteId, "kx_identifier_") !== false){
             $customerId = base64_decode( str_replace("kx_identifier_", "", $quoteId) );
             try {

--- a/Controller/Checkout/Cart.php
+++ b/Controller/Checkout/Cart.php
@@ -3,6 +3,8 @@
 namespace Klaviyo\Reclaim\Controller\Checkout;
 
 
+use Magento\Framework\Exception\NoSuchEntityException;
+
 class Cart extends \Magento\Framework\App\Action\Action
 {
     protected $quoteRepository;
@@ -44,12 +46,24 @@ class Cart extends \Magento\Framework\App\Action\Action
 
         unset($params['quote_id']);
 
-        try {
-            $quoteIdMask = $this->quoteIdMaskFactory->create()->load($quoteId, 'masked_id');
-            $quote = $this->quoteRepository->get($quoteIdMask->getQuoteId());
-            $this->cart->setQuote($quote);
-            $this->cart->save();
-        } catch (\Magento\Framework\Exception\NoSuchEntityException $ex) {
+        // Check if the quote_id has kx_identifier, if yes, retreive active quote for customer, if not get QuoteId from masked QuoteId
+        if (strpos($quoteId, "kx_identifier_") !== false){
+            $customerId = base64_decode( str_replace("kx_identifier_", "", $quoteId) );
+            try {
+                $quote = $this->quoteRepository->getActiveForCustomer($customerId);
+                $this->cart->setQuote($quote);
+                $this->cart->save();
+            } catch (NoSuchEntityException $ex){
+
+            }
+        } else {
+            try {
+                $quoteIdMask = $this->quoteIdMaskFactory->create()->load($quoteId, 'masked_id');
+                $quote = $this->quoteRepository->get($quoteIdMask->getQuoteId());
+                $this->cart->setQuote($quote);
+                $this->cart->save();
+            } catch (NoSuchEntityException $ex) {
+            }
         }
 
         $redirect = $this->resultRedirectFactory->create();

--- a/Cron/EventsTopic.php
+++ b/Cron/EventsTopic.php
@@ -132,8 +132,12 @@ class EventsTopic
     public function replaceQuoteIdAndCategoryIds(string $payload): array
     {
         $decoded_payload = json_decode($payload, true);
-        $maskedQuoteId = $this->_quoteIdMaskResource->getMaskedQuoteId($decoded_payload['QuoteId']);
-        $decoded_payload['MaskedQuoteId'] = $maskedQuoteId;
+
+        //Set MaskedQuoteId if customer is not logged in, otherwise the same identifier from Observer
+        $quoteId = $decoded_payload['QuoteId'];
+        $decoded_payload['MaskedQuoteId'] = strpos($quoteId, "kx_identifier_") !== false ?
+            $quoteId :
+            $this->_quoteIdMaskResource->getMaskedQuoteId((int)$quoteId);
         unset($decoded_payload['QuoteId']);
 
         // Replace CategoryIds for Added Item, Quote Items with resp. CategoryNames

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -124,10 +124,16 @@ class KlSyncs
 
             if (in_array($topic, $trackApiTopics) && !empty($rows)) {
                 foreach($rows as $row) {
+                    $decodedPayload = json_decode($row['payload'], true);
+
+                    $eventTime = $decodedPayload['time'];
+                    unset($decodedPayload['time']);
+
                     $response = $this->_dataHelper->klaviyoTrackEvent(
                         $row['topic'],
                         json_decode($row['user_properties'], true ),
-                        json_decode($row['payload'], true )
+                        $decodedPayload,
+                        $eventTime
                     );
                     if (!$response) {$response = '0';}
 

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -138,7 +138,8 @@ class SalesQuoteProductAddAfter implements ObserverInterface
             'ItemNames' => (array) $cartItemNames,
             'Items' => (array) $items,
             'ItemCount' => (int) $cartQty,
-            'Categories' => (array) $cartItemCategories
+            'Categories' => (array) $cartItemCategories,
+            'time' => time()
         ];
     }
 

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -97,7 +97,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
     }
 
     /**
-     * Check if customer isLoggedIn and return base64 encoded string for the ID
+     * Check if customer is logged in and return base64 encoded string for the ID
      * @param $quote
      * @return string|null
      */

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -78,8 +78,8 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Setting QuoteId at this point since the MaskedQuoteId is not updated when this event is dispatched,
         // MaskedQuoteId is set into the payload while the EventsTopic cron job moves rows into the Sync table
         $quote = $observer->getData('quote');
-        $customerId = $this->checkCustomerAndReturnId($quote);
-        $klAddedToCartPayload['QuoteId'] = isset($customerId) ? "kx_identifier_$customerId" : $quote->getId();
+        $encodedCustomerId = $this->checkCustomerAndReturnEncodedId($quote);
+        $klAddedToCartPayload['QuoteId'] = isset($encodedCustomerId) ? "kx_identifier_$encodedCustomerId" : $quote->getId();
 
         $newEvent = [
             'status' => 'NEW',
@@ -96,7 +96,12 @@ class SalesQuoteSaveAfter implements ObserverInterface
         $this->_dataHelper->unsetObserverAtcPayload();
     }
 
-    private function checkCustomerAndReturnId($quote) {
+    /**
+     * Check if customer isLoggedIn and return base64 encoded string for the ID
+     * @param $quote
+     * @return string|null
+     */
+    private function checkCustomerAndReturnEncodedId($quote) {
         if ($this->_customerSession->isLoggedIn()) {
             $customerId = $quote->getCustomer()->getId();
             return base64_encode($customerId);

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -5,17 +5,27 @@
             <values>
                 <value id="klaviyo-base" type="host">https://static.klaviyo.com</value>
                 <value id="klaviyo-cdn" type="host">https://fast.a.klaviyo.com</value>
+                <value id="klaviyo-analytics" type="host">https://static-tracking.klaviyo.com/</value>
+                <value id="klaviyo-api" type="host">https://a.klaviyo.com/</value>
+                <value id="klaviyo-telemetrics" type="host">https://telemetrics.klaviyo.com/</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
-                <value id="klaviyo" type="host">https://static.klaviyo.com</value>
+                <value id="klaviyo-base" type="host">https://static.klaviyo.com</value>
                 <value id="klaviyo-cdn" type="host">https://fast.a.klaviyo.com</value>
+                <value id="klaviyo-analytics" type="host">https://static-tracking.klaviyo.com/</value>
+                <value id="klaviyo-api" type="host">https://a.klaviyo.com/</value>
+                <value id="klaviyo-telemetrics" type="host">https://telemetrics.klaviyo.com/</value>
             </values>
         </policy>
         <policy id="img-src">
             <values>
-                <value id="klaviyo" type="host">https://a.klaviyo.com</value>
+                <value id="klaviyo-base" type="host">https://static.klaviyo.com</value>
+                <value id="klaviyo-cdn" type="host">https://fast.a.klaviyo.com</value>
+                <value id="klaviyo-analytics" type="host">https://static-tracking.klaviyo.com/</value>
+                <value id="klaviyo-api" type="host">https://a.klaviyo.com/</value>
+                <value id="klaviyo-telemetrics" type="host">https://telemetrics.klaviyo.com/</value>
             </values>
         </policy>
     </policies>

--- a/view/frontend/web/js/customer.js
+++ b/view/frontend/web/js/customer.js
@@ -4,15 +4,18 @@ define([
     'domReady!'
 ], function (_, customerData) {
     'use strict';
-    
     var _learnq = window._learnq || [];
-    var customer = customerData.get('customer')();
 
-    if(_.has(customer, 'email') && customer.email) {
-        _learnq.push(['identify', {
-            $email: customer.email,
-            $first_name: _.has(customer, 'firstname') ? customer.firstname : '',
-            $last_name:  _.has(customer, 'lastname') ? customer.lastname : ''
-        }]);
-    }
+    customerData.getInitCustomerData().done(function () {
+        var customer = customerData.get('customer')();
+
+        if(_.has(customer, 'email') && customer.email && !_learnq.isIdentified()) {
+            _learnq.identify({
+                '$email': customer.email,
+                '$first_name': _.has(customer, 'firstname') ? customer.firstname : '',
+                '$last_name':  _.has(customer, 'lastname') ? customer.lastname : ''
+            });
+        }
+    });
+
 });


### PR DESCRIPTION
This PR fixes a few things: 

MaskedQuoteId is not generated for quotes associated with Logged in users. In such a situation, we would send a null back with the ATC payload, with no way to rebuild cart for these users. 
[TP](https://klaviyo.tpondemand.com/entity/99989-rebuild-carts-for-logged-in-customers)

There was a lot of noise in the console caused by csp policies not whitelising the klaviyo scripts
[TP](https://klaviyo.tpondemand.com/entity/101804-whiteslist-klaviyo-domains-in-magento-2)

Logged in users were not correctly being cookied as the customerData was being generated after script. It will now wait for this to be generated before trying to cookie the user. 