### PR TITLE
V3 API patch for 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [3.0.4-patch] - 2024-02-01
+
+#### Deprecated
+- Removed usage of Klaviyo's V1/V2 APIs, which will be retired on June 30, 2024
+
+#### Added
+- Support for Klaviyo's V3 APIs
+
 ### [3.0.4] - 2021-06-08
 
 #### Fixed
@@ -92,7 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.4...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.4-patch...HEAD
+[3.0.4]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.4...3.0.4-patch
 [3.0.4]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.3...3.0.4
 [3.0.3]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.2...3.0.3
 [3.0.2]: https://github.com/klaviyo/magento2-klaviyo/compare/3.0.1...3.0.2

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1,16 +1,13 @@
 <?php
 namespace Klaviyo\Reclaim\Helper;
 
+use Klaviyo\Reclaim\KlaviyoV3Sdk\KlaviyoV3Api;
 use \Klaviyo\Reclaim\Helper\ScopeSetting;
 use \Magento\Framework\App\Helper\Context;
 use \Klaviyo\Reclaim\Helper\Logger;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
-    const USER_AGENT = 'Klaviyo/1.0';
-    const KLAVIYO_HOST = 'https://a.klaviyo.com/';
-    const LIST_V2_API = 'api/v2/list/';
-
     /**
      * Klaviyo logger helper
      * @var \Klaviyo\Reclaim\Helper\Logger $klaviyoLogger
@@ -34,42 +31,32 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     public function getKlaviyoLists($api_key=null){
-        if (!$api_key) $api_key = $this->_klaviyoScopeSetting->getPrivateApiKey();
-
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, 'https://a.klaviyo.com/api/v2/lists?api_key=' . $api_key);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-
-
-        $output = json_decode(curl_exec($ch));
-        $statusCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
-        curl_close($ch);
-
-        if ($statusCode !== 200) {
-            if ($statusCode === 403) {
-                $reason = 'The Private Klaviyo API Key you have set is invalid.';
-            } elseif ($statusCode === 401) {
-                $reason = 'The Private Klaviyo API key you have set is no longer valid.';
-            } else {
-                $reason = 'Unable to verify Klaviyo Private API Key.';
+        if (!$api_key) {
+            $api_key = $this->_klaviyoScopeSetting->getPrivateApiKey();
+        }
+        $api = new KlaviyoV3Api($this->_klaviyoScopeSetting->getPublicApiKey(), $api_key, $this->_klaviyoScopeSetting, $this->_klaviyoLogger);
+        $lists = array();
+        $success = true;
+        $error = null;
+        try {
+            $lists_response = $api->getLists();
+            foreach ($lists_response as $list) {
+                $lists[] = array(
+                    'id' => $list['id'],
+                    'name' => $list['attributes']['name']
+                );
             }
-
-            $result = [
-                'success' => false,
-                'reason' => $reason
-            ];
-        } else {
-            usort($output, function($a, $b) {
-                return strtolower($a->list_name) > strtolower($b->list_name) ? 1 : -1;
-            });
-
-            $result = [
-                'success' => true,
-                'lists' => $output
-            ];
+        }  catch (\Exception $e) {
+            $this->_klaviyoLogger->log(sprintf('Unable to fetch lists: %s', $e->getMessage()));
+            $error = $e->getCode();
+            $success = false;
         }
 
-        return $result;
+        return [
+            'success' => $success,
+            'lists' => $lists,
+            'error' => $error
+        ];
     }
 
     /**
@@ -79,30 +66,41 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @param string $source
      * @return bool|string
      */
