### PR TITLE
Updates Added to Cart event to use simple product images where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [Unreleased]
 
 #### Changed
-- Updated Added to Cart events to show preference to simple product images over configurable product images. 
+- Updated Added to Cart events to show preference to simple product images over configurable product images.
 - Added StoreId and SimpleProductId fields to Added to Cart event.
 
 ### [4.1.3] - 2024-03-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Changed
+- Updated Added to Cart events to show preference to simple product images over configurable product images. 
+- Added StoreId and SimpleProductId fields to Added to Cart event.
+
 ### [4.1.3] - 2024-03-29
 
 #### Fixed

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -146,7 +146,6 @@ class KlSyncs
                         $storeId = '';
                         if (isset($decodedPayload['StoreId'])) {
                             $storeId = $decodedPayload['StoreId'];
-                            unset($decodedPayload['StoreId']);
                         }
 
                         $response = $this->_dataHelper->klaviyoTrackEvent(

--- a/Observer/SalesQuoteProductAddAfter.php
+++ b/Observer/SalesQuoteProductAddAfter.php
@@ -201,7 +201,8 @@ class SalesQuoteProductAddAfter implements ObserverInterface
      * @param $addedItem
      * @return mixed
      */
-    public function getSimpleProductForEvent($addedItem) {
+    public function getSimpleProductForEvent($addedItem)
+    {
         # try to grab the simple product
         $simpleProduct = null;
         try {
@@ -210,7 +211,8 @@ class SalesQuoteProductAddAfter implements ObserverInterface
             } elseif ($addedItem->getProductType() == "simple") {
                 $simpleProduct = $addedItem->getProduct();
             }
-        } catch (NoSuchEntityException $ex) {}
+        } catch (NoSuchEntityException $ex) {
+        }
         return $simpleProduct;
     }
 


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Previously we synced the configurable product image path instead of the simple product that was added to the cart. This PR updates that behavior to use the simple product image if applicable, and fall back on the configurable product if we cannot find an image on the simple product. 

It also adds 2 new event fields for Added to cart: StoreId and AddedSimpleProductId. These are stored at the top level and can be used for additional filtration or use in catalog tags in email templates. 

## Manual Testing Steps
1. Tested simple products, bundles, groups, and configurable products. Made sure the correct fields were syncing to klaviyo. Validated that the behavior for bundles and grouped products was unchanged. Verified that simple product information is syncing correctly for simple product and configurable product carts. 

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Tested 

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
