### PR TITLE
Allow developers to move the Klaviyo\Reclaim\Block\Initialize block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [Unreleased]
-
+- Add a name to the Klaviyo\Reclaim\Block\Initialize block, so it can be moved around via a layout xml 
 
 ### [4.0.5] - 2022-07-28
 #### Fixed 

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -1,7 +1,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="header.container">
-            <block class="Klaviyo\Reclaim\Block\Initialize" template="analytics/initialize.phtml" />
+            <block class="Klaviyo\Reclaim\Block\Initialize" template="analytics/initialize.phtml" name="klaviyo.initialize" />
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
Give the `Klaviyo\Reclaim\Block\Initialize` block a name giving theme developers the option of referencing the block and moving it elsewhere.