### PR TITLE
202204 release 4.0.3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Root
-*               @klaviyo/integrations-1st-party
+*               @klaviyo/integrations-ecom-self-hosted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [4.0.3] - 2022-04-28
+
+#### Fixed
+- Moved webhooks url to async tier
+- Add install restriction for users on < 2.4.x (must use extension v3.0.11)
+- Removed product descriptions from Added to Cart payloads
+
 ### [4.0.2] - 2022-03-15
 
 #### Fixed
@@ -167,7 +174,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.2...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.3...HEAD
+[4.0.3]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.2...4.0.3
 [4.0.2]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.0-beta...4.0.0

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -9,7 +9,7 @@ use \Klaviyo\Reclaim\Helper\ScopeSetting;
 class Webhook extends \Magento\Framework\App\Helper\AbstractHelper
 {
     const USER_AGENT = 'Klaviyo/MagentoTwo/Webhook';
-    const WEBHOOK_URL = 'https://www.klaviyo.com/api/webhook/integration/magento_two';
+    const WEBHOOK_URL = 'https://a.klaviyo.com/api/webhook/integration/magento_two';
 
     /**
      * Klaviyo logger helper

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -72,11 +72,6 @@ class SalesQuoteProductAddAfter implements ObserverInterface
         $addedProduct = $addedItem->getProduct();
         $addedItemData = [
             'AddedItemCategories' => (array) $addedProduct->getCategoryIds(),
-            'AddedItemDescription' => (string) strip_tags(
-                $addedProduct->getDescription()
-                ?? $addedItem->getDescription()
-                ?? $addedItem->getShortDescription()
-            ),
             'AddedItemImageUrlKey' => (string) stripslashes($addedProduct->getData('small_image')),
             'AddedItemPrice' => (float) $addedProduct->getFinalPrice(),
             'AddedItemQuantity' => (int) $addedItem->getQty(),
@@ -127,11 +122,6 @@ class SalesQuoteProductAddAfter implements ObserverInterface
                 'ProductId' => (int) $cartItemId,
                 'Price' => (float) $product->getFinalPrice(),
                 'Title' => (string) $itemName,
-                'Description' => (string) strip_tags(
-                    $product->getDescription()
-                    ?? $item->getDescription()
-                    ?? $item->getShortDescription()
-                ),
                 'Url' => (string) stripslashes($product->getProductUrl()),
                 'Quantity' => (int) $item->getQty()
             ];

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require": {
         "magento/module-quote": ">=101.1.3",
+        "magento/module-customer": ">=103.0.0",
         "ext-curl": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.0.2" schema_version="4.0.2">
+  <module name="Klaviyo_Reclaim" setup_version="4.0.3" schema_version="4.0.3">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
This update encapsulates changes that were in the develop branch - as they were all simple 1-2 line changes I created a fresh branch to avoid the git issues we were having. I will be closing the develop branch after the next release. 

- Moving webhooks to the async tier (Austin)
- Adding require for customer library specific to v 2.4+ (Jad)
- Remove product description from ATC payload (Claire)
- CODEOWNERS update (Claire)
- Version bump and changelog update (Claire)