### PR TITLE
202302 tp165376

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added precommit to the repository and formatted all PHP files to PSR12 style.
 - Set the newsletter subscription source to Magento 2
 
+#### Fixed
+- Fixed bug in NewsletterSubscribeObserver where customers with an unconfirmed site account were being unsubscribed
+
 ### [4.0.9] - 2023-01-03
 ### Changed
 - Updated default SMS consent language

--- a/Observer/NewsletterSubscribeObserver.php
+++ b/Observer/NewsletterSubscribeObserver.php
@@ -47,17 +47,20 @@ class NewsletterSubscribeObserver implements ObserverInterface
 
         /** @var Subscriber $subscriber */
         $subscriber = $observer->getDataObject();
-        if ($subscriber && ($subscriber->hasDataChanges() || $subscriber->isObjectNew())) {
+        if ($subscriber && $subscriber->isStatusChanged()) {
+            $subscriptionStatus = $subscriber->getStatus();
             $customer = $this->getCustomer($subscriber);
 
-            if ($subscriber->isSubscribed()) {
+            if ($subscriber->getId() && $subscriptionStatus === Subscriber::STATUS_SUBSCRIBED) {
                 $this->helper->subscribeEmailToKlaviyoList(
                     $customer ? $customer->getEmail() : $subscriber->getEmail(),
                     $customer ? $customer->getFirstname() : $subscriber->getFirstname(),
                     $customer ? $customer->getLastname() : $subscriber->getLastname(),
                     self::SOURCE_ID_MAGENTO2
                 );
-            } else {
+            }
+
+            if ($subscriber->getId() && $subscriptionStatus === Subscriber::STATUS_UNSUBSCRIBED) {
                 $this->helper->unsubscribeEmailFromKlaviyoList(
                     $customer ? $customer->getEmail() : $subscriber->getEmail()
                 );


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
This PR fixes a bug where customers that hadn't confirmed their email for their Site account were getting unsubscribed in Klaviyo. This was happening because we weren't accounting for the other two order statuses in our observer file - as a result every subscription update where the customer wasn't explicitly subscribed resulted in them getting unsubscribed. 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->
Tested the following scenerios: 
1. Create a new account for a site that has account confirmation required enabled and opt in to the newsletter. The Klaviyo newsletter settings are set to use the Klaviyo Double Opt-in. 
- Verify that the profile has not been created on Klaviyo yet
- Confirm account via the email
- Verify that I've received the Klaviyo DOI email and once that is confirmed that the profile has been added to the list
2. Create a new account for a site that does **not** have account confirmation required enabled and opt in to the newsletter. The Klaviyo newsletter settings are set to use the Klaviyo Double Opt-in. 
- Verify that I've received the Klaviyo DOI email and once that is confirmed that the profile has been added to the list correctly in Klaviyo. 
3. From an existing account on the store, update the newsletter settings to opt-out of emails.
- verify that the profile has been unsubscribed in Klaviyo as expected.
4. From an existing account on the store, update the newsletter settings to opt in to emails.
- verify that the profile has been resubscribed to klaviyo as expected after confirming via the DOI email. 
5. While not logged into an account on the magento store, fill out the footer form
- Verify that I've received the Klaviyo DOI email and once that is confirmed that the profile has been added to the list correctly in Klaviyo. 
- 
## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
