### PR TITLE
Fix customer custom properties KlaviyoV3Api.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Fixed
+- Updated KlaviyoV3Api to fix the profile properties sent in events to match the format required the V3 API 
+
 ### [4.1.2] - 2024-01-31
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added StoreId and SimpleProductId fields to Added to Cart event.
 
 #### Fixed
-- Updated KlaviyoV3Api to fix the profile properties sent in events to match the format required the V3 API 
+- Updated KlaviyoV3Api to fix the profile properties sent in events to match the format required the V3 API
 
 ### [4.1.3] - 2024-03-29
 

--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -430,7 +430,7 @@ class KlaviyoV3Api
             unset($customerProperties['$id']);
         }
 
-        if(!empty($customerProperties)) {
+        if (!empty($customerProperties)) {
             $data[self::ATTRIBUTE_KEY_PAYLOAD][self::PROPERTIES] = $customerProperties;
         }
 

--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -422,13 +422,16 @@ class KlaviyoV3Api
 
         $data = array(
             self::TYPE_KEY_PAYLOAD => self::PROFILE_KEY_PAYLOAD,
-            self::ATTRIBUTE_KEY_PAYLOAD => $kl_properties,
-            self::PROPERTIES => $customerProperties,
+            self::ATTRIBUTE_KEY_PAYLOAD => $kl_properties
         );
 
         if (isset($customerProperties['$id'])) {
             $data[self::ID_KEY_PAYLOAD] = $customerProperties['$id'];
             unset($customerProperties['$id']);
+        }
+
+        if(!empty($customerProperties)) {
+            $data[self::ATTRIBUTE_KEY_PAYLOAD][self::PROPERTIES] = $customerProperties;
         }
 
         return array(


### PR DESCRIPTION
Hey, you've formatted the properties incorrectly, in the profile object, in properties is a child of data / attributes - see https://jsonformatter.org/fa628e for reference which was taken from the API example on Klaviyo

## Description
Fixes bug with sending custom data on a profile to Klaviyo events API

## Manual Testing Steps

This is an event we sync to Klaviyo that updates a customer profile. This field is no longer updating the contact. I've checked the API documentation and I have found this bug. 

     {"data":{"type":"event","attributes":{"properties":{"$value":null},"time":"2024-02-06T13:46:34","value":null,"metric":{"data":{"type":"metric","attributes":{"name":"Customer Sync","service":"magentotwo"}}},"profile":{"data":{"type":"profile","attributes":{"email":"bcedd554123b00cff993@redacted.com","first_name":"Leila","last_name":"Test"},"properties":{"$first_name":"Leila","$last_name":"Test","email":"bcedd554123b00cff993@redacted.com","$nhs_last_date":"2024-02-06","nhs_last_date":"2024-02-06"}}}}}}