### PR TITLE
Release 4.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+### [4.4.4] - 2026-04-30
+
 #### Changed
 - Update Klaviyo V3 API revision to 2026-04-15.
 
@@ -355,7 +357,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- END RELEASE NOTES -->
 <!-- BEGIN LINKS -->
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.3...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.4...HEAD
+[4.4.4]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.3...4.4.4
 [4.4.3]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.2...4.4.3
 [4.4.2]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.1...4.4.2
 [4.4.1]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.0...4.4.1

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-dev",
     "description": "The local development composer file. This is used for local and continuous integration setup/testing.",
     "type": "magento2-module",
-    "version": "4.4.3",
+    "version": "4.4.4",
     "autoload": {
         "psr-4": {
             "Klaviyo\\Reclaim\\": ""

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.4.3",
+    "version": "4.4.4",
     "autoload": {
         "files": [
             "registration.php"

--- a/composer.magento-coding-standard.dev.json
+++ b/composer.magento-coding-standard.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-coding-standard-dev",
     "description": "The development composer file for coding standard.",
     "type": "magento2-module",
-    "version": "4.4.3",
+    "version": "4.4.4",
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.4.3" schema_version="4.4.3">
+  <module name="Klaviyo_Reclaim" setup_version="4.4.4" schema_version="4.4.4">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
## Summary
Release `4.4.4`.

## Release notes
#### Changed
- Update Klaviyo V3 API revision to 2026-04-15.

#### Fixed
- Fixed race condition for adding profiles to a list, retries subscription if we attempt to create a profile that already exists.

## Test plan
- [ ] CI is green
- [ ] Merging this PR triggers the repo's release workflow