### PR TITLE
ATC bug fixes, updated cleanup crons, enforce payload size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug in Observer/SalesQuoteProductAddAfter.php passing null value to stripslashes
 - Fixed bug in Block/Catalog/Product/ViewedProduct.php passing null value to number_format
 - Fixed issue when Controller/Checkout/Reload.php was loading backend classes on frontend
+- Fixes for Added to Cart: adds error handling to Added to Cart event processing, enforces payload size to 65k characters, adjusts cleanup crons to include failed syncs
 
 ### [4.0.6] - 2022-09-19
 #### Fixed

--- a/Cron/EventsTopic.php
+++ b/Cron/EventsTopic.php
@@ -100,7 +100,7 @@ class EventsTopic
                 catch (\Exception $e) {
                     // the payload was likely truncated, this will catch any indexing errors that occur during processing
                     // defaults to a failed response and allows the other rows to continue syncing
-                    $this->_klaviyoLogger->log(sprintf("Unable to process Added to Cart data: %s", $e->getMessage()));
+                    $this->_klaviyoLogger->log(sprintf("[moveRowsToSync] Unable to process Added to Cart data: %s", $e->getMessage()));
                     array_push($idsFailed, $event['id']);
                     continue;
                 }
@@ -126,7 +126,7 @@ class EventsTopic
                 $sync->save();
                 array_push($idsMoved, $event['id']);
             } catch (\Exception $e) {
-                $this->_klaviyoLogger->log(sprintf("Unable to move row: %s", $e->getMessage()));
+                $this->_klaviyoLogger->log(sprintf("[moveRowsToSync] Unable to move row: %s", $e->getMessage()));
                 array_push($idsFailed, $event['id']);
             }
         }

--- a/Cron/EventsTopic.php
+++ b/Cron/EventsTopic.php
@@ -109,7 +109,7 @@ class EventsTopic
             if (strlen($event['payload']) > self::PAYLOAD_CHARACTER_LIMIT) {
                 // Above processing resulted in a payload size that exceeds the limit
                 // defaults to a failed response and allows the other rows to continue syncing
-                $this->_klaviyoLogger->log(sprintf("Dropped Event - payload too long, character count:%d",strlen($event['payload'])));
+                $this->_klaviyoLogger->log(sprintf("[moveRowsToSync] Dropping event - payload too long, character count: %d",strlen($event['payload'])));
                 array_push($idsFailed, $event['id']);
                 continue;
             }

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -131,7 +131,7 @@ class KlSyncs
 
                         if (is_null($decodedPayload)) {
                             // payload was likely truncated, default to failed response value for the row
-                            $this->_klaviyoLogger->log(sprintf("Truncated Payload - Unable to process and sync row %d: %s",$row['id']));
+                            $this->_klaviyoLogger->log(sprintf("[sendUpdatesToApp] Truncated Payload - Unable to process and sync row %d: %s",$row['id']));
                             array_push($responseManifest["0"], $row['id']);
                             continue;
                         }
@@ -162,7 +162,7 @@ class KlSyncs
                     } catch ( \Exception $e) {
                         // Catch an exception raised while processing or sending the event
                         // defaults to a failed response and allows the other rows to continue syncing
-                        $this->_klaviyoLogger->log(sprintf("Unable to process and sync row %d: %s",$row['id'],$e));
+                        $this->_klaviyoLogger->log(sprintf("[sendUpdatesToApp] Unable to process and sync row %d: %s",$row['id'],$e));
                         array_push($responseManifest["0"], $row['id']);
                         continue;
                     }

--- a/Model/KlaviyoCollection.php
+++ b/Model/KlaviyoCollection.php
@@ -26,23 +26,24 @@ abstract class KlaviyoCollection extends AbstractCollection
 
     /**
      * Collection Helper method to get rows to be deleted.
-     * Fetches all rows older than 2 days and having status `SYNCED` for sync table, `MOVED` for topic tables
+     * Fetches all rows older than 2 days and having status `FAILED` as well as`SYNCED` for sync table, `MOVED` for topic tables
      * and returns ids of these rows
-     * @param $status
+     * @param $statusesToDelete
      * @return mixed
      */
