### PR TITLE
202307 update subscribe conditional2

### DIFF
--- a/.changelogger.yml
+++ b/.changelogger.yml
@@ -2,6 +2,9 @@ versioned_files:
   - rel_path: composer.json
     pattern: '"version": "{{ old_version }}",'
     jinja: '"version": "{{ new_version }}",'
+  - rel_path: composer.dev.json
+    pattern: '"version": "{{ old_version }}",'
+    jinja: '"version": "{{ new_version }}",'
   - rel_path: etc/module.xml
     pattern: 'name="Klaviyo_Reclaim" setup_version="{{ old_version }}" schema_version="{{ old_version }}"'
     jinja: 'name="Klaviyo_Reclaim" setup_version="{{ new_version }}" schema_version="{{ new_version }}"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 - Fixed issue when viewed product block on product page caused slower response time
+- Fixed issue for newletter module where new subscriptions weren't being sent to klaviyo via magento forms for stores using Magento version < 2.4.3
 
 ### [4.0.11] - 2023-04-07
 

--- a/Observer/NewsletterSubscribeObserver.php
+++ b/Observer/NewsletterSubscribeObserver.php
@@ -66,6 +66,8 @@ class NewsletterSubscribeObserver implements ObserverInterface
                 );
             }
         }
+        $a = [];
+        $a[15.5];
     }
 
     /**

--- a/Observer/NewsletterSubscribeObserver.php
+++ b/Observer/NewsletterSubscribeObserver.php
@@ -66,8 +66,6 @@ class NewsletterSubscribeObserver implements ObserverInterface
                 );
             }
         }
-        $a = [];
-        $a[15.5];
     }
 
     /**

--- a/Observer/NewsletterSubscribeObserver.php
+++ b/Observer/NewsletterSubscribeObserver.php
@@ -47,7 +47,7 @@ class NewsletterSubscribeObserver implements ObserverInterface
 
         /** @var Subscriber $subscriber */
         $subscriber = $observer->getDataObject();
-        if ($subscriber && $subscriber->isStatusChanged()) {
+        if ($subscriber && ($subscriber->isStatusChanged() || $subscriber->isObjectNew())) {
             $subscriptionStatus = $subscriber->getStatus();
             $customer = $this->getCustomer($subscriber);
 

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-dev",
     "description": "The local development composer file. This is used for local and continuous integration setup/testing.",
     "type": "magento2-module",
-    "version": "4.0.9",
+    "version": "4.0.11",
     "autoload": {
         "psr-4": {
             "Klaviyo\\Reclaim\\": ""


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
In Magento versions <2.4.3 `isStatusChanged` doesn't evaluate to true for net new subscriptions made through any magento newsletter forms. This prevents new subscriptions from syncing to Klaviyo. This PR adds in a check for `isObjectNew` to be backwards compatible with old m2 versions. 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Tested locally on a 2.4.2 instance

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
