### PR TITLE
202203 tp107056 atc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [4.0.2] - 2022-03-15
+
+#### Fixed
+- Updated Added to Cart track request to use POST to accommodate large payloads
+- Initialized observerAtcPayload to fix Undefined property error
+
 ### [4.0.1] - 2022-01-28
 
 #### Fixed
@@ -161,7 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.1...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.2...HEAD
+[4.0.2]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.0-beta...4.0.0
 [4.0.0-beta]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.11...4.0.0-beta

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -37,6 +37,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         parent::__construct($context);
         $this->_klaviyoLogger = $klaviyoLogger;
         $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
+        $this->observerAtcPayload = null;
     }
 
     public function getObserverAtcPayload(){
@@ -48,7 +49,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     public function unsetObserverAtcPayload(){
-        unset($this->observerAtcPayload);
+        $this->observerAtcPayload = null;
     }
 
     public function getKlaviyoLists($api_key=null){

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -165,8 +165,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         if (!is_null($timestamp)) {
             $params['time'] = $timestamp;
         }
-        $encoded_params = $this->build_params($params);
-        return $this->make_request('api/track', $encoded_params);
+        // $encoded_params = $this->build_params($params);
+        return $this->make_request('api/track', $params);
 
     }
     protected function build_params($params) {
@@ -178,11 +178,21 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     protected function make_request($path, $params) {
-        $url = self::KLAVIYO_HOST . $path . '?' . $params;
-        $response = file_get_contents($url);
+        $url = self::KLAVIYO_HOST . $path;
 
+        $options = array(
+            'http' => array(
+                'header'  => "Content-type: application/json\r\n",
+                'method'  => 'POST',
+                'content' => json_encode($params),
+            ),
+        );
+
+        $context  = stream_context_create($options);
+        $response = file_get_contents($url, false,$context);
+
+        $dataString = json_encode($params);
         if ($response == '0'){
-            $dataString = $this->unwrap_params($params);
             $this->_klaviyoLogger->log("Unable to send event to Track API with data: $dataString");
         }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -166,7 +166,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         if (!is_null($timestamp)) {
             $params['time'] = $timestamp;
         }
-        // $encoded_params = $this->build_params($params);
         return $this->make_request('api/track', $params);
 
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -180,18 +180,18 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     protected function make_request($path, $params) {
         $url = self::KLAVIYO_HOST . $path;
 
+        $dataString = json_encode($params);
         $options = array(
             'http' => array(
                 'header'  => "Content-type: application/json\r\n",
                 'method'  => 'POST',
-                'content' => json_encode($params),
+                'content' => $dataString,
             ),
         );
 
         $context  = stream_context_create($options);
         $response = file_get_contents($url, false,$context);
 
-        $dataString = json_encode($params);
         if ($response == '0'){
             $this->_klaviyoLogger->log("Unable to send event to Track API with data: $dataString");
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -169,13 +169,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->make_request('api/track', $params);
 
     }
-    protected function build_params($params) {
-        return 'data=' . urlencode(base64_encode(json_encode($params)));
-    }
-
-    protected function unwrap_params($params) {
-        return base64_decode(urldecode(substr($params,5)));
-    }
 
     protected function make_request($path, $params) {
         $url = self::KLAVIYO_HOST . $path;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.0.1" schema_version="4.0.1">
+  <module name="Klaviyo_Reclaim" setup_version="4.0.2" schema_version="4.0.2">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
Addressing two existing bugs with ATC: 

- Updated the `klaviyoTrackEvent` method to make a POST request instead of a GET to account for larger payloads. Using POST should allow for payloads up to 1 MB. 
- Fixed bug due to an undefined property `observerAtcPayload` that was raising errors.