### PR TITLE
Get error message using object method not array method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+### [4.1.1] - 2023-10-26
+
+#### Fixed
+- Fixed error handling when getting klaviyo lists
+
 ### [4.1.0] - 2023-09-29
 
 #### Added
@@ -249,7 +254,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- END RELEASE NOTES -->
 <!-- BEGIN LINKS -->
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.1.0...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.1.1...HEAD
+[4.1.1]: https://github.com/klaviyo/magento2-klaviyo/compare/4.1.0...4.1.1
 [4.1.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.12...4.1.0
 [4.0.12]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.11...4.0.12
 [4.0.11]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.10...4.0.11

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -80,10 +80,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 'lists' => $lists
             ];
         } catch (\Exception $e) {
-            $this->_klaviyoLogger->log(sprintf('Unable to get list: %s', $e["detail"]));
+            $this->_klaviyoLogger->log(sprintf('Unable to get list: %s', $e->getMessage()));
             return [
                 'success' => false,
-                'reason' => $e["detail"]
+                'reason' => $e->getMessage()
             ];
         }
     }

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-dev",
     "description": "The local development composer file. This is used for local and continuous integration setup/testing.",
     "type": "magento2-module",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "autoload": {
         "psr-4": {
             "Klaviyo\\Reclaim\\": ""

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.1.0" schema_version="4.1.0">
+  <module name="Klaviyo_Reclaim" setup_version="4.1.1" schema_version="4.1.1">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
## Description
This PR fixes a bug causing a compile error when the integration is disabled in Klaviyo and we try to navigate to either the consent at checkout or newsletter tabs on the klaviyo module on the M2 admin page

[Jira Ticket](https://klaviyo.atlassian.net/browse/ECOS-903?atlOrigin=eyJpIjoiYmNkMTJmNzJjN2JlNGIyMGE0NzhkMmE3NmI0YzRmMDUiLCJwIjoiaiJ9)


## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Switch into klaviyo account `LzPPzc` and disable the magento 2 integration
2. Navigate [to the klaviyo newsletter and consent at checkout pages on the M2 admin page](http://ies-magento2-2023.klaviyostores.com/admin/admin/system_config/index/key/0a7e4d1ec945f46f09c20f00849a057d50ec50ca6395beba0d1a6be2b687b935/)
3. You should be able to see the plugin configuration fields and not an error page with a stack trace

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [x] **Internal Only** - If this is a release, please confirm the following:
  - [x] The links in the changelog have been updated to point towards the new versions
  - [x] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
