### PR TITLE
rolls back _learnq update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Continuous deployment to generate a new release when PRs are merged into the 'stable/**' release branches.
 
 #### Changed
-- Updated the legacy `_learnq` js object to the new `klaviyo` js object.
 - Added precommit to the repository and formatted all PHP files to PSR12 style.
 - Set the newsletter subscription source to Magento 2
 

--- a/view/frontend/templates/product/viewed.phtml
+++ b/view/frontend/templates/product/viewed.phtml
@@ -4,9 +4,9 @@
 
 <script text="text/javascript">
   require(['domReady!'], function () {
-    var klaviyo = window.klaviyo || [];
-    klaviyo.push(['track', 'Viewed Product', <?= $block->getViewedProductJson() ?>]);
-    klaviyo.push(['trackViewedItem', <?= $block->getViewedItemJson() ?>]);
+    var _learnq = window._learnq || [];
+      _learnq.push(['track', 'Viewed Product', <?= $block->getViewedProductJson() ?>]);
+      _learnq.push(['trackViewedItem', <?= $block->getViewedItemJson() ?>]);
   });
 </script>
 

--- a/view/frontend/web/js/customer.js
+++ b/view/frontend/web/js/customer.js
@@ -4,13 +4,13 @@ define([
     'domReady!'
 ], function (_, customerData) {
     'use strict';
-    var klaviyo = window.klaviyo || [];
+    var _learnq = window._learnq || [];
 
     customerData.getInitCustomerData().done(function () {
         var customer = customerData.get('customer')();
 
-        if(_.has(customer, 'email') && customer.email && !klaviyo.isIdentified()) {
-            klaviyo.identify({
+        if(_.has(customer, 'email') && customer.email && !_learnq.isIdentified()) {
+            _learnq.identify({
                 '$email': customer.email,
                 '$first_name': _.has(customer, 'firstname') ? customer.firstname : '',
                 '$last_name':  _.has(customer, 'lastname') ? customer.lastname : ''

--- a/view/frontend/web/js/view/checkout/email.js
+++ b/view/frontend/web/js/view/checkout/email.js
@@ -30,7 +30,7 @@ define([
       }
     },
     isKlaviyoActive: function() {
-      return !!(window.klaviyo && window.klaviyo.identify);
+      return !!(window._learnq && window._learnq.identify);
     },
     bindEmailListener: function () {
       // jquery overrides this, so let's create an instance of the parent
@@ -42,8 +42,8 @@ define([
         }
 
         self._email = jQuery(this).val();
-        if (!window.klaviyo.isIdentified()) {
-          window.klaviyo.push(['identify', {
+        if (!window._learnq.isIdentified()) {
+          window._learnq.push(['identify', {
             '$email': self._email
           }]);
         }


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->

Could not automatically revert #227 - this PR switches back usage of `klaviyo` object to `_learnq` until this feature can be retested.


## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1.

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
