### PR TITLE
Adds urlencode to email before search request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Added to Cart events to show preference to simple product images over configurable product images.
 - Added StoreId and SimpleProductId fields to Added to Cart event.
 
+#### Fixed
+- Properly encodes emails before search request to Klaviyo
+
 ### [4.1.3] - 2024-03-29
 
 #### Fixed

--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -165,7 +165,8 @@ class KlaviyoV3Api
      */
     public function searchProfileByEmail($email)
     {
-        $response_body = $this->requestV3("api/profiles/?filter=equals(email,'$email')", self::HTTP_GET);
+        $encoded_email = urlencode($email);
+        $response_body = $this->requestV3("api/profiles/?filter=equals(email,'$encoded_email')", self::HTTP_GET);
 
         if (empty($response_body[self::DATA_KEY_PAYLOAD])) {
             return false;


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Fixes a bug where we weren't url encoding emails before requesting the `api/profiles/` endpoint. For emails containing special characters this was resulting in misses on the search and the following request to create the new profile would fail because it does already exist. 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Selected to **not** use Klaviyo's opt-in settings in the extension settings. Then filled out the M2 footer form with an email that already existed in Klaviyo, made sure it was properly added to list. 
2. Tested the same as above but with a new email that didn't exist in Klaviyo. 

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
