### PR TITLE
TP157760: Validate the email is not the empty string

### DIFF
--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -86,7 +86,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Make sure we have an identifier for the customer set in the cookie
         if (isset($kl_decoded_cookie['$exchange_id'])) {
             $kl_user_properties = ['$exchange_id' => $kl_decoded_cookie['$exchange_id']];
-        } elseif (isset($kl_decoded_cookie['$email'])) {
+        } elseif (isset($kl_decoded_cookie['$email']) && !empty($kl_decoded_cookie['$email'])) {
             $kl_user_properties = ['$email' => $kl_decoded_cookie['$email']];
         } else {
             return;


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Makes sure the set `$email` in `$kl_decoded_cookie` is not the empty string.

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

```php
> $kl_decoded_cookie = ["email" => ""]
= [
    "email" => "",
  ]

> isset($kl_decoded_cookie["email"])
= true

> isset($kl_decoded_cookie["email"]) && !empty($kl_decoded_cookie["email"])
= false
```

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
