### PR TITLE
Added StoreName to custom profile property

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -102,12 +102,14 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $listId = $this->_klaviyoScopeSetting->getNewsletter();
         $optInSetting = $this->_klaviyoScopeSetting->getOptInSetting();
+        $storeName = $this->_klaviyoScopeSetting->getStoreName();
 
         $properties = [];
         $properties['email'] = $email;
         if ($firstName) $properties['$first_name'] = $firstName;
         if ($lastName) $properties['$last_name'] = $lastName;
         if ($source) $properties['$source'] = $source;
+        if ($storeName) $properties['storeName'] = $storeName;
         if ($optInSetting == ScopeSetting::API_SUBSCRIBE) $properties['$consent'] = ['email'];
 
         $propertiesVal = ['profiles' => $properties];

--- a/Helper/ScopeSetting.php
+++ b/Helper/ScopeSetting.php
@@ -51,6 +51,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_request = $context->getRequest();
         $this->_state = $state;
         $this->_storeId = $storeManager->getStore()->getId();
+        $this->_storeName = $storeManager->getStore()->getName();
         $this->_moduleList = $moduleList;
         $this->_configWriter = $configWriter;
     }
@@ -262,6 +263,16 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
     public function getProductDeleteBeforeSetting($storeId = null)
     {
         return $this->getScopeSetting(self::PRODUCT_DELETE_BEFORE, $storeId);
+    }
+
+    /**
+     * Get Store name
+     *
+     * @return string
+     */
+    public function getStoreName()
+    {
+        return $this->_storeName;
     }
 
 }


### PR DESCRIPTION
The changes for the PR are to add 'storeName' custom profile property during a Magento sync.
This will allow the customers to be able to create segments based upon their M2 Store Name.