### PR TITLE
adding require for customer library specific to v 2.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "magento/module-quote": ">=101.1.3",
-        "magento/module-customer": ">=103.0.3",
+        "magento/module-customer": ">=103.0.0",
         "ext-curl": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require": {
         "magento/module-quote": ">=101.1.3",
+        "magento/module-customer": ">=103.0.3",
         "ext-curl": "*"
     }
 }


### PR DESCRIPTION
currently Magento customers on versions < 2.4.x that install v 4.0.0 of extension will experience errors like this in their website appearing for their users:

`main.min.js:2 TypeError: customerData.getInitCustomerData is not a function`

the fix ensures that customers on versions < 2.4.x will not be able to install the latest extension and should instead revert to v 3.0.11 of the klaviyo extension.