### PR TITLE
Bump Klaviyo V3 API revision to 2026-04-15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Changed
+- Update Klaviyo V3 API revision to 2026-04-15.
+
 #### Fixed
 - Fixed race condition for adding profiles to a list, retries subscription if we attempt to create a profile that already exists.
 

--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -15,7 +15,7 @@ class KlaviyoV3Api
      * Host and versions
      */
     const KLAVIYO_HOST = 'https://a.klaviyo.com/';
-    const KLAVIYO_V3_REVISION = '2025-10-15';
+    const KLAVIYO_V3_REVISION = '2026-04-15';
 
     /**
      * Request methods


### PR DESCRIPTION
Mechanical bump of the Klaviyo V3 API `revision` constant to `2026-04-15`.

Opened as a **draft** by the `/integration-modules-revision-bump` skill. Before marking ready for review:

- [x] Apply any breaking-change fixes called out by the audit report
- [x] Deploy the branch to the test site
- [x] Run e2e tests and attach results

**Had to fix some flaky tests - [see separate PR](https://github.com/klaviyo/magento2-klaviyo/pull/365)**

<img width="867" height="1096" alt="image" src="https://github.com/user-attachments/assets/bb88f9dd-e44b-486c-ba86-b42df7f005e2" />


See the audit report from `/integration-modules-revision-audit` for context on the target revision and any breaking changes.