-    public function getIdsToDelete($status)
+    public function getIdsToDelete($statusesToDelete)
     {
         $now = new \DateTime('now');
         $date = $now->sub(new \DateInterval('P2D'))
             ->format('Y-m-d H:i:s');
 
         $tableName = $this->getMainTable();
+        $statusList = '("'.implode('","', $statusesToDelete).'")';
 
         $idsToDelete = $this->getConnection()->fetchAll( "select id from (
                                                             select id, timestampdiff(day, created_at, \"$date\") as row_age_in_days
                                                             from $tableName
-                                                            where status = '".$status."'
+                                                            where status in $statusList
                                                             having row_age_in_days > 2
                                                           ) as age_of_rows;"
         );

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -4,6 +4,7 @@ namespace Klaviyo\Reclaim\Observer;
 
 use Klaviyo\Reclaim\Helper\Data;
 use Klaviyo\Reclaim\Helper\ScopeSetting;
+use Klaviyo\Reclaim\Helper\Logger;
 use Klaviyo\Reclaim\Model\Events;
 
 use Magento\Framework\Event\Observer;
@@ -12,6 +13,9 @@ use Magento\Customer\Model\Session;
 
 class SalesQuoteSaveAfter implements ObserverInterface
 {
+    // Character limit for a TEXT datatype field
+    const PAYLOAD_CHARACTER_LIMIT = 65535;
+
     /**
      * Klaviyo Scope setting Helper
      * @var ScopeSetting
@@ -23,6 +27,12 @@ class SalesQuoteSaveAfter implements ObserverInterface
      * @var Data
      */
     protected $_dataHelper;
+
+    /**
+     * Klaviyo Logger
+     * @var Logger
+     */
+    protected $_klaviyoLogger;
 
     /**
      * Events Model
@@ -38,18 +48,21 @@ class SalesQuoteSaveAfter implements ObserverInterface
 
     /**
      * SalesQuoteSaveAfter constructor
+     * @param Logger $klaviyoLogger
      * @param ScopeSetting $scopeSetting
      * @param Data $dataHelper
      * @param Events $eventsModel
      * @param Session $customerSession
      */
     public function __construct(
+        Logger $klaviyoLogger,
         ScopeSetting $scopeSetting,
         Data $dataHelper,
         Events $eventsModel,
         Session $customerSession
     )
     {
+        $this->_klaviyoLogger = $klaviyoLogger;
         $this->_scopeSetting = $scopeSetting;
         $this->_dataHelper = $dataHelper;
         $this->_eventsModel = $eventsModel;
@@ -84,16 +97,29 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Setting StoreId in payload
         $klAddedToCartPayload['StoreId'] = $quote->getStoreId();
 
-        $newEvent = [
-            'status' => 'NEW',
-            'user_properties' => json_encode($kl_user_properties),
-            'event'=> 'Added To Cart',
-            'payload' => json_encode($klAddedToCartPayload)
-        ];
+        $stringifiedPayload = json_encode($klAddedToCartPayload);
 
-        // Creating a new row in the kl_events table
-        $eventsData = $this->_eventsModel->setData($newEvent);
-        $eventsData->save();
+        // Check payload length to avoid truncated data being saved to payload column
+        if (strlen($stringifiedPayload) > self::PAYLOAD_CHARACTER_LIMIT) {
+            // TODO: add alerting here - don't want to drop events without letting customer know
+            $this->_klaviyoLogger->log(sprintf("Dropped Event - payload too long, character count:%d",strlen($stringifiedPayload)));
+        }
+        else {
+            $newEvent = [
+                'status' => 'NEW',
+                'user_properties' => json_encode($kl_user_properties),
+                'event'=> 'Added To Cart',
+                'payload' => json_encode($klAddedToCartPayload)
+            ];
+
+            try {
+                // Creating a new row in the kl_events table
+                $eventsData = $this->_eventsModel->setData($newEvent);
+                $eventsData->save();
+            } catch (\Exception $e) {
+                $this->_klaviyoLogger->log(sprintf("Unable to save row to kl_events: %s", $e->getMessage()));
+            }
+        }
 
         //Unset the custom variable set in DataHelper Object
         $this->_dataHelper->unsetObserverAtcPayload();

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -117,7 +117,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
                 $eventsData = $this->_eventsModel->setData($newEvent);
                 $eventsData->save();
             } catch (\Exception $e) {
-                $this->_klaviyoLogger->log(sprintf("Unable to save row to kl_events: %s", $e->getMessage()));
+                $this->_klaviyoLogger->log(sprintf("[SalesQuoteSaveAfterUnable] to save row to kl_events: %s", $e->getMessage()));
             }
         }
 

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -102,7 +102,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Check payload length to avoid truncated data being saved to payload column
         if (strlen($stringifiedPayload) > self::PAYLOAD_CHARACTER_LIMIT) {
             // TODO: add alerting here - don't want to drop events without letting customer know
-            $this->_klaviyoLogger->log(sprintf("Dropped Event - payload too long, character count:%d",strlen($stringifiedPayload)));
+            $this->_klaviyoLogger->log(sprintf("[SalesQuoteSaveAfter] Dropping event - payload too long, character count: %d",strlen($stringifiedPayload)));
         }
         else {
             $newEvent = [


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
This PR encompasses several improvements for the added to cart event. Namely it enforces the payload size, and doesn't allow for rows with truncated payload to be committed to the database. 

Previously, truncated Added to Cart payloads would raise unhandled exceptions when processing in both `Cron/EventsTopic.php` and `Cron/KlSyncs.php`, which in turn would prevent the processing of the remaining rows. The unhandled exceptions also prevented the rows that were able to move over to the kl_sync table from being marked as MOVED, leading to repetitive processing and continuous retries. This PR adds exception handling which will log the exception and mark any rows that raise exceptions during processing as FAILED. The cleanup crons have been adjusted to additionally delete FAILED rows from both the kl_events table and the kl_sync table. Previously these rows would remain indefinitely. 

These fixes are intended to prevent truncated payloads for future events and clear out failed events from the database. Future improvements will be made to further optimize the Added to Cart event. 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Pre-change, recreated the issue with truncated payloads. Triggered a variety of Added to Cart events, some with truncated payloads, some without. 
2. After changes, verified that an event with a payload exceeding the maximum character count would not be added to the kl_events table and that a log was created. 
3. Verified that the `klaviyo_events_topic` cron processed all rows - marking those with existing truncated payloads as FAILED and marking all rows with valid payloads as MOVED.
4. Verified that the `klaviyo_webhook/event_sync` cron processed all rows - marking those with truncated payloads as failed. 
5. Verified that the 2 cleanup crons removed rows marked as FAILED for both tables, as well as MOVED for kl_events and SYNCED for kl_sync.

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, have you:
  - [ ] Updated the links in the CHANGELOG to point towards the new versions
  - [ ] Incremented the version in the following places: module.xml and composer.json

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
