### PR TITLE
Fixed newsletter signup on account creation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
  - Fix 404 AJAX Request
+ - Fixed newsletter signup on account creation
 
 ### [4.0.4] - 2022-05-24
 - Skipped 4.0.3 due to cancelled extension in magento marketplace

--- a/Observer/NewsletterSubscribeObserver.php
+++ b/Observer/NewsletterSubscribeObserver.php
@@ -45,8 +45,7 @@ class NewsletterSubscribeObserver implements ObserverInterface
 
         /** @var Subscriber $subscriber */
         $subscriber = $observer->getDataObject();
-
-        if ($subscriber && $subscriber->hasDataChanges()) {
+        if ($subscriber && ($subscriber->hasDataChanges() || $subscriber->isObjectNew())) {
             $customer = $this->getCustomer($subscriber);
 
             if ($subscriber->isSubscribed()) {


### PR DESCRIPTION
https://klaviyo.tpondemand.com/entity/131521-m2-extension-not-syncing-newsletter-subscribers

Bug Description: when a user registered for an account on the account creation page the subscription wasn't properly being added to Klaviyo because `subscriber->hasDataChanges` was evaluating to false for new users. This change adjusts the logic to additionally check to see if the subscriber is new. We should now subscribe/unsubscribe registered users to Klaviyo lists when the subscription is either updated on the /customer/account/ page or if they checked the box on the /customer/account/create/ page. 