### PR TITLE
removed module requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 - Moved webhooks url to async tier
-- Add install restriction for users on < 2.4.x (must use extension v3.0.11)
 - Removed product descriptions from Added to Cart payloads
 
 ### [4.0.2] - 2022-03-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-### [4.0.3] - 2022-04-28
+### [4.0.3] - 2022-05-09
 
 #### Fixed
 - Moved webhooks url to async tier

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     },
     "require": {
         "magento/module-quote": ">=101.1.3",
-        "magento/module-customer": ">=103.0",
         "ext-curl": "*"
     }
 }


### PR DESCRIPTION
Removing the version restriction for the customers module, this is causing some release issues and we are going to go forward with releasing the other changes until we can prioritize debugging the version restriction. 