### PR TITLE
Make SMS Editable for Logged Customers at the Checkout Page

### DIFF
--- a/Model/Checkout/ShippingInformationManagement.php
+++ b/Model/Checkout/ShippingInformationManagement.php
@@ -3,20 +3,14 @@
 
 namespace Klaviyo\Reclaim\Model\Checkout;
 
-use Magento\Customer\Api\AddressRepositoryInterface;
 use Magento\Quote\Model\QuoteRepository;
 
 class ShippingInformationManagement
 {
     protected $quoteRepository;
-    protected $addressRepository;
 
-    public function __construct(
-        QuoteRepository $quoteRepository,
-        AddressRepositoryInterface $addressRepository
-    ) {
+    public function __construct(QuoteRepository $quoteRepository) {
         $this->quoteRepository = $quoteRepository;
-        $this->addressRepository = $addressRepository;
     }
 
     public function beforeSaveAddressInformation(
@@ -32,20 +26,9 @@ class ShippingInformationManagement
 
         $quote = $this->quoteRepository->getActive($cartId);
 
+        $quote->setKlSmsPhoneNumber($extAttributes->getKlSmsPhoneNumber());
         $quote->setKlSmsConsent($extAttributes->getKlSmsConsent());
         $quote->setKlEmailConsent($extAttributes->getKlEmailConsent());
 
-        $smsConsent = $extAttributes->getKlSmsConsent();
-        $phoneNumber = $extAttributes->getKlSmsPhoneNumber();
-
-        if ($smsConsent && $phoneNumber) {
-           $quote->getShippingAddress()->setTelephone($phoneNumber);
-           $customerAddressId = $quote->getShippingAddress()->getCustomerAddressId();
-           if ($customerAddressId) {
-               $address = $this->addressRepository->getById($customerAddressId);
-               $address->setTelephone($phoneNumber);
-               $this->addressRepository->save($address);
-           }
-        }
     }
 }

--- a/Observer/SaveOrderMarketingConsent.php
+++ b/Observer/SaveOrderMarketingConsent.php
@@ -54,8 +54,10 @@ class SaveOrderMarketingConsent implements ObserverInterface
     {
         $order = $observer->getEvent()->getOrder();
         $quote = $observer->getEvent()->getQuote();
+        $smsConsent = $quote->getKlSmsConsent();
+        $phoneNumber = $quote->getKlSmsPhoneNumber();
 
-        if ($quote->getKlSmsConsent() && $quote->getKlSmsPhoneNumber()) {
+        if ($smsConsent && $phoneNumber) {
             $order->getShippingAddress()->setTelephone($phoneNumber);
             $quote->getShippingAddress()->setTelephone($phoneNumber);
             $customerAddressId = $quote->getShippingAddress()->getCustomerAddressId();

--- a/Plugin/CheckoutLayoutPlugin.php
+++ b/Plugin/CheckoutLayoutPlugin.php
@@ -67,21 +67,22 @@ class CheckoutLayoutPlugin
                 $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shipping-address-fieldset']['children']['kl_sms_consent'] = $smsConsentCheckbox;
             else {
 
-                // extra un-editable field with saved phone number to display to logged in users with default address set
                 $smsConsentTelephone = [
                     'component' => 'Magento_Ui/js/form/element/abstract',
                     'config' =>
                         [
-                            'customScope' => 'shippingAddress',
+                            'customScope' => 'shippingAddress.custom_attributes',
                             'template' => 'ui/form/field',
                             'elementTmpl' => 'ui/form/element/input',
+                            'id' => 'kl_sms_phone_number',
                         ],
+                    'dataScope' => 'shippingAddress.custom_attributes.kl_sms_phone_number',
                     'label' => 'Phone Number',
                     'provider' => 'checkoutProvider',
                     'sortOrder' => '120',
-                    'disabled' => true,
                     'visible' => true,
-                    'value' => $address->getTelephone()
+                    'value' => $address->getTelephone(),
+                    'id' => 'kl_sms_phone_number'
                 ];
 
                 $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_sms_phone_number'] = $smsConsentTelephone;

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -74,6 +74,7 @@
         </index>
     </table>
     <table name="quote" resource="default">
+        <column xsi:type="varchar" name="kl_sms_phone_number" nullable="true" comment="SMS Phone Number"/>
         <column xsi:type="text" name="kl_sms_consent" nullable="true" comment="SMS Consent"/>
         <column xsi:type="text" name="kl_email_consent" nullable="true" comment="Email Consent"/>
     </table>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -61,6 +61,7 @@
     },
     "quote": {
         "column": {
+            "kl_sms_phone_number": true,
             "kl_sms_consent": true,
             "kl_email_consent": true
         }

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Magento\Checkout\Api\Data\ShippingInformationInterface">
+      <attribute code="kl_sms_phone_number" type="string"/>
         <attribute code="kl_sms_consent" type="string"/>
         <attribute code="kl_email_consent" type="string"/>
     </extension_attributes>

--- a/view/frontend/web/js/model/shipping-payload/assigner.js
+++ b/view/frontend/web/js/model/shipping-payload/assigner.js
@@ -5,12 +5,14 @@ define([
     'use strict';
 
     return function (container) {
+        var kl_sms_phone_number = $('[name="custom_attributes[kl_sms_phone_number]"]').val();
         var kl_sms_consent = $('[name="custom_attributes[kl_sms_consent]"]').is(':checked');
         var kl_email_consent = $('[name="custom_attributes[kl_email_consent]"]').is(':checked');
 
         container.extension_attributes = _.extend(
             container.extension_attributes || {},
             {
+                kl_sms_phone_number: kl_sms_phone_number,
                 kl_sms_consent: kl_sms_consent,
                 kl_email_consent: kl_email_consent
             }


### PR DESCRIPTION
This PR makes the SMS Phone Number Field Editable for Logged Customers. Also, this saves the phone number inside the customer's address and quote address. This makes more easily for the customer to update the phone number before checking the option to send the phone number to Klaviyo. Without those changes, the customer needs to go to My Account and edit the address before going to the checkout page.