### PR TITLE
Bug fix add correct method to cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.8] - 2022-11-10
+### Fixed
+- Fixed bug where cleanup cron wasn't referencing correct method name. 
+
 ### [4.0.7] - 2022-11-01
 ### Added
 - Add a name to the Klaviyo\Reclaim\Block\Initialize block, so it can be moved around via a layout xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.7...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.8...HEAD
+[4.0.7]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.7...4.0.8
 [4.0.7]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.6...4.0.7
 [4.0.6]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.5...4.0.6
 [4.0.5]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.4...4.0.5

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.0.7",
+    "version": "4.0.8",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -13,7 +13,7 @@
         <job name="klaviyo_events_topic" instance="Klaviyo\Reclaim\Cron\EventsTopic" method="moveRowsToSync">
             <schedule>*/5 * * * *</schedule>
         </job>
-        <job name="klaviyo_events_cleanup" instance="Klaviyo\Reclaim\Cron\EventsTopic" method="deleteMovedRows">
+        <job name="klaviyo_events_cleanup" instance="Klaviyo\Reclaim\Cron\EventsTopic" method="deleteMovedOrFailedRows">
             <schedule>59 23 * * *</schedule>
         </job>
     </group>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.0.7" schema_version="4.0.7">
+  <module name="Klaviyo_Reclaim" setup_version="4.0.8" schema_version="4.0.8">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Bug fix for cron job - incorrect method was being called after the 4.0.7 refactors which affected the cleanup cron for the kl_events table. 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. On a local account, made sure cleanup cron ran as expected and that MOVED or FAILED rows were removed from the kl_events table

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [x] **Internal Only** - If this is a release, have you:
  - [x] Updated the links in the CHANGELOG to point towards the new versions
  - [x] Incremented the version in the following places: module.xml and composer.json

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
