### PR TITLE
Add parent ids to Product extension attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
-### [4.3.2] - 2025-07-21
+### [4.4.0] - 2025-08-11
+
 #### Added
--  Add 'kl_parent_ids' extension attribute in product requests.
+- Add 'kl_parent_ids' extension attribute in product requests.
 
 #### Fixed
 - null argument to str_replace() caused by getPrice() fallback return of null instead of "0".
@@ -324,8 +325,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- END RELEASE NOTES -->
 <!-- BEGIN LINKS -->
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.3.2...HEAD
-[4.3.2]: https://github.com/klaviyo/magento2-klaviyo/compare/4.3.1...4.3.2
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.0...HEAD
+[4.4.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.3.1...4.4.0
 [4.3.1]: https://github.com/klaviyo/magento2-klaviyo/compare/4.3.0...4.3.1
 [4.3.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.2.0...4.3.0
 [4.2.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.1.4...4.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Added
+-  Add 'kl_parent_ids' extension attribute in product requests.
+
 ### [4.3.0] - 2025-04-16
 
 #### Added

--- a/Plugin/Api/AddProductRelationships.php
+++ b/Plugin/Api/AddProductRelationships.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Klaviyo\Reclaim\Plugin\Api;
+
+use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\Data\ProductSearchResultsInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+
+class AddProductRelationships
+{
+    protected $configurableProductType;
+
+    public function __construct(
+        Configurable $configurableProductType
+    ) {
+        $this->configurableProductType = $configurableProductType;
+    }
+
+    public function afterGet(
+        ProductRepositoryInterface $subject,
+        ProductInterface $entity
+    ) {
+        $extensionAttributes = $entity->getExtensionAttributes();
+        $parentIds = $this->configurableProductType->getParentIdsByChild($entity->getId());
+        $extensionAttributes->setData('kl_parent_ids', $parentIds);
+        $entity->setExtensionAttributes($extensionAttributes);
+
+        return $entity;
+    }
+
+    public function afterGetList(
+        ProductRepositoryInterface $subject,
+        ProductSearchResultsInterface $searchResults
+    ) {
+        $products = [];
+        foreach ($searchResults->getItems() as $entity) {
+            $extensionAttributes = $entity->getExtensionAttributes();
+            $parentIds = $this->configurableProductType->getParentIdsByChild($entity->getId());
+            $extensionAttributes->setData('kl_parent_ids', $parentIds);
+            $entity->setExtensionAttributes($extensionAttributes);
+
+            $products[] = $entity;
+        }
+        $searchResults->setItems($products);
+        return $searchResults;
+    }
+}

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-dev",
     "description": "The local development composer file. This is used for local and continuous integration setup/testing.",
     "type": "magento2-module",
-    "version": "4.3.2",
+    "version": "4.4.0",
     "autoload": {
         "psr-4": {
             "Klaviyo\\Reclaim\\": ""

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.3.2",
+    "version": "4.4.0",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -11,4 +11,7 @@
     <extension_attributes for="Magento\Quote\Api\Data\CartInterface">
         <attribute code="kl_masked_id" type="string" />
     </extension_attributes>
+    <extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
+        <attribute code="kl_parent_ids" type="int[]" />
+    </extension_attributes>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.3.2" schema_version="4.3.2">
+  <module name="Klaviyo_Reclaim" setup_version="4.4.0" schema_version="4.4.0">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -3,4 +3,7 @@
     <type name="Magento\Quote\Api\CartRepositoryInterface">
         <plugin name="checkoutMaskId" type="Klaviyo\Reclaim\Plugin\Api\CartSearchRepository" />
     </type>
+    <type name="Magento\Catalog\Api\ProductRepositoryInterface">
+        <plugin name="klProductRelationships" type="Klaviyo\Reclaim\Plugin\Api\AddProductRelationships" />
+    </type>
 </config>


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
This PR adds an extension attribute to the Products API data interface, both individual and bulk requests.

This uses the built-in Configurable resource's method `getParentIdsByChild`. Will return an empty array if the product is not associated with a parent.

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Update extension and make request to `/index.php/rest/V1/products` or `/index.php/rest/V1/products/:sku` route.
2. Example response:
```
    "extension_attributes": {
        "website_ids": [
            1
        ],
        "category_links": [
            ...
        ],
        "stock_item": {
            ...
        },
        "kl_parent_ids": [
            2
        ]
    }
```

## Pre-Submission Checklist:

- [ ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
