### PR TITLE
TP156258: Switch from _learnq to klaviyo object in javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+#### Changed
+- Updated the legacy `_learnq` js object to the new `klaviyo` js object.
+
 ### [4.0.9] - 2023-01-03
 ### Changed
 - Updated default SMS consent language

--- a/view/frontend/templates/product/viewed.phtml
+++ b/view/frontend/templates/product/viewed.phtml
@@ -4,9 +4,9 @@
 
 <script text="text/javascript">
   require(['domReady!'], function () {
-    var _learnq = window._learnq || [];
-    _learnq.push(['track', 'Viewed Product', <?= $block->getViewedProductJson() ?>]);
-    _learnq.push(['trackViewedItem', <?= $block->getViewedItemJson() ?>]);
+    var klaviyo = window.klaviyo || [];
+    klaviyo.push(['track', 'Viewed Product', <?= $block->getViewedProductJson() ?>]);
+    klaviyo.push(['trackViewedItem', <?= $block->getViewedItemJson() ?>]);
   });
 </script>
 

--- a/view/frontend/web/js/customer.js
+++ b/view/frontend/web/js/customer.js
@@ -4,13 +4,13 @@ define([
     'domReady!'
 ], function (_, customerData) {
     'use strict';
-    var _learnq = window._learnq || [];
+    var klaviyo = window.klaviyo || [];
 
     customerData.getInitCustomerData().done(function () {
         var customer = customerData.get('customer')();
 
-        if(_.has(customer, 'email') && customer.email && !_learnq.isIdentified()) {
-            _learnq.identify({
+        if(_.has(customer, 'email') && customer.email && !klaviyo.isIdentified()) {
+            klaviyo.identify({
                 '$email': customer.email,
                 '$first_name': _.has(customer, 'firstname') ? customer.firstname : '',
                 '$last_name':  _.has(customer, 'lastname') ? customer.lastname : ''

--- a/view/frontend/web/js/view/checkout/email.js
+++ b/view/frontend/web/js/view/checkout/email.js
@@ -30,7 +30,7 @@ define([
       }
     },
     isKlaviyoActive: function() {
-      return !!(window._learnq && window._learnq.identify);
+      return !!(window.klaviyo && window.klaviyo.identify);
     },
     bindEmailListener: function () {
       // jquery overrides this, so let's create an instance of the parent
@@ -42,8 +42,8 @@ define([
         }
 
         self._email = jQuery(this).val();
-        if (!window._learnq.isIdentified()) {
-          window._learnq.push(['identify', {
+        if (!window.klaviyo.isIdentified()) {
+          window.klaviyo.push(['identify', {
             '$email': self._email
           }]);
         }


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Updated the legacy `_learnq` js object to the new `klaviyo` js object.

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Validated the `klaviyo` object is available when the klaviyo.js script is installed.

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, have you:
  - [ ] Updated the links in the CHANGELOG to point towards the new versions
  - [ ] Incremented the version in the following places: module.xml and composer.json

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
