### PR TITLE
Adds StoreID field to Added to Cart and Viewed Product events

### DIFF
--- a/Block/Catalog/Product/ViewedProduct.php
+++ b/Block/Catalog/Product/ViewedProduct.php
@@ -200,7 +200,8 @@ class ViewedProduct extends Template
             'URL' => $_product->getProductUrl(),
             'Price' => $this->getPrice(),
             'FinalPrice' => $this->getFinalPrice(),
-            'Categories' => $this->getProductCategories()
+            'Categories' => $this->getProductCategories(),
+            'StoreID' => $this->_klaviyoScopeSetting->storeId
         ];
 
         if ($this->getProductImage()) {
@@ -224,7 +225,8 @@ class ViewedProduct extends Template
             'Categories' => $this->getProductCategories(),
             'Metadata' => array(
                 'Price' => $this->getPrice()
-            )
+            ),
+            'StoreID' => $this->_klaviyoScopeSetting->storeId
         ];
 
         if ($this->getProductImage()) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Added
+- Adds StoreID field to Viewed Product events
+
+#### Changed
+- Updates StoreId field to StoreID for Added to Cart events
+
 ### [4.1.4] - 2024-05-22
 
 #### Changed

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -144,8 +144,8 @@ class KlSyncs
 
                         //TODO: if conditional for backward compatibility, needs to be removed in future versions
                         $storeId = '';
-                        if (isset($decodedPayload['StoreId'])) {
-                            $storeId = $decodedPayload['StoreId'];
+                        if (isset($decodedPayload['StoreID'])) {
+                            $storeId = $decodedPayload['StoreID'];
                         }
 
                         $response = $this->_dataHelper->klaviyoTrackEvent(

--- a/Helper/ScopeSetting.php
+++ b/Helper/ScopeSetting.php
@@ -52,7 +52,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * @var int
      */
-    protected $_storeId;
+    public $storeId;
 
     /**
      * @var \Magento\Framework\Module\ModuleListInterface
@@ -75,7 +75,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_scopeConfig = $context->getScopeConfig();
         $this->_request = $context->getRequest();
         $this->_state = $state;
-        $this->_storeId = $storeManager->getStore()->getId();
+        $this->storeId = $storeManager->getStore()->getId();
         $this->_moduleList = $moduleList;
         $this->_configWriter = $configWriter;
     }
@@ -114,7 +114,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
             $scopedWebsiteCode = $this->_request->getParam('website');
         } else {
             // In frontend area. Only concerned with store for frontend.
-            $scopedStoreCode = $this->_storeId;
+            $scopedStoreCode = $this->storeId;
         }
 
         if (isset($scopedStoreCode)) {
@@ -142,7 +142,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
             $scopedWebsiteCode = $this->_request->getParam('website');
         } else {
             // In frontend area. Only concerned with store for frontend.
-            $scopedStoreCode = $this->_storeId;
+            $scopedStoreCode = $this->storeId;
         }
 
         if (isset($scopedStoreCode)) {

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -98,7 +98,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Setting QuoteId at this point since the MaskedQuoteId is not updated when this event is dispatched,
         $klAddedToCartPayload['QuoteId'] = isset($encodedCustomerId) ? "kx_identifier_$encodedCustomerId" : $quote->getId();
         // Setting StoreId in payload
-        $klAddedToCartPayload['StoreId'] = $quote->getStoreId();
+        $klAddedToCartPayload['StoreID'] = $quote->getStoreId();
 
         $stringifiedPayload = json_encode($klAddedToCartPayload);
 


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Will allow for filtering within Klaviyo on StoreID. This matches the field that we sync on app-side events (Placed Order, Ordered Product, etc). 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Tested events using local magento instance on 2.4.6

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
