### PR TITLE
Skip unescaped errors from sniffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+### [4.4.1] - 2025-09-15
+
+#### Fixed
+- Removes escapeJs call that was preventing Viewed Product events from syncing successfully in 4.4.0
+
 ### [4.4.0] - 2025-08-11
 
 #### Added
@@ -325,7 +330,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- END RELEASE NOTES -->
 <!-- BEGIN LINKS -->
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.0...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.1...HEAD
+[4.4.1]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.0...4.4.1
 [4.4.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.3.1...4.4.0
 [4.3.1]: https://github.com/klaviyo/magento2-klaviyo/compare/4.3.0...4.3.1
 [4.3.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.2.0...4.3.0

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-dev",
     "description": "The local development composer file. This is used for local and continuous integration setup/testing.",
     "type": "magento2-module",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "autoload": {
         "psr-4": {
             "Klaviyo\\Reclaim\\": ""

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "autoload": {
         "files": [
             "registration.php"

--- a/composer.magento-coding-standard.dev.json
+++ b/composer.magento-coding-standard.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-coding-standard-dev",
     "description": "The development composer file for coding standard.",
     "type": "magento2-module",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.4.0" schema_version="4.4.0">
+  <module name="Klaviyo_Reclaim" setup_version="4.4.1" schema_version="4.4.1">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>

--- a/view/frontend/templates/product/viewed.phtml
+++ b/view/frontend/templates/product/viewed.phtml
@@ -6,8 +6,8 @@
   !function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return"push"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t="function"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();
   require(['domReady!'], function () {
     var klaviyo = window.klaviyo || [];
-      klaviyo.push(['track', 'Viewed Product', <?= $block->escapeJs($block->getViewedProductJson()) ?>]);
-      klaviyo.push(['trackViewedItem', <?= $block->escapeJs($block->getViewedItemJson()) ?>]);
+      klaviyo.push(['track', 'Viewed Product', <?= /* @noEscape */ $block->getViewedProductJson() ?>]);
+      klaviyo.push(['trackViewedItem', <?= /* @noEscape */ $block->getViewedItemJson() ?>]);
   });
 </script>
 


### PR DESCRIPTION
## Description
<!-- What does this PR do? Is it a bug fix, new feature, refactor, or something else -->
Version 4.4.0 included escapeJS calls to satisfy the M2 codesniffer. these caused issues for the klaviyo.js calls, preventing Viewed Product events from syncing successfully. 

## Manual Testing Steps

<!--
Describe how you tested your change. If you are fixing a bug, please provide the version of Magento 2 along with steps to recreate.
-->

1. Tested changes locally and validated that viewed product events were synced successfully.

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [x] **Internal Only** - If this is a release, please confirm the following:
  - [x] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
