### PR TITLE
Add create archive step to CD workflow

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,14 @@
+/docs
+.changelogger*
+.DS_Store
+.git
+.github
+.gitignore
+.idea
+.phpunit.*
+.phpcs.*
+.python-version
+.pre-commit-config.yaml
+CHANGELOG.md
+makefile
+.distignore

--- a/.distignore
+++ b/.distignore
@@ -11,5 +11,6 @@
 .python-version
 .pre-commit-config.yaml
 CHANGELOG.md
+README.md
 makefile
 .distignore

--- a/.distignore
+++ b/.distignore
@@ -1,5 +1,6 @@
 /docs
 .changelogger*
+.dev
 .DS_Store
 .git
 .github

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -1,9 +1,9 @@
 name: Master Release
 run-name: "Master Release"
-on:
-  push:
-    branches:
-      - 'master'
+on: [pull_request]
+#  push:
+#    branches:
+#      - 'master'
 
 jobs:
   determine-if-deploy:
@@ -31,7 +31,7 @@ jobs:
   github-tag-and-release:
     runs-on: ubuntu-latest
     needs: determine-if-deploy
-    if: needs.determine-if-deploy.outputs.deploy == 'true'
+#    if: needs.determine-if-deploy.outputs.deploy == 'true'
     steps:
     - uses: actions/checkout@v3
     - name: Setup Python 3.11
@@ -53,30 +53,48 @@ jobs:
         changelogger notes $VERSION --no-pretty >> $GITHUB_ENV
         echo ${DELIMITER} >> $GITHUB_ENV
 
-    - name: Create GitHub Tag & Release
-      uses: ncipollo/release-action@v1
-      with:
-        tag: ${{ needs.determine-if-deploy.outputs.version }}
-        commit: ${{ github.sha }}
-        name: Release ${{ needs.determine-if-deploy.outputs.version }}
-        body: ${{ env.content }}
-        prerelease: true
+    - name: Exclude files
+      run: |
+        wrapper_dir="magento2-klaviyo"
+        mkdir $wrapper_dir
+        rsync -rc --exclude-from=".distignore" "$GITHUB_WORKSPACE/" $wrapper_dir/ --delete --delete-excluded
+        ls $wrapper_dir
 
-    - name: Send PagerDuty alert on failure
-      if: ${{ failure() }}
-      uses: award28/action-pagerduty-alert@0.4.0
-      with:
-        pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
-        pagerduty-dedup-key: magento_two_cd
+#    - name: Create Archive
+#      uses: thedoctor0/zip-release@0.7.1
+#      with:
+#        type: 'zip'
+#        filename: "klaviyo_reclaim-${{ needs.determine-if-deploy.outputs.version }}.zip"
+#        exclusions: '*.git* '
+#
+#    - name: Temp - upload zip for testing
+#      uses: actions/upload-artifact@v3
+#      with:
+#        path: "klaviyo_reclaim-${{ needs.determine-if-deploy.outputs.version }}.zip"
+#    - name: Create GitHub Tag & Release
+#      uses: ncipollo/release-action@v1
+#      with:
+#        tag: ${{ needs.determine-if-deploy.outputs.version }}
+#        commit: ${{ github.sha }}
+#        name: Release ${{ needs.determine-if-deploy.outputs.version }}
+#        body: ${{ env.content }}
+#        prerelease: true
+
+#    - name: Send PagerDuty alert on failure
+#      if: ${{ failure() }}
+#      uses: award28/action-pagerduty-alert@0.4.0
+#      with:
+#        pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+#        pagerduty-dedup-key: magento_two_cd
 
   integration-release:
     runs-on: ubuntu-latest
     needs: [determine-if-deploy, github-tag-and-release]
     steps:
     - run: echo "Releasing to Magento2"
-    - name: Send PagerDuty alert on failure
-      if: ${{ failure() }}
-      uses: award28/action-pagerduty-alert@0.4.0
-      with:
-        pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
-        pagerduty-dedup-key: magento_two_cd
+#    - name: Send PagerDuty alert on failure
+#      if: ${{ failure() }}
+#      uses: award28/action-pagerduty-alert@0.4.0
+#      with:
+#        pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+#        pagerduty-dedup-key: magento_two_cd

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -1,9 +1,9 @@
 name: Master Release
 run-name: "Master Release"
-on: [pull_request]
-#  push:
-#    branches:
-#      - 'master'
+on:
+  push:
+    branches:
+      - 'master'
 
 jobs:
   determine-if-deploy:
@@ -31,7 +31,9 @@ jobs:
   github-tag-and-release:
     runs-on: ubuntu-latest
     needs: determine-if-deploy
-#    if: needs.determine-if-deploy.outputs.deploy == 'true'
+    if: needs.determine-if-deploy.outputs.deploy == 'true'
+    env:
+      ZIP_FILE_NAME: klaviyo_reclaim-${{ needs.determine-if-deploy.outputs.version }}.zip
     steps:
     - uses: actions/checkout@v3
     - name: Setup Python 3.11
