### PR TITLE
Add VPN/CORS detection and test.step wrappers to E2E utils

### DIFF
--- a/Test/e2e/locators/storefront.js
+++ b/Test/e2e/locators/storefront.js
@@ -1,3 +1,4 @@
+const { test } = require('@playwright/test');
 const { generateEmail } = require('../utils/email');
 
 class Storefront {
@@ -15,15 +16,41 @@ class Storefront {
     }
 
     async goToProductPageAndGetProductName() {
-        // Navigate to a product page (using the first product from the homepage)
-        await Promise.all([
-            this.page.waitForResponse(resp => resp.url().includes(`/client/profiles/?company_id=`) && resp.status() === 202 && resp.request().method() === 'POST'),
-            this.page.goto(`${process.env.M2_BASE_URL}/radiant-tee.html?utm_email=${this.email}`),
-        ])
-        await this.page.locator('.page-title').waitFor();
-        // Get product details before adding to cart
-        const productName = await this.page.locator('.page-title').textContent();
-        return productName;
+        return await test.step('Navigate to product page and wait for Klaviyo identify call', async () => {
+            // Navigate to a product page (using the first product from the homepage)
+            const klaviyoUrl = `/client/profiles/?company_id=`;
+
+            let onRequestFailed;
+            const failedRequest = new Promise((_, reject) => {
+                onRequestFailed = request => {
+                    if (request.url().includes(klaviyoUrl)) {
+                        reject(new Error(
+                            `Klaviyo API request failed: ${request.failure()?.errorText ?? 'unknown error'}\n` +
+                            `URL: ${request.url()}\n` +
+                            `This is often caused by a VPN or proxy interfering with cross-origin requests.\n` +
+                            `Try disconnecting from your VPN and running the tests again.`
+                        ));
+                    }
+                };
+                this.page.on('requestfailed', onRequestFailed);
+            });
+
+            const successfulResponse = Promise.all([
+                this.page.waitForResponse(resp => resp.url().includes(klaviyoUrl) && resp.status() === 202 && resp.request().method() === 'POST'),
+                this.page.goto(`${process.env.M2_BASE_URL}/radiant-tee.html?utm_email=${this.email}`),
+            ]);
+
+            try {
+                await Promise.race([successfulResponse, failedRequest]);
+            } finally {
+                this.page.off('requestfailed', onRequestFailed);
+            }
+
+            await this.page.locator('.page-title').waitFor();
+            // Get product details before adding to cart
+            const productName = await this.page.locator('.page-title').textContent();
+            return productName;
+        });
     }
 
     async fillOutNewsletterFooterForm() {
@@ -68,13 +95,15 @@ class Storefront {
     }
 
     async addProductToCart() {
-        // Select size small and orange color
-        await this.page.locator('#option-label-size-144-item-167').click(); // Small size
-        await this.page.locator('#option-label-color-93-item-56').click(); // Orange color
+        await test.step('Select product options and add to cart', async () => {
+            // Select size small and orange color
+            await this.page.locator('#option-label-size-144-item-167').click(); // Small size
+            await this.page.locator('#option-label-color-93-item-56').click(); // Orange color
 
-        // Add product to cart
-        await this.page.click('button[title="Add to Cart"]');
-        await this.page.locator('.message-success').waitFor({ state: 'visible', timeout: 5000 });
+            // Add product to cart
+            await this.page.click('button[title="Add to Cart"]');
+            await this.page.locator('.message-success').waitFor({ state: 'visible', timeout: 5000 });
+        });
     }
 }
 

--- a/Test/e2e/locators/storefront.js
+++ b/Test/e2e/locators/storefront.js
@@ -18,16 +18,19 @@ class Storefront {
     async goToProductPageAndGetProductName() {
         return await test.step('Navigate to product page and wait for Klaviyo identify call', async () => {
             // Navigate to a product page (using the first product from the homepage)
-            const klaviyoUrl = `/client/profiles/?company_id=`;
+            const klaviyoIdentifyUrl = `/client/profiles/?company_id=`;
 
             let onRequestFailed;
             const failedRequest = new Promise((_, reject) => {
                 onRequestFailed = request => {
-                    if (request.url().includes(klaviyoUrl)) {
+                    const url = request.url();
+                    // Match any klaviyo.com request — klaviyo.js loads from static.klaviyo.com
+                    // and the identify POST goes to a.klaviyo.com. VPN can block either.
+                    if (url.includes('klaviyo.com')) {
                         reject(new Error(
-                            `Klaviyo API request failed: ${request.failure()?.errorText ?? 'unknown error'}\n` +
-                            `URL: ${request.url()}\n` +
-                            `This is often caused by a VPN or proxy interfering with cross-origin requests.\n` +
+                            `Klaviyo request failed: ${request.failure()?.errorText ?? 'unknown error'}\n` +
+                            `URL: ${url}\n` +
+                            `This is often caused by a VPN or proxy blocking requests to klaviyo.com.\n` +
                             `Try disconnecting from your VPN and running the tests again.`
                         ));
                     }
@@ -36,7 +39,7 @@ class Storefront {
             });
 
             const successfulResponse = Promise.all([
-                this.page.waitForResponse(resp => resp.url().includes(klaviyoUrl) && resp.status() === 202 && resp.request().method() === 'POST'),
+                this.page.waitForResponse(resp => resp.url().includes(klaviyoIdentifyUrl) && resp.status() === 202 && resp.request().method() === 'POST'),
                 this.page.goto(`${process.env.M2_BASE_URL}/radiant-tee.html?utm_email=${this.email}`),
             ]);
 


### PR DESCRIPTION
## Description

Improve E2E test DX by detecting VPN/CORS failures early and adding Playwright test steps for better report output. Ported from woocommerce-klaviyo#307.

- **VPN/CORS detection:** `goToProductPageAndGetProductName` now races the Klaviyo API response against a `requestfailed` listener. If the request fails (e.g. due to VPN interfering with cross-origin requests to `a.klaviyo.com`), it immediately throws a descriptive error instead of hanging for the full test timeout.
- **test.step wrappers:** Wrapped `goToProductPageAndGetProductName` and `addProductToCart` in `test.step()` calls so the Playwright HTML report shows clear step breakdowns.

`goToProductPageAndGetProductName` is the only storefront helper that waits on a Klaviyo endpoint (`/client/profiles/?company_id=`); other admin/storefront helpers wait on Magento backend responses which VPN does not block.

## Manual Testing Steps

1. Run `npx playwright test` while connected to VPN — should fail quickly with a message suggesting VPN disconnect.
2. Run `npx playwright test` while off VPN — should pass normally.

## Pre-Submission Checklist

- [x] Test-only changes — no production module files touched, no CHANGELOG entry needed.
- [x] No version bump needed.

## Related

- Parallel PR in woocommerce-klaviyo: https://github.com/klaviyo/woocommerce-klaviyo/pull/307