### PR TITLE
Force cast to prevent type error (php8.4 + null instead of string/array)

### DIFF
--- a/Block/Catalog/Product/ViewedProduct.php
+++ b/Block/Catalog/Product/ViewedProduct.php
@@ -214,7 +214,7 @@ class ViewedProduct extends Template
             'FinalPrice' => $this->getFinalPrice(),
             'Categories' => $this->getProductCategories(),
             'StoreId' => $this->_klaviyoScopeSetting->storeId,
-            '$value' => str_replace(",", "", $this->getPrice())
+            '$value' => str_replace(",", "", (string)$this->getPrice())
         ];
 
         if ($this->getProductImage()) {


### PR DESCRIPTION
## Description
Fix the following error

```
1 exception(s):
Exception #0 (Exception): Deprecated Functionality: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/project/magento/vendor/klaviyo/magento2-extension/Block/Catalog/Product/ViewedProduct.php on line 217
```


## Manual Testing Steps
Any products without prices
