### PR TITLE
202212 update default sms lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Unreleased
 ### Fixed
 - Fixed bug in logging for truncated payloads in the kl_syncs table.
+- Updated default SMS consent language
 
 ### [4.0.8] - 2022-11-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed bug in logging for truncated payloads in the kl_syncs table.
 
-
 ### [4.0.8] - 2022-11-10
 ### Fixed
 - Fixed bug where cleanup cron wasn't referencing correct method name. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Unreleased
+### Changed
+- Updated default SMS consent language
+
 ### Fixed
 - Fixed bug in logging for truncated payloads in the kl_syncs table.
-- Updated default SMS consent language
+
 
 ### [4.0.8] - 2022-11-10
 ### Fixed

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -24,7 +24,7 @@
         </klaviyo_reclaim_consent_at_checkout>
         <klaviyo_reclaim_consent_at_checkout>
             <sms_consent>
-                <consent_text>**By checking this box and entering your phone number above, you consent to receive marketing text messages (such as [promotion codes] and [cart reminders]) from [company name] at the number provided, including messages sent by autodialer. Consent is not a condition of any purchase. Message and data rates may apply. Message frequency varies. You can unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available) in one of our messages. View our Privacy Policy [link] and Terms of Service [link].</consent_text>
+                <consent_text>*By checking this box and entering your phone number above, you consent to receive marketing text messages (e.g. [promos], [cart reminders]) from [company name] at the number provided, including messages sent by autodialer. Consent is not a condition of purchase. Msg &amp; data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] &amp; Terms of Service [link].</consent_text>
             </sms_consent>
         </klaviyo_reclaim_consent_at_checkout>
         <klaviyo_reclaim_consent_at_checkout>
@@ -39,7 +39,7 @@
         </klaviyo_reclaim_consent_at_checkout>
         <klaviyo_reclaim_consent_at_checkout>
             <sms_consent>
-                <label_text>Subscribe for SMS updates**</label_text>
+                <label_text>Subscribe for SMS updates*</label_text>
             </sms_consent>
         </klaviyo_reclaim_consent_at_checkout>
     </default>


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Updates default sms consent language 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1.

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, have you:
  - [ ] Updated the links in the CHANGELOG to point towards the new versions
  - [ ] Incremented the version in the following places: module.xml and composer.json

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
