### PR TITLE
Fix shipping information update on checkout for klEmailConsent and klSmsConsent fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Fixed
+- Fixed bug in checkout where shipping information update caused report error if email or sms consent where activated
+
 #### Changed
 - Fixed bug where historical sync wouldn't run for index of 0
 

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -4,6 +4,10 @@
         <attribute code="kl_sms_consent" type="string"/>
         <attribute code="kl_email_consent" type="string"/>
     </extension_attributes>
+    <extension_attributes for="Magento\Quote\Api\Data\AddressInterface">
+        <attribute code="kl_sms_consent" type="string"/>
+        <attribute code="kl_email_consent" type="string"/>
+    </extension_attributes>
     <extension_attributes for="Magento\Quote\Api\Data\CartInterface">
         <attribute code="kl_masked_id" type="string" />
     </extension_attributes>


### PR DESCRIPTION
## Description
PR preventing Klaviyo to block checkout from working - error with method getKlSmsConsent() and getklEmailConsent() already issued on #191 

## Environment
Magento 2.4.5
PHP 8.1

## Manual Testing Steps
Enable the module, then go at "Stores > Configuration > Klaviyo > Consent at Checkout" section and flag "Subscribe contacts to email marketing at checkout" to "Yes" or/and  flag "Subscribe contacts to SMS marketing at checkout" to "Yes". 
Save the configurations, clean config cache.
After that go on checkout as guest and try complete an order.

## Expected Results
Before this fix, magento checkout will block you sending a 500 error on rest/default/V1/guest-carts/shipping-information endpoint and showing the following message (if your magento is in developer mode, webapi report error on production instead):
<< Property "KlEmailConsent" does not have accessor method "getKlEmailConsent" in class "Magento\Quote\Api\Data\AddressExtensionInterface". >> or << Property "KlSmsConsent" does not have accessor method "getKlSmsConsent" in class "Magento\Quote\Api\Data\AddressExtensionInterface". >> depending on "Consent at Checkout" configuration.
After the fix with same procedure you'll be able to complete the order normally.