-    public function subscribeEmailToKlaviyoList($email, $firstName = null, $lastName = null, $source = null)
+    public function subscribeEmailToKlaviyoList($email)
     {
+        $api = new KlaviyoV3Api($this->_klaviyoScopeSetting->getPublicApiKey(), $this->_klaviyoScopeSetting->getPrivateApiKey(), $this->_klaviyoScopeSetting, $this->_klaviyoLogger);
         $listId = $this->_klaviyoScopeSetting->getNewsletter();
         $optInSetting = $this->_klaviyoScopeSetting->getOptInSetting();
 
-        $properties = [];
-        $properties['email'] = $email;
-        if ($firstName) $properties['$first_name'] = $firstName;
-        if ($lastName) $properties['$last_name'] = $lastName;
-        if ($source) $properties['$source'] = $source;
-        if ($optInSetting == ScopeSetting::API_SUBSCRIBE) $properties['$consent'] = ['email'];
-
-        $propertiesVal = ['profiles' => $properties];
-
-        $path = self::LIST_V2_API . $listId . $optInSetting;
+        $profileAttributes = [];
+        $profileAttributes['email'] = $email;
 
         try {
-            $response = $this->sendApiRequest($path, $propertiesVal, 'POST');
+            if ($optInSetting == ScopeSetting::API_SUBSCRIBE) {
+                // Subscribe profile using the profile creation endpoint for lists
+                $consent_profile_object = array(
+                    'type' => 'profile',
+                    'attributes' => array_merge($profileAttributes, array('subscriptions' => array(
+                        'email' => [
+                            'MARKETING'
+                        ]
+                    )))
+                );
+                $api->subscribeMembersToList($listId, array($consent_profile_object));
+            } else {
+                // Search for profile by email using the api/profiles endpoint
+                $existing_profile = $api->searchProfileByEmail($email);
+                if (!$existing_profile) {
+                    $new_profile = $api->createProfile($profileAttributes);
+                    $profile_id = $new_profile["profile_id"];
+                } else {
+                    $profile_id = $existing_profile["profile_id"];
+                }
+                $api->addProfileToList($listId, $profile_id);
+            }
         } catch (\Exception $e) {
-            $this->_klaviyoLogger->log(sprintf('Unable to subscribe %s to list %s: %s', $email, $listId, $e));
-            $response = false;
+            $this->_klaviyoLogger->log(sprintf('Unable to subscribe %s to list %s: %s', $email, $listId, $e->getMessage()));
         }
-
-        return $response;
     }
 
     /**
@@ -111,93 +109,15 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function unsubscribeEmailFromKlaviyoList($email)
     {
+        $api = new KlaviyoV3Api($this->_klaviyoScopeSetting->getPublicApiKey(), $this->_klaviyoScopeSetting->getPrivateApiKey(), $this->_klaviyoScopeSetting, $this->_klaviyoLogger);
         $listId = $this->_klaviyoScopeSetting->getNewsletter();
 
-        $path = self::LIST_V2_API . $listId . ScopeSetting::API_SUBSCRIBE;
-        $fields = [
-            'emails' => [(string)$email],
-        ];
-
         try {
-            $response = $this->sendApiRequest($path, $fields, 'DELETE');
+            $response = $api->unsubscribeEmailFromKlaviyoList($email, $listId);
         } catch (\Exception $e) {
-            $this->_klaviyoLogger->log(sprintf('Unable to unsubscribe %s from list %s: %s', $email, $listId, $e));
+            $this->_klaviyoLogger->log(sprintf('Unable to unsubscribe %s from list %s: %s', $email, $listId, $e->getMessage()));
             $response = false;
         }
-
-        return $response;
-    }
-
-    public function klaviyoTrackEvent($event, $customer_properties=array(), $properties=array(), $timestamp=NULL)
-    {
-        if ((!array_key_exists('$email', $customer_properties) || empty($customer_properties['$email']))
-            && (!array_key_exists('$id', $customer_properties) || empty($customer_properties['$id']))) {
-
-            return 'You must identify a user by email or ID.';
-        }
-        $params = array(
-            'token' => $this->_klaviyoScopeSetting->getPublicApiKey(),
-            'event' => $event,
-            'properties' => $properties,
-            'customer_properties' => $customer_properties
-        );
-
-        if (!is_null($timestamp)) {
-            $params['time'] = $timestamp;
-        }
-        $encoded_params = $this->build_params($params);
-        return $this->make_request('api/track', $encoded_params);
-
-    }
-    protected function build_params($params) {
-        return 'data=' . urlencode(base64_encode(json_encode($params)));
-    }
-
-    protected function make_request($path, $params) {
-        $url = self::KLAVIYO_HOST . $path . '?' . $params;
-        $response = file_get_contents($url);
-        return $response == '1';
-    }
-
-    /**
-     * @param string $path
-     * @param array $params
-     * @param string $method
-     * @return mixed[]
-     * @throws \Exception
-     */
-    private function sendApiRequest(string $path, array $params, string $method = null)
-    {
-        $url = self::KLAVIYO_HOST . $path;
-
-        //Add API Key to params
-        $params['api_key'] = $this->_klaviyoScopeSetting->getPrivateApiKey();
-
-        $curl = curl_init();
-        $encodedParams = json_encode($params);
-
-        curl_setopt_array($curl, [
-            CURLOPT_URL => $url,
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_CUSTOMREQUEST => (!empty($method)) ? $method : 'POST',
-            CURLOPT_POSTFIELDS => $encodedParams,
-            CURLOPT_USERAGENT => self::USER_AGENT,
-            CURLOPT_HTTPHEADER => [
-                'Content-Type: application/json',
-                'Content-Length: ' . strlen($encodedParams)
-            ],
-        ]);
-
-        // Submit the request
-        $response = curl_exec($curl);
-        $err = curl_errno($curl);
-
-        if ($err) {
-            throw new \Exception(curl_error($curl));
-        }
-
-        // Close cURL session handle
-        curl_close($curl);
 
         return $response;
     }

