### PR TITLE
Fix 404 AJAX Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [Unreleased]
+ - Fix 404 AJAX Request
 
 ### [4.0.4] - 2022-05-24
 - Skipped 4.0.3 due to cancelled extension in magento marketplace

--- a/view/frontend/templates/checkout/cart.phtml
+++ b/view/frontend/templates/checkout/cart.phtml
@@ -4,6 +4,7 @@
            'jquery',
            'mage/url'
         ], function (jQuery, url) {
+          url.setBaseUrl('<?= $block->escapeJs($block->escapeUrl($block->getBaseUrl())) ?>');
           jQuery.ajax({
               url: url.build('reclaim/checkout/reload'),
               method: 'POST',


### PR DESCRIPTION
The base URL needs to be set, otherwise you will generate a relative URL which will 404 on any URL that has a path with more than 1 level deep (ie:  /checkout/cart)