### PR TITLE
Create ACL for Klaviyo config settings

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_general" title="Klaviyo General" translate="title" sortOrder="150" />
+                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_newsletter" title="Klaviyo Newsletter" translate="title" sortOrder="160" />
+                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_consent_at_checkout" title="Klaviyo Consent at checkout" translate="title" sortOrder="170" />
+                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_oauth" title="Klaviyo Oauth" translate="title" sortOrder="180" />
+                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_webhook" title="Klaviyo Webhook" translate="title" sortOrder="190" />
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -6,11 +6,13 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config">
-                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_general" title="Klaviyo General" translate="title" sortOrder="150" />
-                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_newsletter" title="Klaviyo Newsletter" translate="title" sortOrder="160" />
-                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_consent_at_checkout" title="Klaviyo Consent at checkout" translate="title" sortOrder="170" />
-                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_oauth" title="Klaviyo Oauth" translate="title" sortOrder="180" />
-                            <resource id="Klaviyo_Reclaim::klaviyo_reclaim_webhook" title="Klaviyo Webhook" translate="title" sortOrder="190" />
+                            <resource id="Klaviyo_Reclaim" title="Klaviyo">
+                                <resource id="Klaviyo_Reclaim::klaviyo_reclaim_general" title="Klaviyo General" translate="title" sortOrder="150" />
+                                <resource id="Klaviyo_Reclaim::klaviyo_reclaim_newsletter" title="Klaviyo Newsletter" translate="title" sortOrder="160" />
+                                <resource id="Klaviyo_Reclaim::klaviyo_reclaim_consent_at_checkout" title="Klaviyo Consent at checkout" translate="title" sortOrder="170" />
+                                <resource id="Klaviyo_Reclaim::klaviyo_reclaim_oauth" title="Klaviyo Oauth" translate="title" sortOrder="180" />
+                                <resource id="Klaviyo_Reclaim::klaviyo_reclaim_webhook" title="Klaviyo Webhook" translate="title" sortOrder="190" />
+                            </resource>
                         </resource>
                     </resource>
                 </resource>

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -6,7 +6,7 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config">
-                            <resource id="Klaviyo_Reclaim" title="Klaviyo">
+                            <resource id="Klaviyo_Reclaim::config" title="Klaviyo">
                                 <resource id="Klaviyo_Reclaim::klaviyo_reclaim_general" title="Klaviyo General" translate="title" sortOrder="150" />
                                 <resource id="Klaviyo_Reclaim::klaviyo_reclaim_newsletter" title="Klaviyo Newsletter" translate="title" sortOrder="160" />
                                 <resource id="Klaviyo_Reclaim::klaviyo_reclaim_consent_at_checkout" title="Klaviyo Consent at checkout" translate="title" sortOrder="170" />

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -4,7 +4,6 @@
         <tab id="klaviyo" translate="label" sortOrder="10">
             <label>Klaviyo</label>
         </tab>
-
         <section id="klaviyo_reclaim_general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>General</label>
             <tab>klaviyo</tab>
@@ -33,11 +32,10 @@
                 </field>
             </group>
         </section>
-
         <section id="klaviyo_reclaim_newsletter" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Newsletter</label>
             <tab>klaviyo</tab>
-            <resource>Klaviyo_Reclaim::klaviyo_reclaim</resource>
+            <resource>Klaviyo_Reclaim::klaviyo_reclaim_newsletter</resource>
             <group id="newsletter" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Newsletter</label>
                 <field id="newsletter" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -53,11 +51,10 @@
                 </field>
             </group>
         </section>
-
         <section id="klaviyo_reclaim_consent_at_checkout" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Consent at Checkout</label>
             <tab>klaviyo</tab>
-            <resource>Klaviyo_Reclaim::klaviyo_reclaim</resource>
+            <resource>Klaviyo_Reclaim::klaviyo_reclaim_consent_at_checkout</resource>
             <group id="email_consent" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Email</label>
                 <field id="is_active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -129,11 +126,10 @@
                 </field>
             </group>
         </section>
-
         <section id="klaviyo_reclaim_oauth" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Setup OAuth</label>
             <tab>klaviyo</tab>
-            <resource>Klaviyo_Reclaim::klaviyo_reclaim</resource>
+            <resource>Klaviyo_Reclaim::klaviyo_reclaim_oauth</resource>
             <group id="klaviyo_oauth" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Setup Oauth</label>
                 <field id="integration_name" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -142,11 +138,10 @@
                 </field>
             </group>
         </section>
-
         <section id="klaviyo_reclaim_webhook" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Webhooks</label>
             <tab>klaviyo</tab>
-            <resource>Klaviyo_Reclaim::klaviyo_reclaim</resource>
+            <resource>Klaviyo_Reclaim::klaviyo_reclaim_webhook</resource>
             <group id="klaviyo_webhooks" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Setup Klaviyo Webhooks</label>
                 <field id="webhook_secret" translate="label" type="password" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
## Description

This pull request creates the ACL that's raised in this issue https://github.com/klaviyo/magento2-klaviyo/issues/160

It creates permissions for each klaviyo configuration area. 

## Manual Testing Steps

1. php bin/magento cache:clean
2. Log into the admin panel
3. Go to system -> User Roles
4. Check whether the new klaviyo roles appear (control+f klaviyo)

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

