### PR TITLE
Adds external_catalog_id and integration_key to M2 events.

### DIFF
--- a/Block/Catalog/Product/ViewedProduct.php
+++ b/Block/Catalog/Product/ViewedProduct.php
@@ -2,6 +2,7 @@
 
 namespace Klaviyo\Reclaim\Block\Catalog\Product;
 
+use Klaviyo\Reclaim\Helper\Logger;
 use Klaviyo\Reclaim\Helper\ScopeSetting;
 use Magento\Catalog\Helper\Image;
 use Magento\Framework\Registry;
@@ -17,6 +18,12 @@ class ViewedProduct extends Template
     protected $price = 0;
 
     /**
+     * Klaviyo Logger
+     * @var Logger
+     */
+    protected $_klaviyoLogger;
+
+    /**
      * @var Magento\Catalog\Helper\Image
      */
     private $imageHelper;
@@ -25,6 +32,7 @@ class ViewedProduct extends Template
      * ViewedProduct constructor.
      * @param Context $context
      * @param ScopeSetting $klaviyoScopeSetting
+     * @param Logger $klaviyoLogger
      * @param Registry $registry
      * @param Image $imageHelper
      * @param array $data
@@ -32,11 +40,14 @@ class ViewedProduct extends Template
     public function __construct(
         Context $context,
         ScopeSetting $klaviyoScopeSetting,
+        Logger $klaviyoLogger,
         Registry $registry,
         Image $imageHelper,
         array $data = []
     ) {
+//        $this->_storeManager = $context->getStoreManager();
         parent::__construct($context, $data);
+        $this->_klaviyoLogger = $klaviyoLogger;
         $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
         $this->_registry = $registry;
         $this->imageHelper = $imageHelper;
@@ -191,9 +202,11 @@ class ViewedProduct extends Template
      */
     public function getViewedProductJson()
     {
+        $this->_klaviyoLogger->log($this->_storeManager->getStore()->getId());
         $_product = $this->getProduct();
 
         $result = [
+            'external_catalog_id' => (string) $this->_storeManager->getStore()->getId(),
             'ProductID' => $_product->getId(),
             'Name' => $_product->getName(),
             'SKU' => $_product->getSku(),

--- a/Block/Catalog/Product/ViewedProduct.php
+++ b/Block/Catalog/Product/ViewedProduct.php
@@ -2,8 +2,8 @@
 
 namespace Klaviyo\Reclaim\Block\Catalog\Product;
 
-use Klaviyo\Reclaim\Helper\Logger;
 use Klaviyo\Reclaim\Helper\ScopeSetting;
+use Klaviyo\Reclaim\Helper\Data;
 use Magento\Catalog\Helper\Image;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Element\Template;
@@ -16,12 +16,7 @@ class ViewedProduct extends Template
     protected $imageUrl = null;
     protected $categories = [];
     protected $price = 0;
-
-    /**
-     * Klaviyo Logger
-     * @var Logger
-     */
-    protected $_klaviyoLogger;
+    const INTEGRATION_KEY = 'magento_two';
 
     /**
      * @var Magento\Catalog\Helper\Image
@@ -32,25 +27,24 @@ class ViewedProduct extends Template
      * ViewedProduct constructor.
      * @param Context $context
      * @param ScopeSetting $klaviyoScopeSetting
-     * @param Logger $klaviyoLogger
      * @param Registry $registry
      * @param Image $imageHelper
+     * @param Data $dataHelper
      * @param array $data
      */
     public function __construct(
         Context $context,
         ScopeSetting $klaviyoScopeSetting,
-        Logger $klaviyoLogger,
         Registry $registry,
         Image $imageHelper,
+        Data $dataHelper,
         array $data = []
     ) {
-//        $this->_storeManager = $context->getStoreManager();
         parent::__construct($context, $data);
-        $this->_klaviyoLogger = $klaviyoLogger;
         $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
         $this->_registry = $registry;
         $this->imageHelper = $imageHelper;
+        $this->_dataHelper = $dataHelper;
     }
 
     /**
@@ -202,11 +196,16 @@ class ViewedProduct extends Template
      */
     public function getViewedProductJson()
     {
-        $external_catalog_id = $this->_storeManager->getStore()->getWebsiteId() . '-' . $this->_storeManager->getStore()->getId();
+        $external_catalog_id = $this->_dataHelper->getExternalCatalogIdForEvent(
+            $this->_storeManager->getStore()->getWebsiteId(),
+            $this->_storeManager->getStore()->getId()
+        );
+
         $_product = $this->getProduct();
 
         $result = [
             'external_catalog_id' => $external_catalog_id,
+            'integration_key' => self::INTEGRATION_KEY,
             'ProductID' => $_product->getId(),
             'Name' => $_product->getName(),
             'SKU' => $_product->getSku(),

--- a/Block/Catalog/Product/ViewedProduct.php
+++ b/Block/Catalog/Product/ViewedProduct.php
@@ -202,11 +202,11 @@ class ViewedProduct extends Template
      */
     public function getViewedProductJson()
     {
-        $this->_klaviyoLogger->log($this->_storeManager->getStore()->getId());
+        $external_catalog_id = $this->_storeManager->getStore()->getWebsiteId() . '-' . $this->_storeManager->getStore()->getId();
         $_product = $this->getProduct();
 
         $result = [
-            'external_catalog_id' => (string) $this->_storeManager->getStore()->getId(),
+            'external_catalog_id' => $external_catalog_id,
             'ProductID' => $_product->getId(),
             'Name' => $_product->getName(),
             'SKU' => $_product->getSku(),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Added
+- Add 'external_catalog_id' and 'integration_key' to Viewed Product and Added To Cart events.
+
 #### Fixed
 - Fixed Deprecated use of base64_encode in Observer/SalesQuoteSaveAfter.php
 - Fixed profile identification on checkout page

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -185,4 +185,17 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $api = new KlaviyoV3Api($this->_klaviyoScopeSetting->getPublicApiKey($storeId), $this->_klaviyoScopeSetting->getPrivateApiKey($storeId), $this->_klaviyoScopeSetting, $this->_klaviyoLogger);
         return $api->track($params);
     }
+
+    /**
+     * Get the external catalog ID for an event. This is used to link events to a specific scoped catalog in Klaviyo, so that
+     * profile interest events can be connected to a specific scoped product when building flow audiences.
+     *
+     * @param int $website_id
+     * @param int $store_id
+     * @return string
+     */
+    public function getExternalCatalogIdForEvent($website_id, $store_id)
+    {
+        return $website_id . '-' . $store_id;
+    }
 }

--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -68,8 +68,6 @@ class KlaviyoV3Api
     const PROFILES_PAYLOAD_KEY = 'profiles';
     const CUSTOM_SOURCE_PAYLOAD_KEY = 'custom_source';
     const MAGENTO_TWO_PAYLOAD_VALUE = 'Magento Two';
-    const MAGENTO_TWO_INTEGRATION_SERVICE_KEY = 'magentotwo';
-    const SERVICE_PAYLOAD_KEY = 'service';
 
     /**
      * @var string
@@ -396,8 +394,7 @@ class KlaviyoV3Api
                 self::DATA_KEY_PAYLOAD => array(
                     self::TYPE_KEY_PAYLOAD => self::METRIC_KEY_PAYLOAD,
                     self::ATTRIBUTE_KEY_PAYLOAD => array(
-                        self::NAME_KEY_PAYLOAD => $metric,
-                        self::SERVICE_PAYLOAD_KEY => self::MAGENTO_TWO_INTEGRATION_SERVICE_KEY
+                        self::NAME_KEY_PAYLOAD => $metric
                     )
                 )
             )

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -100,6 +100,9 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Setting StoreId in payload
         $klAddedToCartPayload['StoreId'] = $quote->getStoreId();
 
+        // Setting external_catalog_id in payload - this connects the event to the right localized product in the klaviyo catalog and should not be changed
+        $klAddedToCartPayload['external_catalog_id'] = (string) $quote->getStoreId();
+
         $stringifiedPayload = json_encode($klAddedToCartPayload);
 
         // Check payload length to avoid truncated data being saved to payload column

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -14,6 +14,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
 {
     // Character limit for a TEXT datatype field
     const PAYLOAD_CHARACTER_LIMIT = 65535;
+    const INTEGRATION_KEY = 'magento_two';
 
     /**
      * Klaviyo Scope setting Helper
@@ -100,8 +101,10 @@ class SalesQuoteSaveAfter implements ObserverInterface
         // Setting StoreId in payload
         $klAddedToCartPayload['StoreId'] = $quote->getStoreId();
 
-        // Setting external_catalog_id in payload - this connects the event to the right localized product in the klaviyo catalog and should not be changed
-        $klAddedToCartPayload['external_catalog_id'] =  $quote->getStore()->getWebsiteId() . '-' . $quote->getStoreId();
+        // Setting external_catalog_id in payload - this connects the event to the right localized product in the klaviyo catalog.
+        $klAddedToCartPayload['external_catalog_id'] = $this->_dataHelper->getExternalCatalogIdForEvent($quote->getStore()->getWebsiteId(), $quote->getStoreId());
+
+        $klAddedToCartPayload['integration_key'] = self::INTEGRATION_KEY;
 
         $stringifiedPayload = json_encode($klAddedToCartPayload);
 

--- a/Observer/SalesQuoteSaveAfter.php
+++ b/Observer/SalesQuoteSaveAfter.php
@@ -101,7 +101,7 @@ class SalesQuoteSaveAfter implements ObserverInterface
         $klAddedToCartPayload['StoreId'] = $quote->getStoreId();
 
         // Setting external_catalog_id in payload - this connects the event to the right localized product in the klaviyo catalog and should not be changed
-        $klAddedToCartPayload['external_catalog_id'] = (string) $quote->getStoreId();
+        $klAddedToCartPayload['external_catalog_id'] =  $quote->getStore()->getWebsiteId() . '-' . $quote->getStoreId();
 
         $stringifiedPayload = json_encode($klAddedToCartPayload);
 

--- a/Test/.env.example
+++ b/Test/.env.example
@@ -1,6 +1,7 @@
 KLAVIYO_PRIVATE_KEY=pk_...
 KLAVIYO_V3_URL=a.klaviyo.com/api
 METRIC_ID_ATC=AAAAAA
+METRIC_ID_VIEWED_PRODUCT=AAAAAA
 M2_BASE_URL=https://www.example.com
 M2_ADMIN_USERNAME=someone@example.com
 M2_ADMIN_PASSWORD=astrongpassword

--- a/Test/e2e/api/viewed-product.spec.js
+++ b/Test/e2e/api/viewed-product.spec.js
@@ -4,19 +4,18 @@ const { createProfileInKlaviyo, checkEvent } = require('../utils/klaviyo-api');
 const Storefront = require('../locators/storefront');
 
 /**
- * Tests the Klaviyo event tracking functionality
+ * Tests the Klaviyo client-side tracking functionality
  *
  * Tests the following Klaviyo API functionality:
- * - Event tracking when products are added to cart
- * - Event properties including product details and cart information
+ * - Event tracking when products are viewed
+ * - Event properties including product details and external catalog id
  * - Event association with customer profiles
  *
- * @see https://developers.klaviyo.com/en/reference/create_event
+ * @see https://developers.klaviyo.com/en/docs/javascript_api#track-events-and-actions
  */
-test.describe('Added To Cart Event Tracking', () => {
-    test('should create an Added To Cart event in Klaviyo when a user adds an item to their cart', async ({ page }) => {
-        test.slow(); // this test is slow, Magento 2 syncs events every 5 minutes.
-        const klaviyoAtcMetricId = process.env.METRIC_ID_ATC;
+test.describe('Viewed Product Event Tracking', () => {
+    test('should create an Viewed Product event in Klaviyo when a user views a product', async ({ page }) => {
+        const klaviyoViewedProductMetricId = process.env.METRIC_ID_VIEWED_PRODUCT;
 
         // Navigate to a product page (using the first product from the homepage)
         const storefront = new Storefront(page);
@@ -25,14 +24,14 @@ test.describe('Added To Cart Event Tracking', () => {
         const profileId = await createProfileInKlaviyo(storefront.email);
 
         const productName = await storefront.goToProductPageAndGetProductName();
-        await storefront.addProductToCart();
+        await storefront.page.reload();
 
-        // Use exponential backoff to check for the Added To Cart event
+        // Use exponential backoff to check for the Viewed Product event
         const events = await backOff(
             async () => {
-                const results = await checkEvent(profileId, klaviyoAtcMetricId);
+                const results = await checkEvent(profileId, klaviyoViewedProductMetricId);
                 if (results.data.length === 0) {
-                    throw new Error('Added To Cart event not found yet');
+                    throw new Error('Viewed Product event not found yet');
                 }
                 return results;
             },
@@ -49,15 +48,16 @@ test.describe('Added To Cart Event Tracking', () => {
         const eventData = events.data[0].attributes.event_properties;
 
         // Validate metric data
-        expect(metricData.attributes.name).toBe('Added To Cart');
+        expect(metricData.attributes.name).toBe('Viewed Product');
         expect(metricData.attributes.integration.key).toBe('api'); // These events should be unbranded
 
         // Validate event data
-        expect(eventData.AddedItemProductName).toBe(productName.trim());
+        expect(eventData.Name).toBe(productName.trim());
+        expect(eventData.ProductID).toBe("1556");
         expect(eventData.external_catalog_id).toBe('1-1');
         expect(eventData.integration_key).toBe('magento_two');
 
         // Log success for debugging
-        console.log(`Successfully verified Added To Cart event for ${storefront.email}`);
+        console.log(`Successfully verified Viewed Product event for ${storefront.email}`);
     });
 });

--- a/Test/e2e/locators/admin.js
+++ b/Test/e2e/locators/admin.js
@@ -48,6 +48,7 @@ class Admin {
       await this.configurationLink.scrollIntoViewIfNeeded();
       await this.configurationLink.click({timeout: 15000});
       await this.page.waitForLoadState();
+      await this.klaviyoConfigLink.scrollIntoViewIfNeeded();
       await this.klaviyoConfigLink.click({timeout: 15000});
       await Promise.all([
         this.page.waitForResponse(resp => resp.request().url().includes('/admin/admin/system_config/edit/section/klaviyo_reclaim_newsletter') && resp.status() === 200, {timeout: 15000}),
@@ -107,10 +108,14 @@ class Admin {
 
   async navigateToKlaviyoConsentAtCheckoutConfig() {
     await this.page.waitForLoadState();
+    await this.storesLink.scrollIntoViewIfNeeded();
     await this.storesLink.click();
+    await this.configurationLink.scrollIntoViewIfNeeded();
     await this.configurationLink.click();
     await this.page.waitForLoadState();
+    await this.klaviyoConfigLink.scrollIntoViewIfNeeded();
     await this.klaviyoConfigLink.click();
+    await this.klaviyoConsentAtCheckoutLink.scrollIntoViewIfNeeded();
     await this.klaviyoConsentAtCheckoutLink.click();
     await this.page.waitForLoadState();
   }

--- a/Test/e2e/locators/storefront.js
+++ b/Test/e2e/locators/storefront.js
@@ -16,7 +16,10 @@ class Storefront {
 
     async goToProductPageAndGetProductName() {
         // Navigate to a product page (using the first product from the homepage)
-        await this.page.goto(`${process.env.M2_BASE_URL}/radiant-tee.html?utm_email=${this.email}`);
+        await Promise.all([
+            this.page.waitForResponse(resp => resp.url().includes(`/client/profiles/?company_id=`) && resp.status() === 202 && resp.request().method() === 'POST'),
+            this.page.goto(`${process.env.M2_BASE_URL}/radiant-tee.html?utm_email=${this.email}`),
+        ])
         await this.page.locator('.page-title').waitFor();
         // Get product details before adding to cart
         const productName = await this.page.locator('.page-title').textContent();


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Adds external_catalog_id and integration_key to the two events that are shipped from the magento 2 extension: Viewed Product, and Added to Cart. 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Tested locally on a multi-storefront account, making sure the correct catalog ids were used. 
2. Going to run through the playwright tests

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