--- a/KlaviyoV3Sdk/Exception/KlaviyoApiException.php
+++ b/KlaviyoV3Sdk/Exception/KlaviyoApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Klaviyo\Reclaim\KlaviyoV3Sdk\Exception;
+
+class KlaviyoApiException extends KlaviyoException
+{
+}

--- a/KlaviyoV3Sdk/Exception/KlaviyoAuthenticationException.php
+++ b/KlaviyoV3Sdk/Exception/KlaviyoAuthenticationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Klaviyo\Reclaim\KlaviyoV3Sdk\Exception;
+
+class KlaviyoAuthenticationException extends KlaviyoApiException
+{
+}

--- a/KlaviyoV3Sdk/Exception/KlaviyoException.php
+++ b/KlaviyoV3Sdk/Exception/KlaviyoException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Klaviyo\Reclaim\KlaviyoV3Sdk\Exception;
+
+use Exception;
+
+class KlaviyoException extends Exception
+{
+}

--- a/KlaviyoV3Sdk/Exception/KlaviyoRateLimitException.php
+++ b/KlaviyoV3Sdk/Exception/KlaviyoRateLimitException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Klaviyo\Reclaim\KlaviyoV3Sdk\Exception;
+
+class KlaviyoRateLimitException extends KlaviyoApiException
+{
+}

--- a/KlaviyoV3Sdk/Exception/KlaviyoResourceNotFoundException.php
+++ b/KlaviyoV3Sdk/Exception/KlaviyoResourceNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Klaviyo\Reclaim\KlaviyoV3Sdk\Exception;
+
+class KlaviyoResourceNotFoundException extends KlaviyoApiException
+{
+}

--- a/KlaviyoV3Sdk/Exception/index.php
+++ b/KlaviyoV3Sdk/Exception/index.php
@@ -1,0 +1,8 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');

