### PR TITLE
Paginate lists for newsletter setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,7 +187,7 @@ fabric.properties
 
 .idea/*
 
-!.idea/codeStyles
+#!.idea/codeStyles
 !.idea/runConfigurations
 
 ### PHPUnit ###

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,0 @@
-<component name="ProjectCodeStyleConfiguration">
-  <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
-  </state>
-</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 - Updated getKlaviyoLists() exception handling to properly print error message.
+- Paginate to get all lists for account.
 
 ### [4.1.0] - 2023-09-29
 

--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -47,6 +47,8 @@ class KlaviyoV3Api
      */
     const CUSTOMER_PROPERTIES_MAP = ['$email' => 'email', 'firstname' => 'first_name', 'lastname' => 'last_name', '$exchange_id' => '_kx'];
     const DATA_KEY_PAYLOAD = 'data';
+	const LINKS_KEY_PAYLOAD = 'links';
+	const NEXT_KEY_PAYLOAD = 'next';
     const TYPE_KEY_PAYLOAD = 'type';
     const ATTRIBUTE_KEY_PAYLOAD = 'attributes';
     const PROPERTIES_KEY_PAYLOAD = 'properties';
@@ -138,9 +140,19 @@ class KlaviyoV3Api
      */
     public function getLists()
     {
-        $response_body = $this->requestV3('api/lists/', self::HTTP_GET);
+		$response = $this->requestV3('api/lists/', self::HTTP_GET);
+		$lists = $response[self::DATA_KEY_PAYLOAD];
 
-        return $response_body[self::DATA_KEY_PAYLOAD];
+		$next = $response[self::LINKS_KEY_PAYLOAD][self::NEXT_KEY_PAYLOAD];
+		while ($next) {
+			$next_qs = explode("?", $next)[1];
+			$response = $this->requestV3("api/lists/?$next_qs", self::HTTP_GET);
+			array_push($lists, ...$response[self::DATA_KEY_PAYLOAD]);
+
+			$next = $response[self::LINKS_KEY_PAYLOAD][self::NEXT_KEY_PAYLOAD];
+		}
+
+		return $lists;
     }
 
     /**

--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -47,8 +47,8 @@ class KlaviyoV3Api
      */
     const CUSTOMER_PROPERTIES_MAP = ['$email' => 'email', 'firstname' => 'first_name', 'lastname' => 'last_name', '$exchange_id' => '_kx'];
     const DATA_KEY_PAYLOAD = 'data';
-	const LINKS_KEY_PAYLOAD = 'links';
-	const NEXT_KEY_PAYLOAD = 'next';
+    const LINKS_KEY_PAYLOAD = 'links';
+    const NEXT_KEY_PAYLOAD = 'next';
     const TYPE_KEY_PAYLOAD = 'type';
     const ATTRIBUTE_KEY_PAYLOAD = 'attributes';
     const PROPERTIES_KEY_PAYLOAD = 'properties';
@@ -140,19 +140,19 @@ class KlaviyoV3Api
      */
     public function getLists()
     {
-		$response = $this->requestV3('api/lists/', self::HTTP_GET);
-		$lists = $response[self::DATA_KEY_PAYLOAD];
+        $response = $this->requestV3('api/lists/', self::HTTP_GET);
+        $lists = $response[self::DATA_KEY_PAYLOAD];
 
-		$next = $response[self::LINKS_KEY_PAYLOAD][self::NEXT_KEY_PAYLOAD];
-		while ($next) {
-			$next_qs = explode("?", $next)[1];
-			$response = $this->requestV3("api/lists/?$next_qs", self::HTTP_GET);
-			array_push($lists, ...$response[self::DATA_KEY_PAYLOAD]);
+        $next = $response[self::LINKS_KEY_PAYLOAD][self::NEXT_KEY_PAYLOAD];
+        while ($next) {
+            $next_qs = explode("?", $next)[1];
+            $response = $this->requestV3("api/lists/?$next_qs", self::HTTP_GET);
+            array_push($lists, ...$response[self::DATA_KEY_PAYLOAD]);
 
-			$next = $response[self::LINKS_KEY_PAYLOAD][self::NEXT_KEY_PAYLOAD];
-		}
+            $next = $response[self::LINKS_KEY_PAYLOAD][self::NEXT_KEY_PAYLOAD];
+        }
 
-		return $lists;
+        return $lists;
     }
 
     /**


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
V3 lists api only returns 10 lists per page. In order to fully populate the Newsletter configuration dropdown menu we need to paginate to fetch all lists for an account.

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. local setup, tested with an account with 155 lists and with an account with 4 lists. 155 had a few seconds of latency due to the synchronous requests

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
