### PR TITLE
Revert "Adds StoreID field to Added to Cart and Viewed Product events"

### DIFF
--- a/Block/Catalog/Product/ViewedProduct.php
+++ b/Block/Catalog/Product/ViewedProduct.php
@@ -200,8 +200,7 @@ class ViewedProduct extends Template
             'URL' => $_product->getProductUrl(),
             'Price' => $this->getPrice(),
             'FinalPrice' => $this->getFinalPrice(),
-            'Categories' => $this->getProductCategories(),
-            'StoreID' => $this->_klaviyoScopeSetting->storeId
+            'Categories' => $this->getProductCategories()
         ];
 
         if ($this->getProductImage()) {
@@ -225,8 +224,7 @@ class ViewedProduct extends Template
             'Categories' => $this->getProductCategories(),
             'Metadata' => array(
                 'Price' => $this->getPrice()
-            ),
-            'StoreID' => $this->_klaviyoScopeSetting->storeId
+            )
         ];
 
         if ($this->getProductImage()) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
-#### Added
-- Adds StoreID field to Viewed Product events
-
-#### Changed
-- Updates StoreId field to StoreID for Added to Cart events
-
 ### [4.1.4] - 2024-05-22
 
 #### Changed

--- a/Cron/KlSyncs.php
+++ b/Cron/KlSyncs.php
@@ -144,8 +144,8 @@ class KlSyncs
 
                         //TODO: if conditional for backward compatibility, needs to be removed in future versions
                         $storeId = '';
-                        if (isset($decodedPayload['StoreID'])) {
-                            $storeId = $decodedPayload['StoreID'];
+                        if (isset($decodedPayload['StoreId'])) {
+                            $storeId = $decodedPayload['StoreId'];
                         }
 
                         $response = $this->_dataHelper->klaviyoTrackEvent(

--- a/Helper/ScopeSetting.php
+++ b/Helper/ScopeSetting.php
@@ -52,7 +52,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * @var int
      */
-    public $storeId;
+    protected $_storeId;
 
     /**
      * @var \Magento\Framework\Module\ModuleListInterface
@@ -75,7 +75,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_scopeConfig = $context->getScopeConfig();
         $this->_request = $context->getRequest();
         $this->_state = $state;
-        $this->storeId = $storeManager->getStore()->getId();
+        $this->_storeId = $storeManager->getStore()->getId();
         $this->_moduleList = $moduleList;
         $this->_configWriter = $configWriter;
     }
@@ -114,7 +114,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
             $scopedWebsiteCode = $this->_request->getParam('website');
         } else {
             // In frontend area. Only concerned with store for frontend.
-            $scopedStoreCode = $this->storeId;
+            $scopedStoreCode = $this->_storeId;
         }
 
         if (isset($scopedStoreCode)) {
@@ -142,7 +142,7 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
             $scopedWebsiteCode = $this->_request->getParam('website');
         } else {
             // In frontend area. Only concerned with store for frontend.
-            $scopedStoreCode = $this->storeId;
+            $scopedStoreCode = $this->_storeId;
         }
 
         if (isset($scopedStoreCode)) {

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -98,7 +98,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Setting QuoteId at this point since the MaskedQuoteId is not updated when this event is dispatched,
         $klAddedToCartPayload['QuoteId'] = isset($encodedCustomerId) ? "kx_identifier_$encodedCustomerId" : $quote->getId();
         // Setting StoreId in payload
-        $klAddedToCartPayload['StoreID'] = $quote->getStoreId();
+        $klAddedToCartPayload['StoreId'] = $quote->getStoreId();
 
         $stringifiedPayload = json_encode($klAddedToCartPayload);
 


### PR DESCRIPTION
Reverts klaviyo/magento2-klaviyo#303

got too late to the jump on this one - too many accounts are on 4.1.4 using `StoreId`. We are gonna leave it in to avoid introducing breaking changes