### PR TITLE
Version bumps for 4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [Unreleased]
- - Fix 404 AJAX Request
- - Fixed newsletter signup on account creation
+
+
+### [4.0.5] - 2022-07-28
+#### Fixed 
+- Fix 404 AJAX Request on /cart/reclaim/checkout/reload
+- Fixed newsletter signup on account creation. Users will now be subscribed if they check the checkbox on account registration.
 
 ### [4.0.4] - 2022-05-24
 - Skipped 4.0.3 due to cancelled extension in magento marketplace
@@ -176,7 +180,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.4...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.5...HEAD
+[4.0.5]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.4...4.0.5
 [4.0.4]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.2...4.0.4
 [4.0.2]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.0...4.0.1

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.0.4",
+    "version": "4.0.5",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.0.4" schema_version="4.0.4">
+  <module name="Klaviyo_Reclaim" setup_version="4.0.5" schema_version="4.0.5">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
Version bump for extension release: 

moves all unreleased items under version 4.0.5, updates links in changelog, updates composer.json and etc/module.xml