--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -1,0 +1,517 @@
+<?php
+
+namespace Klaviyo\Reclaim\KlaviyoV3Sdk;
+
+use DateTime;
+use Klaviyo\Reclaim\Helper\ScopeSetting;
+use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoApiException;
+use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoAuthenticationException;
+use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoRateLimitException;
+use \Klaviyo\Reclaim\Helper\Logger;
+
+
+class KlaviyoV3Api
+{
+    /**
+     * Host and versions
+     */
+    const KLAVIYO_HOST = 'https://a.klaviyo.com/';
+    const KLAVIYO_V3_REVISION = '2023-08-15';
+
+    /**
+     * Request methods
+     */
+    const HTTP_GET = 'GET';
+    const HTTP_POST = 'POST';
+
+    /**
+     * Error messages
+     */
+    const ERROR_FORBIDDEN = 'Private API key has invalid permissions.';
+    const ERROR_NOT_AUTHORIZED = 'Authentication key missing from request or is invalid. Check that Klaviyo Private API key is correctly set for scope.';
+    const ERROR_NON_200_STATUS = 'Request Failed with HTTP Status Code: %s';
+    const ERROR_API_CALL_FAILED = 'Request could be completed at this time, API call failed';
+    const ERROR_MALFORMED_RESPONSE_BODY = 'Response from API could not be decoded from JSON, check response body';
+    const ERROR_RATE_LIMIT_EXCEEDED = 'Rate limit exceeded';
+    /**
+     * Request options
+     */
+    const ACCEPT_KEY_HEADER = 'accept';
+    const CONTENT_TYPE_KEY_HEADER = 'Content-type';
+    const REVISION_KEY_HEADER = 'revision';
+    const AUTHORIZATION_KEY_HEADER = 'Authorization';
+    const KLAVIYO_API_KEY = 'Klaviyo-API-Key';
+    const PROPERTIES = 'properties';
+    const KLAVIYO_USER_AGENT_KEY = 'X-Klaviyo-User-Agent';
+    const APPLICATION_JSON_HEADER_VALUE = 'application/json';
+
+    /**
+     * Payload options
+     */
+    const CUSTOMER_PROPERTIES_MAP = ['$email' => 'email', 'firstname' => 'first_name', 'lastname' => 'last_name', '$exchange_id' => '_kx'];
+    const DATA_KEY_PAYLOAD = 'data';
+    const LINKS_KEY_PAYLOAD = 'links';
+    const NEXT_KEY_PAYLOAD = 'next';
+    const TYPE_KEY_PAYLOAD = 'type';
+    const ATTRIBUTE_KEY_PAYLOAD = 'attributes';
+    const PROPERTIES_KEY_PAYLOAD = 'properties';
+    const TIME_KEY_PAYLOAD = 'time';
+    const VALUE_KEY_PAYLOAD = 'value';
+    const VALUE_KEY_PAYLOAD_OLD = '$value';
+    const METRIC_KEY_PAYLOAD = 'metric';
+    const PROFILE_KEY_PAYLOAD = 'profile';
+    const NAME_KEY_PAYLOAD = 'name';
+    const EVENT_VALUE_PAYLOAD = 'event';
+    const ID_KEY_PAYLOAD = 'id';
+    const PROFILE_SUBSCRIPTION_BULK_CREATE_JOB_PAYLOAD_KEY = 'profile-subscription-bulk-create-job';
+    const PROFILE_SUBSCRIPTION_BULK_DELETE_JOB_PAYLOAD_KEY = 'profile-subscription-bulk-delete-job';
+    const LIST_PAYLOAD_KEY = 'list';
+    const RELATIONSHIPS_PAYLOAD_KEY = 'relationships';
+    const PROFILES_PAYLOAD_KEY = 'profiles';
+    const CUSTOM_SOURCE_PAYLOAD_KEY = 'custom_source';
+    const MAGENTO_TWO_PAYLOAD_VALUE = 'Magento Two';
+    const MAGENTO_TWO_INTEGRATION_SERVICE_KEY = 'magentotwo';
+    const SERVICE_PAYLOAD_KEY = 'service';
+
+    /**
+     * @var string
+     */
+    protected $private_key;
+
+    /**
+     * @var string
+     */
+    protected $public_key;
+    /**
+     * @var ScopeSetting
+     */
+    private $_klaviyoScopeSetting;
+
+    /**
+     * Klaviyo logger helper
+     * @var \Klaviyo\Reclaim\Helper\Logger $klaviyoLogger
+     */
+    protected $_klaviyoLogger;
+    /**
+     * Constructor method for base class
+     *
+     * @param $public_key
+     * @param $private_key
+     * @param ScopeSetting $klaviyoScopeSetting
+     */
+    public function __construct(
+        $public_key,
+        $private_key,
+        ScopeSetting $klaviyoScopeSetting,
+        Logger $klaviyoLogger
+    ) {
+        $this->public_key = $public_key;
+        $this->private_key = $private_key;
+        $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
+        $this->_klaviyoLogger = $klaviyoLogger;
+    }
+
+    /**
+     * Build headers for the Klaviyo all event
+     *
+     * @param $clientEvent
+     * @return array|array[]
+     */
+    public function getHeaders()
+    {
+        $klVersion = $this->_klaviyoScopeSetting->getVersion();
+
+        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+        $productMetadata = $objectManager->get('Magento\Framework\App\ProductMetadataInterface');
+        $m2Version = $productMetadata->getVersion();
+
+        $headers = array(
+            CURLOPT_HTTPHEADER => [
+                self::REVISION_KEY_HEADER . ': ' . self::KLAVIYO_V3_REVISION,
+                self::CONTENT_TYPE_KEY_HEADER . ': ' . self::APPLICATION_JSON_HEADER_VALUE,
+                self::ACCEPT_KEY_HEADER . ': ' . self::APPLICATION_JSON_HEADER_VALUE,
+                self::KLAVIYO_USER_AGENT_KEY . ': ' . 'magento2-klaviyo/' . $klVersion . ' Magento2/' . $m2Version . ' PHP/' . phpversion(),
+                self::AUTHORIZATION_KEY_HEADER . ': ' . self::KLAVIYO_API_KEY . ' ' . $this->private_key
+            ]
+        );
+
+        return $headers;
+    }
+
+
+    /**
+     * Query for all available lists in Klaviyo
+     * https://developers.klaviyo.com/en/v2023-08-15/reference/get_lists
+     *
+     * @return array
+     * @throws KlaviyoApiException
+     * @throws KlaviyoAuthenticationException
+     * @throws KlaviyoRateLimitException
+     */
+    public function getLists()
+    {
+        $response = $this->requestV3('api/lists/', self::HTTP_GET);
+        $lists = $response[self::DATA_KEY_PAYLOAD];
+
+        $next = $response[self::LINKS_KEY_PAYLOAD][self::NEXT_KEY_PAYLOAD];
+        while ($next) {
+            $next_qs = explode("?", $next)[1];
+            $response = $this->requestV3("api/lists/?$next_qs", self::HTTP_GET);
+            array_push($lists, ...$response[self::DATA_KEY_PAYLOAD]);
+
+            $next = $response[self::LINKS_KEY_PAYLOAD][self::NEXT_KEY_PAYLOAD];
+        }
+
+        return $lists;
+    }
+
+    /**
+     * Search for profile by Email
+     * https://developers.klaviyo.com/en/v2023-08-15/reference/get_profiles
+     *
+     * @param $email
+     * @return false|mixed
+     */
+    public function searchProfileByEmail($email)
+    {
+        $encoded_email = urlencode($email);
+        $response_body = $this->requestV3("api/profiles/?filter=equals(email,'$encoded_email')", self::HTTP_GET);
+        $this->_klaviyoLogger->log(json_encode($response_body));
+        if (empty($response_body[self::DATA_KEY_PAYLOAD])) {
+            return false;
+        } else {
+            $id = $response_body[self::DATA_KEY_PAYLOAD][0][self::ID_KEY_PAYLOAD];
+            return [
+                'response' => $response_body,
+                'profile_id' => $id
+            ];
+        }
+    }
+
+    /**
+     * Add a Profile to a list using profile id
+     * https://developers.klaviyo.com/en/v2023-08-15/reference/create_list_relationships
+     *
+     * @param $list_id
+     * @param $profile_id
+     * @return array|string|null
+     * @throws KlaviyoApiException
+     */
+    public function addProfileToList($list_id, $profile_id)
+    {
+        $body = array(
+            self::DATA_KEY_PAYLOAD => array(
+                array(
+                    self::TYPE_KEY_PAYLOAD => self::PROFILE_KEY_PAYLOAD,
+                    self::ID_KEY_PAYLOAD => $profile_id
+                )
+            )
+        );
+
+        $this->requestV3("api/lists/$list_id/relationships/profiles/", self::HTTP_POST, $body);
+    }
+
+    /**
+     * Create a new Profile in Klaviyo
+     * https://developers.klaviyo.com/en/v2023-08-15/reference/create_profile
+     *
+     * @param $profile_properties
+     * @return array|string|null
+     * @throws KlaviyoApiException
+     */
+    public function createProfile($profile_properties)
+    {
+        $body = array(
+            self::DATA_KEY_PAYLOAD =>
+                array(
+                    self::TYPE_KEY_PAYLOAD => self::PROFILE_KEY_PAYLOAD,
+                    self::ATTRIBUTE_KEY_PAYLOAD => $profile_properties
+                )
+
+        );
+
+        $response_body = $this->requestV3('api/profiles/', self::HTTP_POST, $body);
+        $id = $response_body[self::DATA_KEY_PAYLOAD][self::ID_KEY_PAYLOAD];
+        return [
+            'data' => $response_body,
+            'profile_id' => $id
+        ];
+    }
+
+    /**
+     * Record an event for a customer on their Klaviyo profile
+     *  https://developers.klaviyo.com/en/reference/create_client_event
+     *
+     * @param $config
+     * @return array
+     */
+    /**
+     * Record an event for a customer on their Klaviyo profile
+     * https://developers.klaviyo.com/en/v2023-08-15/reference/create_event
+     *
+     * @param $config
+     * @return array
+     * @throws KlaviyoApiException
+     * @throws KlaviyoAuthenticationException
+     * @throws KlaviyoRateLimitException
+     */
+    public function track($config)
+    {
+        $event_time = new DateTime();
+        $event_time->setTimestamp($config['time'] ?? time());
+
+        $body = array(
+            self::DATA_KEY_PAYLOAD => array(
+                self::TYPE_KEY_PAYLOAD => self::EVENT_VALUE_PAYLOAD,
+                self::ATTRIBUTE_KEY_PAYLOAD =>
+                    $this->buildEventProperties($config['properties'], $event_time->format('Y-m-d\TH:i:s'), $config['event']) +
+                    $this->buildCustomerProperties($config['customer_properties'])
+            )
+        );
+
+        return $this->requestV3('/api/events/', self::HTTP_POST, $body);
+    }
+
+    /**
+     * Subscribe members to a Klaviyo list
+     * https://developers.klaviyo.com/en/reference/subscribe_profiles
+     *
+     * @param $listId
+     * @param $profiles
+     * @return array
+     * @throws KlaviyoApiException
+     * @throws KlaviyoAuthenticationException
+     * @throws KlaviyoRateLimitException
+     */
+    public function subscribeMembersToList($listId, $profiles)
+    {
+        $body = array(
+            self::DATA_KEY_PAYLOAD => array(
+                self::TYPE_KEY_PAYLOAD => self::PROFILE_SUBSCRIPTION_BULK_CREATE_JOB_PAYLOAD_KEY,
+                self::ATTRIBUTE_KEY_PAYLOAD => array(
+                    self::CUSTOM_SOURCE_PAYLOAD_KEY => self::MAGENTO_TWO_PAYLOAD_VALUE,
+                    self::PROFILES_PAYLOAD_KEY => array(
+                        self::DATA_KEY_PAYLOAD => $profiles
+                    )
+                ),
+                self::RELATIONSHIPS_PAYLOAD_KEY => array(
+                    self::LIST_PAYLOAD_KEY => array(
+                        self::DATA_KEY_PAYLOAD => array(
+                            self::TYPE_KEY_PAYLOAD => self::LIST_PAYLOAD_KEY,
+                            self::ID_KEY_PAYLOAD => $listId
+                        )
+                    )
+                )
+            )
+        );
+
+        return $this->requestV3('/api/profile-subscription-bulk-create-jobs/', self::HTTP_POST, $body);
+    }
+
+
+    /**
+     * @param string $email
+     * @return array|null|string
+     */
+    public function unsubscribeEmailFromKlaviyoList($email, $listId)
+    {
+        $body = array(
+            self::DATA_KEY_PAYLOAD => array(
+                self::TYPE_KEY_PAYLOAD => self::PROFILE_SUBSCRIPTION_BULK_DELETE_JOB_PAYLOAD_KEY,
+                self::ATTRIBUTE_KEY_PAYLOAD => array(
+                    self::PROFILES_PAYLOAD_KEY => array(
+                        self::DATA_KEY_PAYLOAD => array(
+                            array(
+                                self::TYPE_KEY_PAYLOAD => self::PROFILE_KEY_PAYLOAD,
+                                self::ATTRIBUTE_KEY_PAYLOAD => array(
+                                    'email' => $email
+                                )
+                            )
+                        )
+                    )
+                ),
+                self::RELATIONSHIPS_PAYLOAD_KEY => array(
+                    self::LIST_PAYLOAD_KEY => array(
+                        self::DATA_KEY_PAYLOAD => array(
+                            self::TYPE_KEY_PAYLOAD => self::LIST_PAYLOAD_KEY,
+                            self::ID_KEY_PAYLOAD => $listId
+                        )
+                    )
+                )
+            )
+        );
+
+        return $this->requestV3('/api/profile-subscription-bulk-delete-jobs/', self::HTTP_POST, $body);
+    }
+
+    /**
+     * Request method used by all API methods to make calls
+     *
+     * @param $path
+     * @param $method
+     * @param $body
+     * @param $attempt
+     * @return array|string|null
+     * @throws KlaviyoApiException
+     * @throws KlaviyoAuthenticationException
+     * @throws KlaviyoRateLimitException
+     */
+    protected function requestV3($path, $method = null, $body = null, $attempt = 0)
+    {
+        $curl = curl_init();
+        $options = array(
+                CURLOPT_URL => self::KLAVIYO_HOST . $path,
+            ) + $this->getHeaders() + $this->getDefaultCurlOptions($method);
+
+        curl_setopt_array($curl, $options);
+
+        if ($body !== null) {
+            curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($body));
+        }
+
+        $response = curl_exec($curl);
+        $phpVersionHttpCode = version_compare(phpversion(), '5.5.0', '>') ? CURLINFO_RESPONSE_CODE : CURLINFO_HTTP_CODE;
+        $statusCode = curl_getinfo($curl, $phpVersionHttpCode);
+        // In the event that the curl_exec fails for whatever reason, it responds with `false`,
+        // Implementing a timeout and retry mechanism which will attempt the API call 3 times at 5 second intervals
+        if ($statusCode < 200 || $statusCode >= 300 || $response === false) {
+            if ($attempt < 3) {
+                sleep(1);
+                $this->requestV3($path, $method, $body, $attempt + 1);
+            } else {
+                $this->handleAPIResponse($response, $statusCode);
+            }
+        }
+        curl_close($curl);
+
+        return $this->handleAPIResponse($response, $statusCode);
+    }
+
+    /**
+     * Build Event Properties for the api/events endpoint
+     *
+     * @param $eventProperties
+     * @param $time
+     * @param $metric
+     * @return array
+     */
+    public function buildEventProperties($eventProperties, $time, $metric)
+    {
+        return array(
+            self::PROPERTIES_KEY_PAYLOAD => $eventProperties,
+            self::TIME_KEY_PAYLOAD => $time,
+            self::VALUE_KEY_PAYLOAD => $eventProperties[self::VALUE_KEY_PAYLOAD_OLD],
+            self::METRIC_KEY_PAYLOAD => array(
+                self::DATA_KEY_PAYLOAD => array(
+                    self::TYPE_KEY_PAYLOAD => self::METRIC_KEY_PAYLOAD,
+                    self::ATTRIBUTE_KEY_PAYLOAD => array(
+                        self::NAME_KEY_PAYLOAD => $metric,
+                        self::SERVICE_PAYLOAD_KEY => self::MAGENTO_TWO_INTEGRATION_SERVICE_KEY
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * Build customer properties for the api/events endpoint
+     *
+     * @param $customerProperties
+     * @return array[][]
+     */
+    public function buildCustomerProperties($customerProperties)
+    {
+        $kl_properties = [];
+
+        foreach (array_keys(self::CUSTOMER_PROPERTIES_MAP) as $property_name) {
+            if (isset($customerProperties[$property_name])) {
+                $kl_properties[self::CUSTOMER_PROPERTIES_MAP[$property_name]] = $customerProperties[$property_name];
+                unset($customerProperties[$property_name]);
+            }
+        }
+
+        $data = array(
+            self::TYPE_KEY_PAYLOAD => self::PROFILE_KEY_PAYLOAD,
+            self::ATTRIBUTE_KEY_PAYLOAD => $kl_properties,
+            self::PROPERTIES => $customerProperties,
+        );
+
+        if (isset($customerProperties['$id'])) {
+            $data[self::ID_KEY_PAYLOAD] = $customerProperties['$id'];
+            unset($customerProperties['$id']);
+        }
+
+        return array(
+            self::PROFILE_KEY_PAYLOAD => array(
+                self::DATA_KEY_PAYLOAD => $data
+            )
+        );
+    }
+
+    /**
+     * Get base options array for curl request.
+     *
+     * @return array
+     */
+    #[\ReturnTypeWillChange]
+    protected function getDefaultCurlOptions($method)
+    {
+        return array(
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_ENCODING => "",
+            CURLOPT_MAXREDIRS => 10,
+            CURLOPT_TIMEOUT => 30,
+            CURLOPT_CUSTOMREQUEST => $method,
+        );
+    }
+
+    /**
+     * Handle the API response and return the parsed data.
+     *
+     * @param string $response The raw API response.
+     * @param int $statusCode The HTTP status code of the response.
+     * @return array| string |null An array containing the parsed data or null on error.
+     * @throws KlaviyoApiException
+     * @throws KlaviyoAuthenticationException
+     * @throws KlaviyoRateLimitException
+     */
+    protected function handleAPIResponse($response, $statusCode)
+    {
+        $decoded_response = $this->decodeJsonResponse($response);
+        if ($statusCode == 401) {
+            throw new KlaviyoAuthenticationException(self::ERROR_NOT_AUTHORIZED, $statusCode);
+        } elseif ($statusCode == 403) {
+            throw new KlaviyoAuthenticationException(self::ERROR_FORBIDDEN, $statusCode);
+        } elseif ($statusCode == 429) {
+            throw new KlaviyoRateLimitException(
+                self::ERROR_RATE_LIMIT_EXCEEDED
+            );
+        } elseif ($statusCode < 200 || $statusCode >= 300) {
+            throw new KlaviyoApiException(isset($decoded_response['errors']) ? $decoded_response['errors'][0]['detail'] : sprintf(self::ERROR_NON_200_STATUS, $statusCode), $statusCode);
+        }
+
+        return $decoded_response;
+    }
+
+    /**
+     * Return decoded JSON response as associative or empty array.
+     * Certain Klaviyo endpoints (such as Delete) return an empty string on success
+     * and so PHP versions >= 7 will throw a JSON_ERROR_SYNTAX when trying to decode it
+     *
+     * @param string $response
+     * @return mixed
+     * @throws KlaviyoException
+     */
+    private function decodeJsonResponse($response)
+    {
+        if (!empty($response)) {
+            try {
+                return json_decode($response, true);
+            } catch (Exception $e) {
+                throw new KlaviyoException(self::ERROR_MALFORMED_RESPONSE_BODY);
+            }
+        }
+
+        return json_decode('{}', true);
+    }
+}

--- a/Model/Config/Source/ListOptions.php
+++ b/Model/Config/Source/ListOptions.php
@@ -7,6 +7,21 @@ class ListOptions implements \Magento\Framework\Option\ArrayInterface
     const LABEL = 'label';
     const VALUE = 'value';
 
+    /**
+     * @var \Magento\Framework\Message\ManagerInterface
+     */
+    protected $messageManager;
+
+    /**
+     * @var \Klaviyo\Reclaim\Helper\ScopeSetting
+     */
+    protected $_klaviyoScopeSetting;
+
+    /**
+     * @var \Klaviyo\Reclaim\Helper\Data
+     */
+    protected $_dataHelper;
+
     public function __construct(
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Klaviyo\Reclaim\Helper\ScopeSetting $_klaviyoScopeSetting,
@@ -36,7 +51,7 @@ class ListOptions implements \Magento\Framework\Option\ArrayInterface
         $result = $this->_dataHelper->getKlaviyoLists();
         if (!$result['success']) {
             return [[
-                self::LABEL => $result['reason'] . ' To sync newsletter subscribers to Klaviyo, update the <strong>Private Klaviyo API Key</strong> on the "General" tab.',
+                self::LABEL => $result['error'] . ' Error: To sync newsletter subscribers to Klaviyo, update the <strong>Private Klaviyo API Key</strong> on the "General" tab.',
                 self::VALUE => 0
             ]];
         }
@@ -48,8 +63,8 @@ class ListOptions implements \Magento\Framework\Option\ArrayInterface
             ]];
         }
 
-        $options = array_map(function($list) {
-            return [self::LABEL => $list->list_name, self::VALUE => $list->list_id];
+        $options = array_map(function ($list) {
+            return [self::LABEL => $list['name'], self::VALUE => $list['id']];
         }, $result['lists']);
 
         $default_value = [

--- a/Observer/UserProfileNewsletterSubscribeObserver.php
+++ b/Observer/UserProfileNewsletterSubscribeObserver.php
@@ -34,9 +34,7 @@ class UserProfileNewsletterSubscribeObserver implements ObserverInterface
 
           if ($subscriber->isSubscribed()) {
             $this->_dataHelper->subscribeEmailToKlaviyoList(
-                $customer->getEmail(),
-                $customer->getFirstname(),
-                $customer->getLastname()
+                $customer->getEmail()
             );
           } else {
             $this->_dataHelper->unsubscribeEmailFromKlaviyoList($customer->getEmail());

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "3.0.4",
+    "version": "3.0.4-patch",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="3.0.4" schema_version="3.0.4">
+  <module name="Klaviyo_Reclaim" setup_version="3.0.4-patch" schema_version="3.0.4-patch">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>

--- a/view/frontend/templates/product/viewed.phtml
+++ b/view/frontend/templates/product/viewed.phtml
@@ -3,10 +3,10 @@
 ?>
 
 <script text="text/javascript">
-  require(['domReady!'], function () {
-    var _learnq = window._learnq || [];
-    _learnq.push(['track', 'Viewed Product', <?= $block->getViewedProductJson() ?>]);
-    _learnq.push(['trackViewedItem', <?= $block->getViewedItemJson() ?>]);
-  });
+    !function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return"push"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t="function"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();
+    require(['domReady!'], function () {
+        var klaviyo = window.klaviyo || [];
+        klaviyo.push(['track', 'Viewed Product', <?= $block->getViewedProductJson() ?>]);
+        klaviyo.push(['trackViewedItem', <?= $block->getViewedItemJson() ?>]);
+    });
 </script>
-

--- a/view/frontend/web/js/customer.js
+++ b/view/frontend/web/js/customer.js
@@ -1,18 +1,22 @@
+!function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return"push"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t="function"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();
+
 define([
     'underscore',
     'Magento_Customer/js/customer-data',
     'domReady!'
 ], function (_, customerData) {
     'use strict';
-    
-    var _learnq = window._learnq || [];
+
+    var klaviyo = window.klaviyo || [];
     var customer = customerData.get('customer')();
 
-    if(_.has(customer, 'email') && customer.email) {
-        _learnq.push(['identify', {
-            $email: customer.email,
-            $first_name: _.has(customer, 'firstname') ? customer.firstname : '',
-            $last_name:  _.has(customer, 'lastname') ? customer.lastname : ''
-        }]);
-    }
+    klaviyo.isIdentified().then((identified)=> {
+        if (!identified && customer.email && _.has(customer,'email')) {
+            klaviyo.identify({
+                '$email': customer.email,
+                '$first_name': _.has(customer, 'firstname') ? customer.firstname : '',
+                '$last_name':  _.has(customer, 'lastname') ? customer.lastname : ''
+            })
+        }
+    });
 });

--- a/view/frontend/web/js/view/checkout/email.js
+++ b/view/frontend/web/js/view/checkout/email.js
@@ -1,3 +1,4 @@
+!function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return"push"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t="function"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();
 define([
   'uiComponent',
   'jquery',
@@ -29,7 +30,7 @@ define([
       }
     },
     isKlaviyoActive: function() {
-      return !!(window._learnq && window._learnq.identify);
+      return !window.klaviyo;
     },
     bindEmailListener: function () {
       // jquery overrides this, so let's create an instance of the parent
@@ -41,11 +42,15 @@ define([
         }
 
         self._email = jQuery(this).val();
-        if (!window._learnq.identify().email) {
-          window._learnq.push(['identify', {
-            '$email': self._email
-          }]);
-        }
+
+        klaviyo.isIdentified().then((identified)=> {
+          if (!identified) {
+            klaviyo.push(['identify', {
+              '$email': self._email
+            }]);
+          }
+        })
+
         self.postUserEmail(self._email);
       });
     },


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Adds a patch for extension version 3.0.4 to switch it over to Klaviyo's V3 APIs ahead of the V1/V2 API retirement. 

**This patch only updates the extension to use Klaviyo's v3 APIs. No other bug fixes were made as part of this work.**


## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Tested on a 2.3.3 store locally

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [x] **Internal Only** - If this is a release, please confirm the following:
  - [x] The links in the changelog have been updated to point towards the new versions
  - [x] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