@@ -53,48 +55,37 @@ jobs:
         changelogger notes $VERSION --no-pretty >> $GITHUB_ENV
         echo ${DELIMITER} >> $GITHUB_ENV
 
-    - name: Exclude files
+    - name: Create Archive
       run: |
         wrapper_dir="magento2-klaviyo"
-        mkdir $wrapper_dir
         rsync -rc --exclude-from=".distignore" "$GITHUB_WORKSPACE/" $wrapper_dir/ --delete --delete-excluded
-        ls -al $wrapper_dir
+        zip -r ${{ env.ZIP_FILE_NAME }} ./$wrapper_dir
 
-#    - name: Create Archive
-#      uses: thedoctor0/zip-release@0.7.1
-#      with:
-#        type: 'zip'
-#        filename: "klaviyo_reclaim-${{ needs.determine-if-deploy.outputs.version }}.zip"
-#        exclusions: '*.git* '
-#
-#    - name: Temp - upload zip for testing
-#      uses: actions/upload-artifact@v3
-#      with:
-#        path: "klaviyo_reclaim-${{ needs.determine-if-deploy.outputs.version }}.zip"
-#    - name: Create GitHub Tag & Release
-#      uses: ncipollo/release-action@v1
-#      with:
-#        tag: ${{ needs.determine-if-deploy.outputs.version }}
-#        commit: ${{ github.sha }}
-#        name: Release ${{ needs.determine-if-deploy.outputs.version }}
-#        body: ${{ env.content }}
-#        prerelease: true
+    - name: Create GitHub Tag & Release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ needs.determine-if-deploy.outputs.version }}
+        commit: ${{ github.sha }}
+        name: Release ${{ needs.determine-if-deploy.outputs.version }}
+        body: ${{ env.content }}
+        prerelease: true
+        artifacts: ${{ env.ZIP_FILE_NAME }}
 
-#    - name: Send PagerDuty alert on failure
-#      if: ${{ failure() }}
-#      uses: award28/action-pagerduty-alert@0.4.0
-#      with:
-#        pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
-#        pagerduty-dedup-key: magento_two_cd
+    - name: Send PagerDuty alert on failure
+      if: ${{ failure() }}
+      uses: award28/action-pagerduty-alert@0.4.0
+      with:
+        pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+        pagerduty-dedup-key: magento_two_cd
 
   integration-release:
     runs-on: ubuntu-latest
     needs: [determine-if-deploy, github-tag-and-release]
     steps:
     - run: echo "Releasing to Magento2"
-#    - name: Send PagerDuty alert on failure
-#      if: ${{ failure() }}
-#      uses: award28/action-pagerduty-alert@0.4.0
-#      with:
-#        pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
-#        pagerduty-dedup-key: magento_two_cd
+    - name: Send PagerDuty alert on failure
+      if: ${{ failure() }}
+      uses: award28/action-pagerduty-alert@0.4.0
+      with:
+        pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+        pagerduty-dedup-key: magento_two_cd

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -56,12 +56,14 @@ jobs:
         echo ${DELIMITER} >> $GITHUB_ENV
 
     - name: Create Archive
+      # Create zip archive for release to composer repository (Packagist)
       run: |
         wrapper_dir="magento2-klaviyo"
         rsync -rc --exclude-from=".distignore" "$GITHUB_WORKSPACE/" $wrapper_dir/ --delete --delete-excluded
         zip -r ${{ env.ZIP_FILE_NAME }} ./$wrapper_dir
 
     - name: Create GitHub Tag & Release
+      # Creates GH tag and release, adds zip archive as artifact to release.
       uses: ncipollo/release-action@v1
       with:
         tag: ${{ needs.determine-if-deploy.outputs.version }}

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -58,7 +58,7 @@ jobs:
         wrapper_dir="magento2-klaviyo"
         mkdir $wrapper_dir
         rsync -rc --exclude-from=".distignore" "$GITHUB_WORKSPACE/" $wrapper_dir/ --delete --delete-excluded
-        ls $wrapper_dir
+        ls -al $wrapper_dir
 
 #    - name: Create Archive
 #      uses: thedoctor0/zip-release@0.7.1

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ fabric.properties
 /build/
 
 # End of https://www.toptal.com/developers/gitignore/api/phpunit,php-cs-fixer,phpcodesniffer,phpstorm,phpstorm+all
+
+# pyenv
+.python-version


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Adds a step to the CD workflow to create a zip archive while excluding files that don't need to be released through a `.distignore` file.

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Forked the repo and made these updates to test distignore, zip and adding artifact to release. See attachced zip file for example of output.
[klaviyo_reclaim-4.1.0.zip](https://github.com/klaviyo/magento2-klaviyo/files/13654136/klaviyo_reclaim-4.1.0.zip)


## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
