### PR TITLE
Subscriber source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - Updated the legacy `_learnq` js object to the new `klaviyo` js object.
 - Added precommit to the repository and formatted all PHP files to PSR12 style.
+- Set the newsletter subscription source to Magento 2
 
 ### [4.0.9] - 2023-01-03
 ### Changed

--- a/Observer/NewsletterSubscribeObserver.php
+++ b/Observer/NewsletterSubscribeObserver.php
@@ -14,6 +14,8 @@ use Magento\Newsletter\Model\Subscriber;
 
 class NewsletterSubscribeObserver implements ObserverInterface
 {
+    private const SOURCE_ID_MAGENTO2 = '-56';
+
     /**
      * @var Data
      */
@@ -52,7 +54,8 @@ class NewsletterSubscribeObserver implements ObserverInterface
                 $this->helper->subscribeEmailToKlaviyoList(
                     $customer ? $customer->getEmail() : $subscriber->getEmail(),
                     $customer ? $customer->getFirstname() : $subscriber->getFirstname(),
-                    $customer ? $customer->getLastname() : $subscriber->getLastname()
+                    $customer ? $customer->getLastname() : $subscriber->getLastname(),
+                    self::SOURCE_ID_MAGENTO2
                 );
             } else {
                 $this->helper->unsubscribeEmailFromKlaviyoList(


### PR DESCRIPTION
## Description
This adds Magento 2 as the source when customers subscribe to the newsletter.

Logging $source properties on Klaviyo profiles is necessary to track where contacts are originating from and understanding their various user journeys, similar to understanding traffic source patterns in Google Analytics.

Source ID used was supplied by Klaviyo Support and can be referenced here: https://help.klaviyo.com/hc/en-us/articles/1260804673530-Source-Value-Reference

## Manual Testing Steps

1. Subscribe to the newsletter.
2. The subscriber's profile should have Magento 2 specified as the source

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, have you:
  - [ ] Updated the links in the CHANGELOG to point towards the new versions
  - [ ] Incremented the version in the following places: module.xml and composer.json