### PR TITLE
update response handling for false

### DIFF
--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -359,7 +359,7 @@ class KlaviyoV3Api
         $statusCode = curl_getinfo($curl, $phpVersionHttpCode);
         // In the event that the curl_exec fails for whatever reason, it responds with `false`,
         // Implementing a timeout and retry mechanism which will attempt the API call 3 times at 5 second intervals
-        if ($statusCode < 200 || $statusCode >= 300 || $response == false) {
+        if ($statusCode < 200 || $statusCode >= 300 || $response === false) {
             if ($attempt < 3) {
                 sleep(1);
                 $this->requestV3($path, $method, $body, $attempt + 1);


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
This PR fixes behavior for when `curl_exec` returns something that is not explicitly false but evaluates to false (ex: `null`). This will prevent successful responses from retrying and follows the recommendation here: https://www.php.net/manual/en/function.curl-exec.php#refsect1-function.curl-exec-returnvalues

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1.

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
