### PR TITLE
Do not load not needed backend classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [Unreleased]
 - Fixed bug in Observer/SalesQuoteProductAddAfter.php passing null value to stripslashes
 - Fixed bug in Block/Catalog/Product/ViewedProduct.php passing null value to number_format
+- Fixed issue when Controller/Checkout/Reload.php was loading backend classes on frontend
 
 ### [4.0.6] - 2022-09-19
 #### Fixed

--- a/Controller/Checkout/Reload.php
+++ b/Controller/Checkout/Reload.php
@@ -7,7 +7,7 @@ class Reload extends \Magento\Framework\App\Action\Action
     protected $resultJsonFactory;
 
     public function __construct(
-        \Magento\Backend\App\Action\Context $context,
+        \Magento\Framework\App\Action\Context $context,
         \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
     ) {
         $this->resultJsonFactory = $resultJsonFactory;


### PR DESCRIPTION
## Description
This PR replaces the backend context with the frontend one. Since this controller is used on frontend, it doesn't make any sense to create classes needed for backend, e.g. backend session which is part of this context.

Basically, it just improves speed of this controller and reduces session locks on checkout 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1.

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, have you:
  - [ ] Updated the links in the CHANGELOG to point towards the new versions
  - [ ] Incremented the version in the following places: module.xml and composer.json

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
