### PR TITLE
Add promise handling to isIdentified() call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Fixed
+- Updated customer.js to correctly handle promise returned from isIdentified
+
 ### [4.1.1] - 2023-12-12
 
 #### Added

--- a/view/frontend/web/js/customer.js
+++ b/view/frontend/web/js/customer.js
@@ -12,13 +12,16 @@ define([
     customerData.getInitCustomerData().done(function () {
         var customer = customerData.get('customer')();
 
-        if(_.has(customer, 'email') && customer.email && !klaviyo.isIdentified()) {
-            klaviyo.identify({
-                '$email': customer.email,
-                '$first_name': _.has(customer, 'firstname') ? customer.firstname : '',
-                '$last_name':  _.has(customer, 'lastname') ? customer.lastname : ''
-            });
-        }
+        klaviyo.isIdentified().then((identified)=> {
+            if(_.has(customer, 'email') && customer.email && !identified) {
+                klaviyo.identify({
+                    '$email': customer.email,
+                    '$first_name': _.has(customer, 'firstname') ? customer.firstname : '',
+                    '$last_name':  _.has(customer, 'lastname') ? customer.lastname : ''
+                });
+            }
+        });
+
     });
 
 });


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Fixes a bug where we don't correctly handle the Promise returned by `klaviyo.isIdentified()`. Was preventing us from identifying customers after account registration or login. 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Tested that I'm correctly identified in Klaviyo after registering a new account
2. Tested that I'm correctly identified in Klaviyo after logging into an account.

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [x] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
