### PR TITLE
Pin click to 8.2.2 in CI to avoid 8.3.0 bug

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/setup-python@v4.4.0
         with:
           python-version: '3.11'
+      - name: Install click 8.2.2 until bug in 8.3.0 is resolved
+        run: pip install click==8.2.2
       - name: Install script dependencies
         run: pip install changelogged==0.11.3
       - name: Validate Changelog


### PR DESCRIPTION
Pins click package to version 8.2.2 in the changelog-validation CI job to work around a bug in click 8.3.0 that causes Secondary flag errors.