### PR TITLE
Release stalled - reverted version bump and updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-### [4.0.3] - 2022-05-09
-
 #### Fixed
 - Moved webhooks url to async tier
 - Removed product descriptions from Added to Cart payloads
@@ -173,8 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.3...HEAD
-[4.0.3]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.2...4.0.3
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.2...HEAD
 [4.0.2]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.0-beta...4.0.0

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.0.3",
+    "version": "4.0.2",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.0.3" schema_version="4.0.3">
+  <module name="Klaviyo_Reclaim" setup_version="4.0.2" schema_version="4.0.2">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
Reverts the version bump back down to 4.0.2 and moves the changes up for the next release under Unreleased in the changelog to reduce any confusion. 