### PR TITLE
[FIX] Klaviyo_Reclaim: Update Cart Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
+* Added ability to load quote_id parameters that are unmasked. This adds support for logged in sessions where a masked quote_id was not created
 
 ### [4.4.2] - 2025-11-04
 


### PR DESCRIPTION

## Description

Adds support for unmasked quote IDs since logged in carts are not assigned a masked quote ID.


## Manual Testing Steps
1. Log in
2. Create a cart
3. Leave the store
4. Wait for the email to come in
5.  Check the URI to ensure it is using an unmasked quote_id
6. Ensure the cart reloads

## Pre-Submission Checklist:

- [X ] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
