### PR TITLE
updates the exception handling for getKlaviyoLists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - Added name to initialize block in checkout
 
+#### Fixed
+- Updated getKlaviyoLists() exception handling to properly print error message.
+
 ### [4.1.0] - 2023-09-29
 
 #### Added

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -80,10 +80,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 'lists' => $lists
             ];
         } catch (\Exception $e) {
-            $this->_klaviyoLogger->log(sprintf('Unable to get list: %s', $e["detail"]));
+            $this->_klaviyoLogger->log(sprintf('Unable to get list: %s', $e->getMessage()));
             return [
                 'success' => false,
-                'reason' => $e["detail"]
+                'reason' => $e->getMessage()
             ];
         }
     }


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Bug fix for #277 
Uses `getMessage()` instead of array indexing.

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Tested on local magento 2 with a bad private API key. Verified that the admin newsletter page renders successfully

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
