### PR TITLE
Improve performance of Viewed Product block

### DIFF
--- a/Block/Catalog/Product/ViewedProduct.php
+++ b/Block/Catalog/Product/ViewedProduct.php
@@ -4,7 +4,6 @@ namespace Klaviyo\Reclaim\Block\Catalog\Product;
 
 use Klaviyo\Reclaim\Helper\ScopeSetting;
 use Magento\Catalog\Helper\Image;
-use Magento\Catalog\Model\CategoryFactory;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
@@ -13,7 +12,6 @@ class ViewedProduct extends Template
 {
     protected $_klaviyoScopeSetting;
     protected $_registry;
-    protected $_categoryFactory;
     protected $imageUrl = null;
     protected $categories = [];
     protected $price = 0;
@@ -28,7 +26,6 @@ class ViewedProduct extends Template
      * @param Context $context
      * @param ScopeSetting $klaviyoScopeSetting
      * @param Registry $registry
-     * @param CategoryFactory $categoryFactory
      * @param Image $imageHelper
      * @param array $data
      */
@@ -36,14 +33,12 @@ class ViewedProduct extends Template
         Context $context,
         ScopeSetting $klaviyoScopeSetting,
         Registry $registry,
-        CategoryFactory $categoryFactory,
         Image $imageHelper,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
         $this->_registry = $registry;
-        $this->_categoryFactory = $categoryFactory;
         $this->imageHelper = $imageHelper;
     }
 
@@ -90,10 +85,10 @@ class ViewedProduct extends Template
     public function getProductCategories()
     {
         if (empty($this->categories)) {
-            foreach ($this->getProduct()->getCategoryIds() as $category_id) {
-                $category = $category = $this->_categoryFactory->create()->load($category_id);
-                $this->categories[] = $category->getName();
-            }
+            $this->categories = $this->getProduct()
+                ->getCategoryCollection()
+                ->addAttributeToSelect('name')
+                ->getColumnValues('name');
         }
 
         return $this->categories;


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
I noticed that some product pages loaded pretty fast while others did not. I did profiling and noticed that Klaviyo Viewed Product block was loading about 0.26-0.3 seconds on my pretty fast machine, which is very big number. That was caused by loading all linked category models in the loop (some products have 150+ categories).
To improve this situation, I replaced the loading category model in the loop with using a single collection call with fetching only needed info (category name). That worked way faster on the same machine- about 0.007 vs 0.3 seconds.

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Create product and link it to 150+ categories
2. Enable Magento profiler with `php bin/magento dev:profiler:enable` and see how long klaviyo block is getting rendered.
3. Apply the patch
4.  Compare results between the measurements 
 
## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
