### PR TITLE
IES-217: Unified Mobile consent group + single mobile checkbox + V3 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+### [4.5.0] - 2026-05-27
+
+#### Added
+- WhatsApp consent collection at checkout via a new unified Mobile consent group. Merchants choose to collect consent for SMS, WhatsApp, or both, and a single mobile checkbox at checkout drives per-channel subscriptions in Klaviyo.
+
+#### Changed
+- Replaced the SMS consent admin group with a unified Mobile group. Existing SMS settings are migrated to the new paths on upgrade; custom label and disclosure copy is preserved.
+- Consent submission at order placement now uses the V3 /api/profile-subscription-bulk-create-jobs/ endpoint instead of the legacy custom webhook.
+- Phone numbers collected at checkout are now normalized to E.164 before being sent to Klaviyo.
+- Minimum PHP requirement is now 8.1.
+
 ### [4.4.4] - 2026-04-30
 
 #### Changed
@@ -357,7 +368,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- END RELEASE NOTES -->
 <!-- BEGIN LINKS -->
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.4...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.5.0...HEAD
+[4.5.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.4...4.5.0
 [4.4.4]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.3...4.4.4
 [4.4.3]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.2...4.4.3
 [4.4.2]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.1...4.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
-### [4.5.0] - 2026-05-27
+### [5.0.0] - 2026-05-29
 
 #### Added
 - WhatsApp consent collection at checkout via a new unified Mobile consent group. Merchants choose to collect consent for SMS, WhatsApp, or both, and a single mobile checkbox at checkout drives per-channel subscriptions in Klaviyo.
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the SMS consent admin group with a unified Mobile group. Existing SMS settings are migrated to the new paths on upgrade; custom label and disclosure copy is preserved.
 - Consent submission at order placement now uses the V3 /api/profile-subscription-bulk-create-jobs/ endpoint instead of the legacy custom webhook.
 - Phone numbers collected at checkout are now normalized to E.164 before being sent to Klaviyo.
-- Minimum PHP requirement is now 8.1.
+
+#### Removed
+- Support for PHP versions below 8.1. The plugin now requires PHP 8.1 or later, aligning with Magento 2.4.5+. Merchants on PHP 7.x must upgrade their PHP runtime before installing this release.
 
 ### [4.4.4] - 2026-04-30
 
@@ -368,8 +370,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- END RELEASE NOTES -->
 <!-- BEGIN LINKS -->
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.5.0...HEAD
-[4.5.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.4...4.5.0
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/5.0.0...HEAD
+[5.0.0]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.4...5.0.0
 [4.4.4]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.3...4.4.4
 [4.4.3]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.2...4.4.3
 [4.4.2]: https://github.com/klaviyo/magento2-klaviyo/compare/4.4.1...4.4.2

--- a/Helper/ScopeSetting.php
+++ b/Helper/ScopeSetting.php
@@ -21,11 +21,12 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
     const CONSENT_AT_CHECKOUT_EMAIL_CONSENT_TEXT = 'klaviyo_reclaim_consent_at_checkout/email_consent/consent_text';
     const CONSENT_AT_CHECKOUT_EMAIL_SORT_ORDER = 'klaviyo_reclaim_consent_at_checkout/email_consent/sort_order';
 
-    const CONSENT_AT_CHECKOUT_SMS_IS_ACTIVE = 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active';
-    const CONSENT_AT_CHECKOUT_SMS_LIST_ID = 'klaviyo_reclaim_consent_at_checkout/sms_consent/list_id';
-    const CONSENT_AT_CHECKOUT_SMS_CONSENT_TEXT = 'klaviyo_reclaim_consent_at_checkout/sms_consent/consent_text';
-    const CONSENT_AT_CHECKOUT_SMS_SORT_ORDER = 'klaviyo_reclaim_consent_at_checkout/sms_consent/sort_order';
-    const CONSENT_AT_CHECKOUT_SMS_LABEL_TEXT = 'klaviyo_reclaim_consent_at_checkout/sms_consent/label_text';
+    const CONSENT_AT_CHECKOUT_MOBILE_IS_ACTIVE = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/is_active';
+    const CONSENT_AT_CHECKOUT_MOBILE_LIST_ID = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/list_id';
+    const CONSENT_AT_CHECKOUT_MOBILE_CONSENT_TEXT = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text';
+    const CONSENT_AT_CHECKOUT_MOBILE_SORT_ORDER = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/sort_order';
+    const CONSENT_AT_CHECKOUT_MOBILE_LABEL_TEXT = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text';
+    const CONSENT_AT_CHECKOUT_MOBILE_CHANNELS = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/channels';
 
     const KLAVIYO_NAME_DEFAULT = 'klaviyo';
 
@@ -236,29 +237,43 @@ class ScopeSetting extends \Magento\Framework\App\Helper\AbstractHelper
         return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_EMAIL_SORT_ORDER);
     }
 
-    public function getConsentAtCheckoutSMSIsActive($storeId = null)
+    public function getMobileConsentIsActive($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_IS_ACTIVE, $storeId);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_MOBILE_IS_ACTIVE, $storeId);
     }
 
-    public function getConsentAtCheckoutSMSListId($storeId = null)
+    public function getMobileConsentListId($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_LIST_ID, $storeId);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_MOBILE_LIST_ID, $storeId);
     }
 
-    public function getConsentAtCheckoutSMSConsentText($storeId = null)
+    public function getMobileConsentText($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_CONSENT_TEXT, $storeId);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_MOBILE_CONSENT_TEXT, $storeId);
     }
 
-    public function getConsentAtCheckoutSMSConsentSortOrder($storeId = null)
+    public function getMobileConsentSortOrder($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_SORT_ORDER, $storeId);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_MOBILE_SORT_ORDER, $storeId);
     }
 
-    public function getConsentAtCheckoutSMSConsentLabelText($storeId = null)
+    public function getMobileConsentLabelText($storeId = null)
     {
-        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_SMS_LABEL_TEXT, $storeId);
+        return $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_MOBILE_LABEL_TEXT, $storeId);
+    }
+
+    public function getMobileConsentChannels($storeId = null)
+    {
+        $value = $this->getScopeSetting(self::CONSENT_AT_CHECKOUT_MOBILE_CHANNELS, $storeId);
+        if (empty($value)) {
+            return [];
+        }
+        return explode(',', $value);
+    }
+
+    public function isMobileChannelEnabled($storeId, $channel)
+    {
+        return in_array($channel, $this->getMobileConsentChannels($storeId));
     }
 
 

--- a/Model/Checkout/ShippingInformationManagement.php
+++ b/Model/Checkout/ShippingInformationManagement.php
@@ -25,7 +25,7 @@ class ShippingInformationManagement
 
         $quote = $this->quoteRepository->getActive($cartId);
 
-        $quote->setKlSmsConsent($extAttributes->getKlSmsConsent());
+        $quote->setKlMobileConsent($extAttributes->getKlMobileConsent());
         $quote->setKlEmailConsent($extAttributes->getKlEmailConsent());
     }
 }

--- a/Model/Checkout/ShippingInformationManagement.php
+++ b/Model/Checkout/ShippingInformationManagement.php
@@ -25,7 +25,7 @@ class ShippingInformationManagement
 
         $quote = $this->quoteRepository->getActive($cartId);
 
-        $quote->setKlMobileConsent($extAttributes->getKlMobileConsent());
+        $quote->setKlSmsConsent($extAttributes->getKlSmsConsent());
         $quote->setKlEmailConsent($extAttributes->getKlEmailConsent());
     }
 }

--- a/Model/Config/Source/MobileChannels.php
+++ b/Model/Config/Source/MobileChannels.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model\Config\Source;
+
+class MobileChannels implements \Magento\Framework\Option\ArrayInterface
+{
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 'sms', 'label' => __('SMS')],
+            ['value' => 'whatsapp', 'label' => __('WhatsApp')],
+        ];
+    }
+}

--- a/Model/Config/Source/MobileChannels.php
+++ b/Model/Config/Source/MobileChannels.php
@@ -7,7 +7,7 @@ class MobileChannels implements \Magento\Framework\Option\ArrayInterface
     public function toOptionArray()
     {
         return [
-            ['value' => 'sms', 'label' => __('SMS')],
+            ['value' => 'sms', 'label' => __('Text message')],
             ['value' => 'whatsapp', 'label' => __('WhatsApp')],
         ];
     }

--- a/Observer/SaveOrderMarketingConsent.php
+++ b/Observer/SaveOrderMarketingConsent.php
@@ -2,94 +2,133 @@
 
 namespace Klaviyo\Reclaim\Observer;
 
-use Exception;
+use Klaviyo\Reclaim\Helper\Logger;
 use Klaviyo\Reclaim\Helper\ScopeSetting;
-use Klaviyo\Reclaim\Helper\Webhook;
+use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoApiException;
+use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoResourceConflictException;
+use Klaviyo\Reclaim\KlaviyoV3Sdk\KlaviyoV3Api;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 
 class SaveOrderMarketingConsent implements ObserverInterface
 {
     /**
-     * Klaviyo scope setting helper
-     * @var ScopeSetting $klaviyoScopeSetting
+     * @var ScopeSetting
      */
     protected $_klaviyoScopeSetting;
 
     /**
-     * @var Webhook $webhookHelper
+     * @var Logger
      */
-    protected $_webhookHelper;
+    protected $_klaviyoLogger;
 
     /**
-     * @param Webhook $webhookHelper
+     * @param Logger $klaviyoLogger
      * @param ScopeSetting $klaviyoScopeSetting
      */
     public function __construct(
-        Webhook $webhookHelper,
+        Logger $klaviyoLogger,
         ScopeSetting $klaviyoScopeSetting
     ) {
-        $this->_webhookHelper = $webhookHelper;
+        $this->_klaviyoLogger = $klaviyoLogger;
         $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
     }
 
     /**
-     * customer register event handler
+     * Creates the KlaviyoV3Api client. Extracted to allow test subclasses to inject a mock.
      *
+     * @param int|null $storeId
+     * @return KlaviyoV3Api
+     */
+    protected function buildKlaviyoV3Api($storeId = null): KlaviyoV3Api
+    {
+        return new KlaviyoV3Api(
+            $this->_klaviyoScopeSetting->getPublicApiKey($storeId),
+            $this->_klaviyoScopeSetting->getPrivateApiKey($storeId),
+            $this->_klaviyoScopeSetting,
+            $this->_klaviyoLogger
+        );
+    }
+
+    /**
      * @param Observer $observer
-     * @return void
-     * @throws Exception
+     * @return $this
      */
     public function execute(Observer $observer)
     {
         $order = $observer->getEvent()->getOrder();
         $quote = $observer->getEvent()->getQuote();
 
-        $order->setData("kl_sms_consent", json_encode($quote->getKlSmsConsent()));
-        $order->setData("kl_email_consent", json_encode($quote->getKlEmailConsent()));
+        $order->setData('kl_mobile_consent', json_encode($quote->getKlMobileConsent()));
+        $order->setData('kl_email_consent', json_encode($quote->getKlEmailConsent()));
 
-        $shippingInfo = $quote->getShippingAddress();
-        $webhookSecret = $this->_klaviyoScopeSetting->getWebhookSecret();
-        $updatedAt = $quote->getUpdatedAt();
+        $storeId = $quote->getStoreId();
+        $email = $quote->getCustomerEmail();
 
-        $data = array("data" => array());
-
-        if (
-            $webhookSecret
-            && $quote->getKlSmsConsent()
-            && $this->_klaviyoScopeSetting->getConsentAtCheckoutSMSIsActive()
-        ) {
-            $data["data"][] = array(
-                "customer" => array(
-                    "email" => $quote->getCustomerEmail(),
-                    "country" => $shippingInfo->getCountry(),
-                    "phone" => $shippingInfo->getTelephone(),
-                ),
-                "consent" => true,
-                "consent_type" => "sms",
-                "group_id" => $this->_klaviyoScopeSetting->getConsentAtCheckoutSMSListId(),
-                "updated_at" => $quote->getUpdatedAt(),
-            );
-        }
-        if (
-            $webhookSecret
-            && $quote->getKlEmailConsent()
-            && $this->_klaviyoScopeSetting->getConsentAtCheckoutEmailIsActive()
-        ) {
-            $data["data"][] = array(
-                "customer" => array(
-                    "email" => $quote->getCustomerEmail(),
-                    "phone" => $shippingInfo->getTelephone(),
-                ),
-                "consent" => true,
-                "consent_type" => "email",
-                "group_id" => $this->_klaviyoScopeSetting->getConsentAtCheckoutEmailListId(),
-                "updated_at" => $updatedAt,
-            );
+        if ($quote->getKlEmailConsent() && $this->_klaviyoScopeSetting->getConsentAtCheckoutEmailIsActive($storeId)) {
+            $listId = $this->_klaviyoScopeSetting->getConsentAtCheckoutEmailListId($storeId);
+            $emailProfileObject = [
+                'type' => 'profile',
+                'attributes' => [
+                    'email' => $email,
+                    'subscriptions' => [
+                        'email' => [
+                            'marketing' => [
+                                'consent' => 'SUBSCRIBED',
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+            try {
+                $api = $this->buildKlaviyoV3Api($storeId);
+                $api->subscribeMembersToList($listId, [$emailProfileObject]);
+            } catch (KlaviyoApiException $e) {
+                $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Email subscribe failed: %s', $e->getMessage()));
+            } catch (KlaviyoResourceConflictException $e) {
+                $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Email subscribe conflict: %s', $e->getMessage()));
+            }
         }
 
-        if (count($data["data"]) > 0) {
-            $this->_webhookHelper->makeWebhookRequest('custom/consent', $data);
+        if ($quote->getKlMobileConsent() && $this->_klaviyoScopeSetting->getMobileConsentIsActive($storeId)) {
+            $mobileListId = $this->_klaviyoScopeSetting->getMobileConsentListId($storeId);
+            $mobileSubscriptions = [];
+
+            if ($this->_klaviyoScopeSetting->isMobileChannelEnabled($storeId, 'sms')) {
+                $mobileSubscriptions['sms'] = [
+                    'marketing' => [
+                        'consent' => 'SUBSCRIBED',
+                    ],
+                ];
+            }
+
+            if ($this->_klaviyoScopeSetting->isMobileChannelEnabled($storeId, 'whatsapp')) {
+                $mobileSubscriptions['whatsapp'] = [
+                    'marketing' => [
+                        'consent' => 'SUBSCRIBED',
+                    ],
+                ];
+            }
+
+            if (!empty($mobileSubscriptions)) {
+                $shippingInfo = $quote->getShippingAddress();
+                $mobileProfileObject = [
+                    'type' => 'profile',
+                    'attributes' => [
+                        'email' => $email,
+                        'phone_number' => $shippingInfo ? $shippingInfo->getTelephone() : null,
+                        'subscriptions' => $mobileSubscriptions,
+                    ],
+                ];
+                try {
+                    $api = $this->buildKlaviyoV3Api($storeId);
+                    $api->subscribeMembersToList($mobileListId, [$mobileProfileObject]);
+                } catch (KlaviyoApiException $e) {
+                    $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe failed: %s', $e->getMessage()));
+                } catch (KlaviyoResourceConflictException $e) {
+                    $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe conflict: %s', $e->getMessage()));
+                }
+            }
         }
 
         return $this;

--- a/Observer/SaveOrderMarketingConsent.php
+++ b/Observer/SaveOrderMarketingConsent.php
@@ -101,25 +101,16 @@ class SaveOrderMarketingConsent implements ObserverInterface
 
         if ($quote->getKlSmsConsent() && $this->_klaviyoScopeSetting->getMobileConsentIsActive($storeId)) {
             $mobileListId = $this->_klaviyoScopeSetting->getMobileConsentListId($storeId);
-            $mobileSubscriptions = [];
 
-            if ($this->_klaviyoScopeSetting->isMobileChannelEnabled($storeId, 'sms')) {
-                $mobileSubscriptions['sms'] = [
-                    'marketing' => [
-                        'consent' => 'SUBSCRIBED',
-                    ],
-                ];
+            // Stable order so tests and log lines stay deterministic.
+            $enabledChannels = [];
+            foreach (['sms', 'whatsapp'] as $channel) {
+                if ($this->_klaviyoScopeSetting->isMobileChannelEnabled($storeId, $channel)) {
+                    $enabledChannels[] = $channel;
+                }
             }
 
-            if ($this->_klaviyoScopeSetting->isMobileChannelEnabled($storeId, 'whatsapp')) {
-                $mobileSubscriptions['whatsapp'] = [
-                    'marketing' => [
-                        'consent' => 'SUBSCRIBED',
-                    ],
-                ];
-            }
-
-            if (!empty($mobileSubscriptions)) {
+            if (!empty($enabledChannels)) {
                 $shippingInfo = $quote->getShippingAddress();
                 $rawPhone = $shippingInfo ? $shippingInfo->getTelephone() : null;
                 $isoCountry = $shippingInfo ? $shippingInfo->getCountryId() : null;
@@ -131,21 +122,32 @@ class SaveOrderMarketingConsent implements ObserverInterface
                         $storeId
                     ));
                 } else {
-                    $mobileProfileObject = [
-                        'type' => 'profile',
-                        'attributes' => [
-                            'email' => $email,
-                            'phone_number' => $e164Phone,
-                            'subscriptions' => $mobileSubscriptions,
-                        ],
-                    ];
-                    try {
-                        $api = $this->buildKlaviyoV3Api($storeId);
-                        $api->subscribeMembersToList($mobileListId, [$mobileProfileObject]);
-                    } catch (KlaviyoResourceConflictException $e) {
-                        $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe conflict: %s', $e->getMessage()));
-                    } catch (KlaviyoApiException $e) {
-                        $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe failed: %s', $e->getMessage()));
+                    // One subscribe call per enabled channel. Each call has its
+                    // own try/catch so a failure in one channel doesn't suppress
+                    // the other — partial success is intentional.
+                    $api = $this->buildKlaviyoV3Api($storeId);
+                    foreach ($enabledChannels as $channel) {
+                        $profileObject = [
+                            'type' => 'profile',
+                            'attributes' => [
+                                'email' => $email,
+                                'phone_number' => $e164Phone,
+                                'subscriptions' => [
+                                    $channel => [
+                                        'marketing' => [
+                                            'consent' => 'SUBSCRIBED',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ];
+                        try {
+                            $api->subscribeMembersToList($mobileListId, [$profileObject]);
+                        } catch (KlaviyoResourceConflictException $e) {
+                            $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] %s subscribe conflict: %s', $channel, $e->getMessage()));
+                        } catch (KlaviyoApiException $e) {
+                            $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] %s subscribe failed: %s', $channel, $e->getMessage()));
+                        }
                     }
                 }
             }

--- a/Observer/SaveOrderMarketingConsent.php
+++ b/Observer/SaveOrderMarketingConsent.php
@@ -7,6 +7,7 @@ use Klaviyo\Reclaim\Helper\ScopeSetting;
 use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoApiException;
 use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoResourceConflictException;
 use Klaviyo\Reclaim\KlaviyoV3Sdk\KlaviyoV3Api;
+use Klaviyo\Reclaim\Util\PhoneFormatter;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 
@@ -23,15 +24,23 @@ class SaveOrderMarketingConsent implements ObserverInterface
     protected $_klaviyoLogger;
 
     /**
+     * @var PhoneFormatter
+     */
+    protected $_phoneFormatter;
+
+    /**
      * @param Logger $klaviyoLogger
      * @param ScopeSetting $klaviyoScopeSetting
+     * @param PhoneFormatter $phoneFormatter
      */
     public function __construct(
         Logger $klaviyoLogger,
-        ScopeSetting $klaviyoScopeSetting
+        ScopeSetting $klaviyoScopeSetting,
+        PhoneFormatter $phoneFormatter
     ) {
         $this->_klaviyoLogger = $klaviyoLogger;
         $this->_klaviyoScopeSetting = $klaviyoScopeSetting;
+        $this->_phoneFormatter = $phoneFormatter;
     }
 
     /**
@@ -112,21 +121,32 @@ class SaveOrderMarketingConsent implements ObserverInterface
 
             if (!empty($mobileSubscriptions)) {
                 $shippingInfo = $quote->getShippingAddress();
-                $mobileProfileObject = [
-                    'type' => 'profile',
-                    'attributes' => [
-                        'email' => $email,
-                        'phone_number' => $shippingInfo ? $shippingInfo->getTelephone() : null,
-                        'subscriptions' => $mobileSubscriptions,
-                    ],
-                ];
-                try {
-                    $api = $this->buildKlaviyoV3Api($storeId);
-                    $api->subscribeMembersToList($mobileListId, [$mobileProfileObject]);
-                } catch (KlaviyoApiException $e) {
-                    $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe failed: %s', $e->getMessage()));
-                } catch (KlaviyoResourceConflictException $e) {
-                    $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe conflict: %s', $e->getMessage()));
+                $rawPhone = $shippingInfo ? $shippingInfo->getTelephone() : null;
+                $isoCountry = $shippingInfo ? $shippingInfo->getCountryId() : null;
+                $e164Phone = $this->_phoneFormatter->formatE164($rawPhone, $isoCountry);
+
+                if ($e164Phone === null) {
+                    $this->_klaviyoLogger->log(sprintf(
+                        '[SaveOrderMarketingConsent] Mobile subscribe skipped: phone could not be normalized to E.164 for store %s',
+                        $storeId
+                    ));
+                } else {
+                    $mobileProfileObject = [
+                        'type' => 'profile',
+                        'attributes' => [
+                            'email' => $email,
+                            'phone_number' => $e164Phone,
+                            'subscriptions' => $mobileSubscriptions,
+                        ],
+                    ];
+                    try {
+                        $api = $this->buildKlaviyoV3Api($storeId);
+                        $api->subscribeMembersToList($mobileListId, [$mobileProfileObject]);
+                    } catch (KlaviyoApiException $e) {
+                        $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe failed: %s', $e->getMessage()));
+                    } catch (KlaviyoResourceConflictException $e) {
+                        $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe conflict: %s', $e->getMessage()));
+                    }
                 }
             }
         }

--- a/Observer/SaveOrderMarketingConsent.php
+++ b/Observer/SaveOrderMarketingConsent.php
@@ -92,10 +92,10 @@ class SaveOrderMarketingConsent implements ObserverInterface
             try {
                 $api = $this->buildKlaviyoV3Api($storeId);
                 $api->subscribeMembersToList($listId, [$emailProfileObject]);
-            } catch (KlaviyoApiException $e) {
-                $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Email subscribe failed: %s', $e->getMessage()));
             } catch (KlaviyoResourceConflictException $e) {
                 $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Email subscribe conflict: %s', $e->getMessage()));
+            } catch (KlaviyoApiException $e) {
+                $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Email subscribe failed: %s', $e->getMessage()));
             }
         }
 
@@ -142,10 +142,10 @@ class SaveOrderMarketingConsent implements ObserverInterface
                     try {
                         $api = $this->buildKlaviyoV3Api($storeId);
                         $api->subscribeMembersToList($mobileListId, [$mobileProfileObject]);
-                    } catch (KlaviyoApiException $e) {
-                        $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe failed: %s', $e->getMessage()));
                     } catch (KlaviyoResourceConflictException $e) {
                         $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe conflict: %s', $e->getMessage()));
+                    } catch (KlaviyoApiException $e) {
+                        $this->_klaviyoLogger->log(sprintf('[SaveOrderMarketingConsent] Mobile subscribe failed: %s', $e->getMessage()));
                     }
                 }
             }

--- a/Observer/SaveOrderMarketingConsent.php
+++ b/Observer/SaveOrderMarketingConsent.php
@@ -59,7 +59,7 @@ class SaveOrderMarketingConsent implements ObserverInterface
         $order = $observer->getEvent()->getOrder();
         $quote = $observer->getEvent()->getQuote();
 
-        $order->setData('kl_mobile_consent', json_encode($quote->getKlMobileConsent()));
+        $order->setData('kl_sms_consent', json_encode($quote->getKlSmsConsent()));
         $order->setData('kl_email_consent', json_encode($quote->getKlEmailConsent()));
 
         $storeId = $quote->getStoreId();
@@ -90,7 +90,7 @@ class SaveOrderMarketingConsent implements ObserverInterface
             }
         }
 
-        if ($quote->getKlMobileConsent() && $this->_klaviyoScopeSetting->getMobileConsentIsActive($storeId)) {
+        if ($quote->getKlSmsConsent() && $this->_klaviyoScopeSetting->getMobileConsentIsActive($storeId)) {
             $mobileListId = $this->_klaviyoScopeSetting->getMobileConsentListId($storeId);
             $mobileSubscriptions = [];
 

--- a/Plugin/CheckoutLayoutPlugin.php
+++ b/Plugin/CheckoutLayoutPlugin.php
@@ -52,34 +52,34 @@ class CheckoutLayoutPlugin
 
     public function afterProcess(\Magento\Checkout\Block\Checkout\LayoutProcessor $processor, $jsLayout)
     {
-        if ($this->_klaviyoScopeSetting->getConsentAtCheckoutSMSIsActive()) {
-            $smsConsentCheckbox = [
+        if ($this->_klaviyoScopeSetting->getMobileConsentIsActive()) {
+            $mobileConsentCheckbox = [
                 'component' => 'Magento_Ui/js/form/element/abstract',
                 'config' => [
                     'customScope' => 'shippingAddress.custom_attributes',
                     'template' => 'ui/form/field',
                     'elementTmpl' => 'ui/form/element/checkbox',
                     'options' => [],
-                    'id' => 'kl_sms_consent',
+                    'id' => 'kl_mobile_consent',
                 ],
-                'dataScope' => 'shippingAddress.custom_attributes.kl_sms_consent',
-                'label' => $this->_klaviyoScopeSetting->getConsentAtCheckoutSMSConsentLabelText(),
-                'description' => $this->_klaviyoScopeSetting->getConsentAtCheckoutSMSConsentText(),
+                'dataScope' => 'shippingAddress.custom_attributes.kl_mobile_consent',
+                'label' => $this->_klaviyoScopeSetting->getMobileConsentLabelText(),
+                'description' => $this->_klaviyoScopeSetting->getMobileConsentText(),
                 'provider' => 'checkoutProvider',
                 'visible' => true,
                 'checked' => false,
                 'validation' => [],
-                'sortOrder' => $this->_klaviyoScopeSetting->getConsentAtCheckoutSMSConsentSortOrder(),
-                'id' => 'kl_sms_consent',
+                'sortOrder' => $this->_klaviyoScopeSetting->getMobileConsentSortOrder(),
+                'id' => 'kl_mobile_consent',
             ];
 
             $address = $this->_getDefaultAddressIfSetForCustomer();
 
             if (!$address) {
-                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shipping-address-fieldset']['children']['kl_sms_consent'] = $smsConsentCheckbox;
+                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shipping-address-fieldset']['children']['kl_mobile_consent'] = $mobileConsentCheckbox;
             } else {
                 // extra un-editable field with saved phone number to display to logged in users with default address set
-                $smsConsentTelephone = [
+                $mobileConsentTelephone = [
                     'component' => 'Magento_Ui/js/form/element/abstract',
                     'config' =>
                         [
@@ -95,8 +95,8 @@ class CheckoutLayoutPlugin
                     'value' => $address->getTelephone()
                 ];
 
-                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_sms_phone_number'] = $smsConsentTelephone;
-                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_sms_consent'] = $smsConsentCheckbox;
+                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_mobile_phone_number'] = $mobileConsentTelephone;
+                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_mobile_consent'] = $mobileConsentCheckbox;
             }
         }
 

--- a/Plugin/CheckoutLayoutPlugin.php
+++ b/Plugin/CheckoutLayoutPlugin.php
@@ -60,9 +60,9 @@ class CheckoutLayoutPlugin
                     'template' => 'ui/form/field',
                     'elementTmpl' => 'ui/form/element/checkbox',
                     'options' => [],
-                    'id' => 'kl_mobile_consent',
+                    'id' => 'kl_sms_consent',
                 ],
-                'dataScope' => 'shippingAddress.custom_attributes.kl_mobile_consent',
+                'dataScope' => 'shippingAddress.custom_attributes.kl_sms_consent',
                 'label' => $this->_klaviyoScopeSetting->getMobileConsentLabelText(),
                 'description' => $this->_klaviyoScopeSetting->getMobileConsentText(),
                 'provider' => 'checkoutProvider',
@@ -70,13 +70,13 @@ class CheckoutLayoutPlugin
                 'checked' => false,
                 'validation' => [],
                 'sortOrder' => $this->_klaviyoScopeSetting->getMobileConsentSortOrder(),
-                'id' => 'kl_mobile_consent',
+                'id' => 'kl_sms_consent',
             ];
 
             $address = $this->_getDefaultAddressIfSetForCustomer();
 
             if (!$address) {
-                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shipping-address-fieldset']['children']['kl_mobile_consent'] = $mobileConsentCheckbox;
+                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shipping-address-fieldset']['children']['kl_sms_consent'] = $mobileConsentCheckbox;
             } else {
                 // extra un-editable field with saved phone number to display to logged in users with default address set
                 $mobileConsentTelephone = [
@@ -95,8 +95,8 @@ class CheckoutLayoutPlugin
                     'value' => $address->getTelephone()
                 ];
 
-                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_mobile_phone_number'] = $mobileConsentTelephone;
-                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_mobile_consent'] = $mobileConsentCheckbox;
+                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_sms_phone_number'] = $mobileConsentTelephone;
+                $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['before-form']['children']['kl_sms_consent'] = $mobileConsentCheckbox;
             }
         }
 

--- a/Setup/Patch/Data/MigrateSmsToMobileConsent.php
+++ b/Setup/Patch/Data/MigrateSmsToMobileConsent.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Klaviyo\Reclaim\Setup\Patch\Data;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchVersionInterface;
+
+class MigrateSmsToMobileConsent implements DataPatchInterface, PatchVersionInterface
+{
+    private const SMS_CONSENT_PREFIX = 'klaviyo_reclaim_consent_at_checkout/sms_consent/';
+    private const MOBILE_CHANNELS_PATH = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/channels';
+
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    public function __construct(ModuleDataSetupInterface $moduleDataSetup)
+    {
+        $this->moduleDataSetup = $moduleDataSetup;
+    }
+
+    public function apply()
+    {
+        $connection = $this->moduleDataSetup->getConnection();
+        $connection->startSetup();
+
+        $table = $this->moduleDataSetup->getTable('core_config_data');
+
+        $select = $connection->select()
+            ->from($table)
+            ->where('path LIKE ?', self::SMS_CONSENT_PREFIX . '%');
+        $smsRows = $connection->fetchAll($select);
+
+        foreach ($smsRows as $row) {
+            $mobilePath = str_replace('sms_consent/', 'mobile_consent/', $row['path']);
+
+            if (!$this->rowExists($connection, $table, $row['scope'], (int)$row['scope_id'], $mobilePath)) {
+                $connection->insert($table, [
+                    'scope'    => $row['scope'],
+                    'scope_id' => $row['scope_id'],
+                    'path'     => $mobilePath,
+                    'value'    => $row['value'],
+                ]);
+            }
+
+            // When SMS is_active was enabled, seed the channels field with 'sms'
+            if (strpos($row['path'], '/is_active') !== false && $row['value'] == '1') {
+                if (!$this->rowExists($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_CHANNELS_PATH)) {
+                    $connection->insert($table, [
+                        'scope'    => $row['scope'],
+                        'scope_id' => $row['scope_id'],
+                        'path'     => self::MOBILE_CHANNELS_PATH,
+                        'value'    => 'sms',
+                    ]);
+                }
+            }
+        }
+
+        $connection->endSetup();
+        return $this;
+    }
+
+    public function getAliases()
+    {
+        return [];
+    }
+
+    public static function getDependencies()
+    {
+        return [UpdateOldPrivateKeysToEncryptedVersions::class];
+    }
+
+    public static function getVersion()
+    {
+        return '4.5.0';
+    }
+
+    private function rowExists($connection, string $table, string $scope, int $scopeId, string $path): bool
+    {
+        $select = $connection->select()
+            ->from($table, ['config_id'])
+            ->where('scope = ?', $scope)
+            ->where('scope_id = ?', $scopeId)
+            ->where('path = ?', $path);
+        return (bool) $connection->fetchOne($select);
+    }
+}

--- a/Setup/Patch/Data/MigrateSmsToMobileConsent.php
+++ b/Setup/Patch/Data/MigrateSmsToMobileConsent.php
@@ -59,9 +59,22 @@ class MigrateSmsToMobileConsent implements DataPatchInterface, PatchVersionInter
 
         foreach ($smsRows as $row) {
             if (strpos($row['path'], '/is_active') !== false && $row['value'] == '1') {
+                // channels is a new field with no pre-migration value at any
+                // scope, so seed it at the same scope where is_active=1 was
+                // set — matching the ticket spec ("channels = ['sms'] where
+                // SMS was active") and respecting any per-scope intent.
                 $this->seedIfMissing($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_CHANNELS_PATH, 'sms');
-                $this->seedIfMissing($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_LABEL_TEXT_PATH, self::SMS_LABEL_DEFAULT);
-                $this->seedIfMissing($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_CONSENT_TEXT_PATH, self::SMS_CONSENT_DEFAULT);
+
+                // label_text and consent_text already had pre-migration values
+                // that could be inherited down the scope chain. Seeding at a
+                // non-default scope would override that inherited value with
+                // SMS boilerplate, silently regressing the merchant's content.
+                // Seed at the default scope only; Magento's scope-resolution
+                // chain delivers the value to child scopes that have no
+                // override. If pass 1 already copied a default-scope
+                // customization, seedIfMissing is a no-op here.
+                $this->seedIfMissing($connection, $table, 'default', 0, self::MOBILE_LABEL_TEXT_PATH, self::SMS_LABEL_DEFAULT);
+                $this->seedIfMissing($connection, $table, 'default', 0, self::MOBILE_CONSENT_TEXT_PATH, self::SMS_CONSENT_DEFAULT);
             }
         }
 

--- a/Setup/Patch/Data/MigrateSmsToMobileConsent.php
+++ b/Setup/Patch/Data/MigrateSmsToMobileConsent.php
@@ -94,7 +94,7 @@ class MigrateSmsToMobileConsent implements DataPatchInterface, PatchVersionInter
         return (bool) $connection->fetchOne($select);
     }
 
-    private function seedIfMissing($connection, string $table, string $scope, int $scopeId, string $path, string $value): void
+    private function seedIfMissing($connection, string $table, string $scope, int $scopeId, string $path, ?string $value): void
     {
         if ($this->rowExists($connection, $table, $scope, $scopeId, $path)) {
             return;

--- a/Setup/Patch/Data/MigrateSmsToMobileConsent.php
+++ b/Setup/Patch/Data/MigrateSmsToMobileConsent.php
@@ -94,7 +94,7 @@ class MigrateSmsToMobileConsent implements DataPatchInterface, PatchVersionInter
 
     public static function getVersion()
     {
-        return '4.5.0';
+        return '5.0.0';
     }
 
     private function rowExists($connection, string $table, string $scope, int $scopeId, string $path): bool

--- a/Setup/Patch/Data/MigrateSmsToMobileConsent.php
+++ b/Setup/Patch/Data/MigrateSmsToMobileConsent.php
@@ -12,6 +12,16 @@ class MigrateSmsToMobileConsent implements DataPatchInterface, PatchVersionInter
 {
     private const SMS_CONSENT_PREFIX = 'klaviyo_reclaim_consent_at_checkout/sms_consent/';
     private const MOBILE_CHANNELS_PATH = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/channels';
+    private const MOBILE_LABEL_TEXT_PATH = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text';
+    private const MOBILE_CONSENT_TEXT_PATH = 'klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text';
+
+    // SMS-specific Figma defaults — backfilled for merchants upgrading from
+    // SMS-only consent who never customized these fields. Without this
+    // backfill they'd fall through to the new mobile_consent defaults in
+    // config.xml (which are "both"-channel copy mentioning WhatsApp).
+    // Canonical source: view/adminhtml/web/js/mobile-consent-form.js (CONTENT.sms).
+    private const SMS_LABEL_DEFAULT = 'Check this box to receive promotional marketing texts (Exclusive text messaging-only deals, offers, and coupons)';
+    private const SMS_CONSENT_DEFAULT = 'By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts (e.g., cart reminders) from [company name] including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] & Terms [link].';
 
     /**
      * @var ModuleDataSetupInterface
@@ -48,15 +58,13 @@ class MigrateSmsToMobileConsent implements DataPatchInterface, PatchVersionInter
             }
 
             // When SMS is_active was enabled, seed the channels field with 'sms'
+            // and backfill SMS-specific label/disclosure copy for merchants who
+            // never customized those fields (so they don't inherit the new
+            // "both" default in config.xml that mentions WhatsApp).
             if (strpos($row['path'], '/is_active') !== false && $row['value'] == '1') {
-                if (!$this->rowExists($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_CHANNELS_PATH)) {
-                    $connection->insert($table, [
-                        'scope'    => $row['scope'],
-                        'scope_id' => $row['scope_id'],
-                        'path'     => self::MOBILE_CHANNELS_PATH,
-                        'value'    => 'sms',
-                    ]);
-                }
+                $this->seedIfMissing($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_CHANNELS_PATH, 'sms');
+                $this->seedIfMissing($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_LABEL_TEXT_PATH, self::SMS_LABEL_DEFAULT);
+                $this->seedIfMissing($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_CONSENT_TEXT_PATH, self::SMS_CONSENT_DEFAULT);
             }
         }
 
@@ -87,5 +95,18 @@ class MigrateSmsToMobileConsent implements DataPatchInterface, PatchVersionInter
             ->where('scope_id = ?', $scopeId)
             ->where('path = ?', $path);
         return (bool) $connection->fetchOne($select);
+    }
+
+    private function seedIfMissing($connection, string $table, string $scope, int $scopeId, string $path, string $value): void
+    {
+        if ($this->rowExists($connection, $table, $scope, $scopeId, $path)) {
+            return;
+        }
+        $connection->insert($table, [
+            'scope'    => $scope,
+            'scope_id' => $scopeId,
+            'path'     => $path,
+            'value'    => $value,
+        ]);
     }
 }

--- a/Setup/Patch/Data/MigrateSmsToMobileConsent.php
+++ b/Setup/Patch/Data/MigrateSmsToMobileConsent.php
@@ -45,22 +45,19 @@ class MigrateSmsToMobileConsent implements DataPatchInterface, PatchVersionInter
             ->where('path LIKE ?', self::SMS_CONSENT_PREFIX . '%');
         $smsRows = $connection->fetchAll($select);
 
+        // Two-pass migration. Pass 1 copies every existing sms_consent row to
+        // its mobile_consent equivalent. Pass 2 backfills SMS defaults for
+        // active-SMS merchants who never customized label/disclosure copy.
+        // Pass 1 must complete before pass 2 so merchant customizations are
+        // never shadowed by a seed-default (which would happen if iteration
+        // hit /is_active before /label_text in config_id order).
+
         foreach ($smsRows as $row) {
             $mobilePath = str_replace('sms_consent/', 'mobile_consent/', $row['path']);
+            $this->seedIfMissing($connection, $table, $row['scope'], (int)$row['scope_id'], $mobilePath, $row['value']);
+        }
 
-            if (!$this->rowExists($connection, $table, $row['scope'], (int)$row['scope_id'], $mobilePath)) {
-                $connection->insert($table, [
-                    'scope'    => $row['scope'],
-                    'scope_id' => $row['scope_id'],
-                    'path'     => $mobilePath,
-                    'value'    => $row['value'],
-                ]);
-            }
-
-            // When SMS is_active was enabled, seed the channels field with 'sms'
-            // and backfill SMS-specific label/disclosure copy for merchants who
-            // never customized those fields (so they don't inherit the new
-            // "both" default in config.xml that mentions WhatsApp).
+        foreach ($smsRows as $row) {
             if (strpos($row['path'], '/is_active') !== false && $row['value'] == '1') {
                 $this->seedIfMissing($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_CHANNELS_PATH, 'sms');
                 $this->seedIfMissing($connection, $table, $row['scope'], (int)$row['scope_id'], self::MOBILE_LABEL_TEXT_PATH, self::SMS_LABEL_DEFAULT);

--- a/Test/Unit/Etc/ConfigXmlTest.php
+++ b/Test/Unit/Etc/ConfigXmlTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Klaviyo\Reclaim\Test\Unit\Etc;
+
+use PHPUnit\Framework\TestCase;
+use SimpleXMLElement;
+
+class ConfigXmlTest extends TestCase
+{
+    /** @var SimpleXMLElement */
+    private $xml;
+
+    protected function setUp(): void
+    {
+        $path = dirname(__DIR__, 3) . '/etc/config.xml';
+        $this->xml = new SimpleXMLElement(file_get_contents($path));
+    }
+
+    public function test_config_xml_contains_no_sms_consent_references()
+    {
+        $content = file_get_contents(dirname(__DIR__, 3) . '/etc/config.xml');
+        $this->assertStringNotContainsString(
+            'sms_consent',
+            $content,
+            'etc/config.xml must not reference sms_consent after migration to mobile_consent'
+        );
+    }
+
+    public function test_config_xml_mobile_consent_label_text_default_is_sms_subscribe()
+    {
+        $nodes = $this->xml->xpath(
+            '//default/klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text'
+        );
+        $this->assertNotEmpty($nodes, 'mobile_consent/label_text default must exist in config.xml');
+        $this->assertSame('Subscribe for SMS updates*', (string) $nodes[0]);
+    }
+
+    public function test_config_xml_mobile_consent_consent_text_default_is_tcpa_boilerplate()
+    {
+        $nodes = $this->xml->xpath(
+            '//default/klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text'
+        );
+        $this->assertNotEmpty($nodes, 'mobile_consent/consent_text default must exist in config.xml');
+        $this->assertStringContainsString(
+            'consent to receive marketing text messages',
+            (string) $nodes[0],
+            'consent_text default must contain TCPA boilerplate'
+        );
+    }
+
+    public function test_config_xml_mobile_consent_sort_order_default_is_200()
+    {
+        $nodes = $this->xml->xpath(
+            '//default/klaviyo_reclaim_consent_at_checkout/mobile_consent/sort_order'
+        );
+        $this->assertNotEmpty($nodes, 'mobile_consent/sort_order default must exist in config.xml');
+        $this->assertSame('200', (string) $nodes[0]);
+    }
+}

--- a/Test/Unit/Etc/ConfigXmlTest.php
+++ b/Test/Unit/Etc/ConfigXmlTest.php
@@ -28,26 +28,31 @@ class ConfigXmlTest extends TestCase
         );
     }
 
-    public function test_config_xml_mobile_consent_label_text_default_is_sms_subscribe()
+    public function test_config_xml_mobile_consent_label_text_default_exists_and_is_non_empty()
     {
         $nodes = $this->xml->xpath(
             '//default/klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text'
         );
         $this->assertNotEmpty($nodes, 'mobile_consent/label_text default must exist in config.xml');
-        $this->assertSame('Subscribe for SMS updates*', (string) $nodes[0]);
+        $this->assertNotSame('', trim((string) $nodes[0]), 'mobile_consent/label_text default must be non-empty');
     }
 
-    public function test_config_xml_mobile_consent_consent_text_default_is_tcpa_boilerplate()
+    public function test_config_xml_mobile_consent_consent_text_default_exists_and_is_non_empty()
     {
         $nodes = $this->xml->xpath(
             '//default/klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text'
         );
         $this->assertNotEmpty($nodes, 'mobile_consent/consent_text default must exist in config.xml');
-        $this->assertStringContainsString(
-            'consent to receive marketing text messages',
-            (string) $nodes[0],
-            'consent_text default must contain TCPA boilerplate'
+        $this->assertNotSame('', trim((string) $nodes[0]), 'mobile_consent/consent_text default must be non-empty');
+    }
+
+    public function test_config_xml_mobile_consent_channels_default_is_sms_and_whatsapp()
+    {
+        $nodes = $this->xml->xpath(
+            '//default/klaviyo_reclaim_consent_at_checkout/mobile_consent/channels'
         );
+        $this->assertNotEmpty($nodes, 'mobile_consent/channels default must exist in config.xml');
+        $this->assertSame('sms,whatsapp', (string) $nodes[0]);
     }
 
     public function test_config_xml_mobile_consent_sort_order_default_is_200()

--- a/Test/Unit/Helper/ScopeSettingMobileTest.php
+++ b/Test/Unit/Helper/ScopeSettingMobileTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Klaviyo\Reclaim\Test\Unit\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Klaviyo\Reclaim\Helper\ScopeSetting;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\State;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+
+class ScopeSettingMobileTest extends TestCase
+{
+    protected function createScopeSettingWithConfig(array $configValues): ScopeSetting
+    {
+        $requestMock = $this->createMock(RequestInterface::class);
+        $requestMock->method('getParam')->willReturn(1);
+
+        $scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfigMock->method('getValue')
+            ->will($this->returnCallback(
+                function ($path) use ($configValues) {
+                    return $configValues[$path] ?? null;
+                }
+            ));
+
+        $contextMock = $this->createMock(Context::class);
+        $contextMock->method('getScopeConfig')->willReturn($scopeConfigMock);
+        $contextMock->method('getRequest')->willReturn($requestMock);
+
+        $stateMock = $this->createMock(State::class);
+        $stateMock->method('getAreaCode')->willReturn(\Magento\Framework\App\Area::AREA_ADMINHTML);
+
+        $storeMock = $this->createMock(StoreInterface::class);
+        $storeMock->method('getId')->willReturn(1);
+        $storeManagerMock = $this->createMock(StoreManagerInterface::class);
+        $storeManagerMock->method('getStore')->willReturn($storeMock);
+
+        $moduleListMock = $this->createMock(ModuleListInterface::class);
+        $moduleListMock->method('getOne')->willReturn(['setup_version' => '4.5.0']);
+
+        $configWriterMock = $this->createMock(WriterInterface::class);
+
+        return new ScopeSetting(
+            $contextMock,
+            $stateMock,
+            $storeManagerMock,
+            $moduleListMock,
+            $configWriterMock
+        );
+    }
+
+    public function test_getMobileConsentIsActive_returns_mocked_value()
+    {
+        $scopeSetting = $this->createScopeSettingWithConfig([
+            ScopeSetting::CONSENT_AT_CHECKOUT_MOBILE_IS_ACTIVE => '1',
+        ]);
+        $this->assertSame('1', $scopeSetting->getMobileConsentIsActive());
+    }
+
+    public function test_getMobileConsentChannels_returns_sms_array_when_config_returns_sms()
+    {
+        $scopeSetting = $this->createScopeSettingWithConfig([
+            ScopeSetting::CONSENT_AT_CHECKOUT_MOBILE_CHANNELS => 'sms',
+        ]);
+        $this->assertSame(['sms'], $scopeSetting->getMobileConsentChannels());
+    }
+
+    public function test_getMobileConsentChannels_returns_both_when_config_returns_sms_comma_whatsapp()
+    {
+        $scopeSetting = $this->createScopeSettingWithConfig([
+            ScopeSetting::CONSENT_AT_CHECKOUT_MOBILE_CHANNELS => 'sms,whatsapp',
+        ]);
+        $this->assertSame(['sms', 'whatsapp'], $scopeSetting->getMobileConsentChannels());
+    }
+
+    public function test_getMobileConsentChannels_returns_empty_array_when_config_returns_null()
+    {
+        $scopeSetting = $this->createScopeSettingWithConfig([]);
+        $this->assertSame([], $scopeSetting->getMobileConsentChannels());
+    }
+
+    public function test_isMobileChannelEnabled_returns_true_for_sms_when_channels_contains_sms()
+    {
+        $scopeSetting = $this->createScopeSettingWithConfig([
+            ScopeSetting::CONSENT_AT_CHECKOUT_MOBILE_CHANNELS => 'sms',
+        ]);
+        $this->assertTrue($scopeSetting->isMobileChannelEnabled(1, 'sms'));
+    }
+
+    public function test_isMobileChannelEnabled_returns_false_for_whatsapp_when_channels_contains_only_sms()
+    {
+        $scopeSetting = $this->createScopeSettingWithConfig([
+            ScopeSetting::CONSENT_AT_CHECKOUT_MOBILE_CHANNELS => 'sms',
+        ]);
+        $this->assertFalse($scopeSetting->isMobileChannelEnabled(1, 'whatsapp'));
+    }
+}

--- a/Test/Unit/Model/Checkout/ShippingInformationManagementTest.php
+++ b/Test/Unit/Model/Checkout/ShippingInformationManagementTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+// Stub Magento classes so the plugin can load without the full Magento stack.
+namespace Magento\Quote\Model {
+    if (!class_exists(\Magento\Quote\Model\QuoteRepository::class, false)) {
+        class QuoteRepository
+        {
+            public function getActive($cartId)
+            {
+                return null;
+            }
+        }
+    }
+}
+
+namespace Magento\Checkout\Model {
+    if (!class_exists(\Magento\Checkout\Model\ShippingInformationManagement::class, false)) {
+        class ShippingInformationManagement
+        {
+        }
+    }
+}
+
+namespace Magento\Checkout\Api\Data {
+    if (!interface_exists(\Magento\Checkout\Api\Data\ShippingInformationInterface::class, false)) {
+        interface ShippingInformationInterface
+        {
+            public function getExtensionAttributes();
+        }
+    }
+}
+
+namespace Klaviyo\Reclaim\Test\Unit\Model\Checkout {
+
+    use Klaviyo\Reclaim\Model\Checkout\ShippingInformationManagement;
+    use Magento\Checkout\Api\Data\ShippingInformationInterface;
+    use Magento\Checkout\Model\ShippingInformationManagement as Subject;
+    use Magento\Quote\Model\QuoteRepository;
+    use PHPUnit\Framework\TestCase;
+
+    class ShippingInformationManagementTest extends TestCase
+    {
+        private function buildPlugin($quote): ShippingInformationManagement
+        {
+            $repo = $this->getMockBuilder(QuoteRepository::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $repo->method('getActive')->willReturn($quote);
+            return new ShippingInformationManagement($repo);
+        }
+
+        private function buildAddressInfo($extAttributes): ShippingInformationInterface
+        {
+            $info = $this->getMockBuilder(ShippingInformationInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $info->method('getExtensionAttributes')->willReturn($extAttributes);
+            return $info;
+        }
+
+        public function test_beforeSaveAddressInformation_mobile_consent_sets_kl_mobile_consent_on_quote()
+        {
+            $extAttributes = new class {
+                public function getKlMobileConsent(): string
+                {
+                    return '1';
+                }
+                public function getKlEmailConsent(): ?string
+                {
+                    return null;
+                }
+            };
+
+            $quote = $this->getMockBuilder(\stdClass::class)
+                ->addMethods(['setKlMobileConsent', 'setKlEmailConsent'])
+                ->getMock();
+            $quote->expects($this->once())
+                ->method('setKlMobileConsent')
+                ->with('1');
+            $quote->expects($this->once())
+                ->method('setKlEmailConsent')
+                ->with(null);
+
+            $plugin = $this->buildPlugin($quote);
+            $plugin->beforeSaveAddressInformation(
+                new Subject(),
+                1,
+                $this->buildAddressInfo($extAttributes)
+            );
+        }
+
+        public function test_beforeSaveAddressInformation_email_consent_sets_kl_email_consent_on_quote()
+        {
+            $extAttributes = new class {
+                public function getKlMobileConsent(): ?string
+                {
+                    return null;
+                }
+                public function getKlEmailConsent(): string
+                {
+                    return '1';
+                }
+            };
+
+            $quote = $this->getMockBuilder(\stdClass::class)
+                ->addMethods(['setKlMobileConsent', 'setKlEmailConsent'])
+                ->getMock();
+            $quote->expects($this->once())
+                ->method('setKlMobileConsent')
+                ->with(null);
+            $quote->expects($this->once())
+                ->method('setKlEmailConsent')
+                ->with('1');
+
+            $plugin = $this->buildPlugin($quote);
+            $plugin->beforeSaveAddressInformation(
+                new Subject(),
+                1,
+                $this->buildAddressInfo($extAttributes)
+            );
+        }
+
+        public function test_beforeSaveAddressInformation_no_ext_attributes_returns_null()
+        {
+            $info = $this->getMockBuilder(ShippingInformationInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $info->method('getExtensionAttributes')->willReturn(null);
+
+            $repo = $this->getMockBuilder(QuoteRepository::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $repo->expects($this->never())->method('getActive');
+
+            $plugin = new ShippingInformationManagement($repo);
+            $result = $plugin->beforeSaveAddressInformation(new Subject(), 1, $info);
+            $this->assertNull($result);
+        }
+    }
+}

--- a/Test/Unit/Model/Checkout/ShippingInformationManagementTest.php
+++ b/Test/Unit/Model/Checkout/ShippingInformationManagementTest.php
@@ -60,10 +60,10 @@ namespace Klaviyo\Reclaim\Test\Unit\Model\Checkout {
             return $info;
         }
 
-        public function test_beforeSaveAddressInformation_mobile_consent_sets_kl_mobile_consent_on_quote()
+        public function test_beforeSaveAddressInformation_mobile_consent_sets_kl_sms_consent_on_quote()
         {
             $extAttributes = new class {
-                public function getKlMobileConsent(): string
+                public function getKlSmsConsent(): string
                 {
                     return '1';
                 }
@@ -74,10 +74,10 @@ namespace Klaviyo\Reclaim\Test\Unit\Model\Checkout {
             };
 
             $quote = $this->getMockBuilder(\stdClass::class)
-                ->addMethods(['setKlMobileConsent', 'setKlEmailConsent'])
+                ->addMethods(['setKlSmsConsent', 'setKlEmailConsent'])
                 ->getMock();
             $quote->expects($this->once())
-                ->method('setKlMobileConsent')
+                ->method('setKlSmsConsent')
                 ->with('1');
             $quote->expects($this->once())
                 ->method('setKlEmailConsent')
@@ -94,7 +94,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Model\Checkout {
         public function test_beforeSaveAddressInformation_email_consent_sets_kl_email_consent_on_quote()
         {
             $extAttributes = new class {
-                public function getKlMobileConsent(): ?string
+                public function getKlSmsConsent(): ?string
                 {
                     return null;
                 }
@@ -105,10 +105,10 @@ namespace Klaviyo\Reclaim\Test\Unit\Model\Checkout {
             };
 
             $quote = $this->getMockBuilder(\stdClass::class)
-                ->addMethods(['setKlMobileConsent', 'setKlEmailConsent'])
+                ->addMethods(['setKlSmsConsent', 'setKlEmailConsent'])
                 ->getMock();
             $quote->expects($this->once())
-                ->method('setKlMobileConsent')
+                ->method('setKlSmsConsent')
                 ->with(null);
             $quote->expects($this->once())
                 ->method('setKlEmailConsent')

--- a/Test/Unit/Model/Config/Source/MobileChannelsTest.php
+++ b/Test/Unit/Model/Config/Source/MobileChannelsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+// Stub Magento's framework interface so MobileChannels can load without the full Magento framework.
+namespace Magento\Framework\Option {
+    if (!interface_exists(\Magento\Framework\Option\ArrayInterface::class)) {
+        interface ArrayInterface
+        {
+            public function toOptionArray();
+        }
+    }
+}
+
+// Stub Magento's __() translation function in the MobileChannels namespace.
+namespace Klaviyo\Reclaim\Model\Config\Source {
+    if (!function_exists('Klaviyo\Reclaim\Model\Config\Source\__')) {
+        function __($string)
+        {
+            return $string;
+        }
+    }
+}
+
+namespace Klaviyo\Reclaim\Test\Unit\Model\Config\Source {
+
+    use PHPUnit\Framework\TestCase;
+    use Klaviyo\Reclaim\Model\Config\Source\MobileChannels;
+
+    class MobileChannelsTest extends TestCase
+    {
+        /**
+         * @var MobileChannels
+         */
+        protected $mobileChannels;
+
+        protected function setUp(): void
+        {
+            $this->mobileChannels = new MobileChannels();
+        }
+
+        public function test_toOptionArray_returns_exactly_two_entries()
+        {
+            $result = $this->mobileChannels->toOptionArray();
+            $this->assertCount(2, $result);
+        }
+
+        public function test_toOptionArray_first_entry_has_sms_value()
+        {
+            $result = $this->mobileChannels->toOptionArray();
+            $values = array_column($result, 'value');
+            $this->assertContains('sms', $values);
+        }
+
+        public function test_toOptionArray_second_entry_has_whatsapp_value()
+        {
+            $result = $this->mobileChannels->toOptionArray();
+            $values = array_column($result, 'value');
+            $this->assertContains('whatsapp', $values);
+        }
+
+        public function test_toOptionArray_implements_array_interface()
+        {
+            $this->assertInstanceOf(\Magento\Framework\Option\ArrayInterface::class, $this->mobileChannels);
+        }
+    }
+}

--- a/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
+++ b/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
@@ -1,0 +1,422 @@
+<?php
+
+/**
+ * Stub Magento\Framework\Event\Observer and related classes so the observer can load
+ * without the full Magento framework installed.
+ */
+
+namespace Magento\Framework\Event {
+    if (!class_exists(\Magento\Framework\Event\Observer::class, false)) {
+        class Observer
+        {
+            public function getEvent()
+            {
+                return new Event();
+            }
+        }
+    }
+    if (!class_exists(\Magento\Framework\Event\Event::class, false)) {
+        class Event
+        {
+            public function getOrder()
+            {
+                return null;
+            }
+            public function getQuote()
+            {
+                return null;
+            }
+        }
+    }
+    if (!interface_exists(\Magento\Framework\Event\ObserverInterface::class, false)) {
+        interface ObserverInterface
+        {
+            public function execute(Observer $observer);
+        }
+    }
+}
+
+/**
+ * Stub Magento\Framework\App\Helper\AbstractHelper so ScopeSetting can load.
+ */
+namespace Magento\Framework\App\Helper {
+    if (!class_exists(\Magento\Framework\App\Helper\AbstractHelper::class, false)) {
+        abstract class AbstractHelper
+        {
+            public function __construct($context = null)
+            {
+            }
+        }
+    }
+}
+
+namespace Klaviyo\Reclaim\Test\Unit\Observer {
+
+    use PHPUnit\Framework\TestCase;
+    use Klaviyo\Reclaim\Helper\Logger;
+    use Klaviyo\Reclaim\Helper\ScopeSetting;
+    use Klaviyo\Reclaim\KlaviyoV3Sdk\KlaviyoV3Api;
+    use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoApiException;
+    use Klaviyo\Reclaim\Observer\SaveOrderMarketingConsent;
+    use Magento\Framework\Event\Observer;
+
+    /**
+     * Testable subclass that replaces buildKlaviyoV3Api() with an injected mock.
+     */
+    class TestableSaveOrderMarketingConsent extends SaveOrderMarketingConsent
+    {
+        private $apiMock;
+
+        public function __construct(Logger $logger, ScopeSetting $scopeSetting, KlaviyoV3Api $apiMock)
+        {
+            parent::__construct($logger, $scopeSetting);
+            $this->apiMock = $apiMock;
+        }
+
+        protected function buildKlaviyoV3Api($storeId = null): KlaviyoV3Api
+        {
+            return $this->apiMock;
+        }
+    }
+
+    /**
+     * Stub order that captures setData calls.
+     */
+    class StubOrder
+    {
+        public $data = [];
+
+        public function setData($key, $value)
+        {
+            $this->data[$key] = $value;
+        }
+    }
+
+    /**
+     * Stub shipping address.
+     */
+    class StubAddress
+    {
+        private $phone;
+
+        public function __construct($phone)
+        {
+            $this->phone = $phone;
+        }
+
+        public function getTelephone()
+        {
+            return $this->phone;
+        }
+    }
+
+    /**
+     * Stub quote.
+     */
+    class StubQuote
+    {
+        private $mobileConsent;
+        private $emailConsent;
+        private $storeId;
+        private $customerEmail;
+        private $address;
+
+        public function __construct($mobileConsent, $emailConsent, $storeId, $customerEmail, $address)
+        {
+            $this->mobileConsent = $mobileConsent;
+            $this->emailConsent = $emailConsent;
+            $this->storeId = $storeId;
+            $this->customerEmail = $customerEmail;
+            $this->address = $address;
+        }
+
+        public function getKlMobileConsent()
+        {
+            return $this->mobileConsent;
+        }
+
+        public function getKlEmailConsent()
+        {
+            return $this->emailConsent;
+        }
+
+        public function getStoreId()
+        {
+            return $this->storeId;
+        }
+
+        public function getCustomerEmail()
+        {
+            return $this->customerEmail;
+        }
+
+        public function getShippingAddress()
+        {
+            return $this->address;
+        }
+    }
+
+    /**
+     * Stub event that holds order and quote.
+     */
+    class StubEvent extends \Magento\Framework\Event\Event
+    {
+        private $order;
+        private $quote;
+
+        public function __construct($order, $quote)
+        {
+            $this->order = $order;
+            $this->quote = $quote;
+        }
+
+        public function getOrder()
+        {
+            return $this->order;
+        }
+
+        public function getQuote()
+        {
+            return $this->quote;
+        }
+    }
+
+    /**
+     * Stub observer that holds a stub event.
+     */
+    class StubObserver extends Observer
+    {
+        private $event;
+
+        public function __construct($event)
+        {
+            $this->event = $event;
+        }
+
+        public function getEvent()
+        {
+            return $this->event;
+        }
+    }
+
+    class SaveOrderMarketingConsentTest extends TestCase
+    {
+        private function makeMagentoObserver($mobileConsent, $emailConsent, $storeId = 1)
+        {
+            $order = new StubOrder();
+            $address = new StubAddress('555-0100');
+            $quote = new StubQuote($mobileConsent, $emailConsent, $storeId, 'buyer@example.com', $address);
+            $event = new StubEvent($order, $quote);
+            return new StubObserver($event);
+        }
+
+        private function makeScopeMock($mobileActive, $emailActive, array $channels)
+        {
+            $mock = $this->getMockBuilder(ScopeSetting::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $mock->method('getMobileConsentIsActive')->willReturn($mobileActive ? '1' : null);
+            $mock->method('getConsentAtCheckoutEmailIsActive')->willReturn($emailActive ? '1' : null);
+            $mock->method('getMobileConsentListId')->willReturn('mobile-list-id');
+            $mock->method('getConsentAtCheckoutEmailListId')->willReturn('email-list-id');
+            $mock->method('getMobileConsentChannels')->willReturn($channels);
+            $channelsCopy = $channels;
+            $mock->method('isMobileChannelEnabled')->willReturnCallback(
+                function ($storeId, $channel) use ($channelsCopy) {
+                    return in_array($channel, $channelsCopy, true);
+                }
+            );
+            $mock->method('getPublicApiKey')->willReturn('pk');
+            $mock->method('getPrivateApiKey')->willReturn('sk');
+            return $mock;
+        }
+
+        private function makeLoggerMock()
+        {
+            return $this->getMockBuilder(Logger::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
+
+        private function makeApiMock()
+        {
+            return $this->getMockBuilder(KlaviyoV3Api::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
+
+        public function test_sms_only_enabled_mobile_consent_true_subscribe_has_sms_key_not_whatsapp()
+        {
+            $scope = $this->makeScopeMock(true, false, ['sms']);
+            $api = $this->makeApiMock();
+            $magentoObserver = $this->makeMagentoObserver('1', null);
+
+            $capturedProfiles = null;
+            $api->expects($this->once())
+                ->method('subscribeMembersToList')
+                ->with(
+                    'mobile-list-id',
+                    $this->callback(function ($profiles) use (&$capturedProfiles) {
+                        $capturedProfiles = $profiles;
+                        return true;
+                    })
+                );
+
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer->execute($magentoObserver);
+
+            $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
+            $this->assertArrayHasKey('sms', $subscriptions);
+            $this->assertArrayNotHasKey('whatsapp', $subscriptions);
+        }
+
+        public function test_whatsapp_only_enabled_mobile_consent_true_subscribe_has_whatsapp_key_not_sms()
+        {
+            $scope = $this->makeScopeMock(true, false, ['whatsapp']);
+            $api = $this->makeApiMock();
+            $magentoObserver = $this->makeMagentoObserver('1', null);
+
+            $capturedProfiles = null;
+            $api->expects($this->once())
+                ->method('subscribeMembersToList')
+                ->with(
+                    'mobile-list-id',
+                    $this->callback(function ($profiles) use (&$capturedProfiles) {
+                        $capturedProfiles = $profiles;
+                        return true;
+                    })
+                );
+
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer->execute($magentoObserver);
+
+            $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
+            $this->assertArrayHasKey('whatsapp', $subscriptions);
+            $this->assertArrayNotHasKey('sms', $subscriptions);
+        }
+
+        public function test_both_channels_enabled_mobile_consent_true_subscribe_has_sms_and_whatsapp_keys()
+        {
+            $scope = $this->makeScopeMock(true, false, ['sms', 'whatsapp']);
+            $api = $this->makeApiMock();
+            $magentoObserver = $this->makeMagentoObserver('1', null);
+
+            $capturedProfiles = null;
+            $api->expects($this->once())
+                ->method('subscribeMembersToList')
+                ->with(
+                    'mobile-list-id',
+                    $this->callback(function ($profiles) use (&$capturedProfiles) {
+                        $capturedProfiles = $profiles;
+                        return true;
+                    })
+                );
+
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer->execute($magentoObserver);
+
+            $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
+            $this->assertArrayHasKey('sms', $subscriptions);
+            $this->assertArrayHasKey('whatsapp', $subscriptions);
+            $this->assertSame('SUBSCRIBED', $subscriptions['sms']['marketing']['consent']);
+            $this->assertSame('SUBSCRIBED', $subscriptions['whatsapp']['marketing']['consent']);
+        }
+
+        public function test_email_only_mobile_consent_false_subscribe_called_once_with_email_key_no_mobile()
+        {
+            $scope = $this->makeScopeMock(false, true, []);
+            $api = $this->makeApiMock();
+            $magentoObserver = $this->makeMagentoObserver(null, '1');
+
+            $capturedListId = null;
+            $capturedProfiles = null;
+            $api->expects($this->once())
+                ->method('subscribeMembersToList')
+                ->with(
+                    $this->callback(function ($listId) use (&$capturedListId) {
+                        $capturedListId = $listId;
+                        return true;
+                    }),
+                    $this->callback(function ($profiles) use (&$capturedProfiles) {
+                        $capturedProfiles = $profiles;
+                        return true;
+                    })
+                );
+
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer->execute($magentoObserver);
+
+            $this->assertSame('email-list-id', $capturedListId);
+            $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
+            $this->assertArrayHasKey('email', $subscriptions);
+            $this->assertArrayNotHasKey('sms', $subscriptions);
+            $this->assertArrayNotHasKey('whatsapp', $subscriptions);
+        }
+
+        public function test_email_and_mobile_both_consents_true_two_subscribe_calls_with_correct_keys()
+        {
+            $scope = $this->makeScopeMock(true, true, ['sms', 'whatsapp']);
+            $api = $this->makeApiMock();
+            $magentoObserver = $this->makeMagentoObserver('1', '1');
+
+            $calls = [];
+            $api->expects($this->exactly(2))
+                ->method('subscribeMembersToList')
+                ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
+                    $calls[] = ['listId' => $listId, 'profiles' => $profiles];
+                });
+
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer->execute($magentoObserver);
+
+            $this->assertCount(2, $calls);
+
+            $emailCall = null;
+            $mobileCall = null;
+            foreach ($calls as $call) {
+                if ($call['listId'] === 'email-list-id') {
+                    $emailCall = $call;
+                } elseif ($call['listId'] === 'mobile-list-id') {
+                    $mobileCall = $call;
+                }
+            }
+
+            $this->assertNotNull($emailCall, 'Expected an email subscribe call');
+            $this->assertNotNull($mobileCall, 'Expected a mobile subscribe call');
+
+            $emailSubs = $emailCall['profiles'][0]['attributes']['subscriptions'];
+            $this->assertArrayHasKey('email', $emailSubs);
+
+            $mobileSubs = $mobileCall['profiles'][0]['attributes']['subscriptions'];
+            $this->assertArrayHasKey('sms', $mobileSubs);
+            $this->assertArrayHasKey('whatsapp', $mobileSubs);
+        }
+
+        public function test_no_webhook_call_constructor_does_not_accept_webhook_parameter()
+        {
+            $reflection = new \ReflectionClass(SaveOrderMarketingConsent::class);
+            $constructor = $reflection->getConstructor();
+            $paramTypes = [];
+            foreach ($constructor->getParameters() as $param) {
+                $type = $param->getType();
+                $paramTypes[] = $type ? $type->getName() : '';
+            }
+            $this->assertNotContains('Klaviyo\Reclaim\Helper\Webhook', $paramTypes);
+            $this->assertCount(2, $constructor->getParameters());
+        }
+
+        public function test_v3_error_does_not_fail_order_execute_returns_observer()
+        {
+            $scope = $this->makeScopeMock(true, false, ['sms']);
+            $api = $this->makeApiMock();
+            $magentoObserver = $this->makeMagentoObserver('1', null);
+
+            $api->method('subscribeMembersToList')
+                ->willThrowException(new KlaviyoApiException('V3 error'));
+
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $result = $observer->execute($magentoObserver);
+            $this->assertSame($observer, $result);
+        }
+    }
+}

--- a/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
+++ b/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
@@ -303,31 +303,36 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
             $this->assertArrayNotHasKey('sms', $subscriptions);
         }
 
-        public function test_both_channels_enabled_mobile_consent_true_subscribe_has_sms_and_whatsapp_keys()
+        public function test_both_channels_enabled_mobile_consent_true_two_separate_subscribe_calls()
         {
             $scope = $this->makeScopeMock(true, false, ['sms', 'whatsapp']);
             $api = $this->makeApiMock();
             $magentoObserver = $this->makeMagentoObserver('1', null);
 
-            $capturedProfiles = null;
-            $api->expects($this->once())
+            $calls = [];
+            $api->expects($this->exactly(2))
                 ->method('subscribeMembersToList')
-                ->with(
-                    'mobile-list-id',
-                    $this->callback(function ($profiles) use (&$capturedProfiles) {
-                        $capturedProfiles = $profiles;
-                        return true;
-                    })
-                );
+                ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
+                    $calls[] = ['listId' => $listId, 'profiles' => $profiles];
+                });
 
             $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
             $observer->execute($magentoObserver);
 
-            $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
-            $this->assertArrayHasKey('sms', $subscriptions);
-            $this->assertArrayHasKey('whatsapp', $subscriptions);
-            $this->assertSame('SUBSCRIBED', $subscriptions['sms']['marketing']['consent']);
-            $this->assertSame('SUBSCRIBED', $subscriptions['whatsapp']['marketing']['consent']);
+            $this->assertCount(2, $calls);
+            // Both calls go to the same mobile list.
+            $this->assertSame('mobile-list-id', $calls[0]['listId']);
+            $this->assertSame('mobile-list-id', $calls[1]['listId']);
+
+            // Each call carries exactly one channel in its subscriptions payload.
+            $sub0 = $calls[0]['profiles'][0]['attributes']['subscriptions'];
+            $sub1 = $calls[1]['profiles'][0]['attributes']['subscriptions'];
+            $this->assertArrayHasKey('sms', $sub0);
+            $this->assertArrayNotHasKey('whatsapp', $sub0);
+            $this->assertSame('SUBSCRIBED', $sub0['sms']['marketing']['consent']);
+            $this->assertArrayHasKey('whatsapp', $sub1);
+            $this->assertArrayNotHasKey('sms', $sub1);
+            $this->assertSame('SUBSCRIBED', $sub1['whatsapp']['marketing']['consent']);
         }
 
         public function test_email_only_mobile_consent_false_subscribe_called_once_with_email_key_no_mobile()
@@ -361,14 +366,14 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
             $this->assertArrayNotHasKey('whatsapp', $subscriptions);
         }
 
-        public function test_email_and_mobile_both_consents_true_two_subscribe_calls_with_correct_keys()
+        public function test_email_and_mobile_both_consents_true_three_subscribe_calls_one_per_channel()
         {
             $scope = $this->makeScopeMock(true, true, ['sms', 'whatsapp']);
             $api = $this->makeApiMock();
             $magentoObserver = $this->makeMagentoObserver('1', '1');
 
             $calls = [];
-            $api->expects($this->exactly(2))
+            $api->expects($this->exactly(3))
                 ->method('subscribeMembersToList')
                 ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
                     $calls[] = ['listId' => $listId, 'profiles' => $profiles];
@@ -377,27 +382,30 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
             $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
             $observer->execute($magentoObserver);
 
-            $this->assertCount(2, $calls);
+            $this->assertCount(3, $calls);
 
-            $emailCall = null;
-            $mobileCall = null;
+            // Partition calls by what they target.
+            $emailCalls = [];
+            $smsCalls = [];
+            $whatsappCalls = [];
             foreach ($calls as $call) {
-                if ($call['listId'] === 'email-list-id') {
-                    $emailCall = $call;
-                } elseif ($call['listId'] === 'mobile-list-id') {
-                    $mobileCall = $call;
+                $subs = $call['profiles'][0]['attributes']['subscriptions'];
+                if (array_key_exists('email', $subs)) {
+                    $emailCalls[] = $call;
+                } elseif (array_key_exists('sms', $subs)) {
+                    $smsCalls[] = $call;
+                } elseif (array_key_exists('whatsapp', $subs)) {
+                    $whatsappCalls[] = $call;
                 }
             }
 
-            $this->assertNotNull($emailCall, 'Expected an email subscribe call');
-            $this->assertNotNull($mobileCall, 'Expected a mobile subscribe call');
+            $this->assertCount(1, $emailCalls, 'Expected exactly one email subscribe call');
+            $this->assertCount(1, $smsCalls, 'Expected exactly one sms subscribe call');
+            $this->assertCount(1, $whatsappCalls, 'Expected exactly one whatsapp subscribe call');
 
-            $emailSubs = $emailCall['profiles'][0]['attributes']['subscriptions'];
-            $this->assertArrayHasKey('email', $emailSubs);
-
-            $mobileSubs = $mobileCall['profiles'][0]['attributes']['subscriptions'];
-            $this->assertArrayHasKey('sms', $mobileSubs);
-            $this->assertArrayHasKey('whatsapp', $mobileSubs);
+            $this->assertSame('email-list-id', $emailCalls[0]['listId']);
+            $this->assertSame('mobile-list-id', $smsCalls[0]['listId']);
+            $this->assertSame('mobile-list-id', $whatsappCalls[0]['listId']);
         }
 
         public function test_no_webhook_call_constructor_does_not_accept_webhook_parameter()
@@ -461,6 +469,35 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
 
             $this->assertCount(1, $calls, 'Only the email subscribe should fire when mobile phone is unparseable');
             $this->assertSame('email-list-id', $calls[0]['listId']);
+        }
+
+        public function test_both_channels_enabled_one_channel_failure_does_not_block_other_channel()
+        {
+            // Per-channel subscribe semantics: if the first call (sms) throws,
+            // the second call (whatsapp) must still fire.
+            $scope = $this->makeScopeMock(true, false, ['sms', 'whatsapp']);
+            $api = $this->makeApiMock();
+            $magentoObserver = $this->makeMagentoObserver('1', null);
+
+            $calls = [];
+            $callCount = 0;
+            $api->method('subscribeMembersToList')
+                ->willReturnCallback(function ($listId, $profiles) use (&$calls, &$callCount) {
+                    $callCount++;
+                    $calls[] = ['listId' => $listId, 'profiles' => $profiles];
+                    if ($callCount === 1) {
+                        throw new KlaviyoApiException('Simulated SMS subscribe failure');
+                    }
+                });
+
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+            $observer->execute($magentoObserver);
+
+            $this->assertCount(2, $calls, 'Second channel subscribe must still fire after first throws');
+            $subs1 = $calls[0]['profiles'][0]['attributes']['subscriptions'];
+            $subs2 = $calls[1]['profiles'][0]['attributes']['subscriptions'];
+            $this->assertArrayHasKey('sms', $subs1, 'First call should target sms (the one that throws)');
+            $this->assertArrayHasKey('whatsapp', $subs2, 'Second call should still target whatsapp despite first failure');
         }
     }
 }

--- a/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
+++ b/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
@@ -58,6 +58,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
     use Klaviyo\Reclaim\KlaviyoV3Sdk\KlaviyoV3Api;
     use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoApiException;
     use Klaviyo\Reclaim\Observer\SaveOrderMarketingConsent;
+    use Klaviyo\Reclaim\Util\PhoneFormatter;
     use Magento\Framework\Event\Observer;
 
     /**
@@ -67,9 +68,9 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
     {
         private $apiMock;
 
-        public function __construct(Logger $logger, ScopeSetting $scopeSetting, KlaviyoV3Api $apiMock)
+        public function __construct(Logger $logger, ScopeSetting $scopeSetting, PhoneFormatter $phoneFormatter, KlaviyoV3Api $apiMock)
         {
-            parent::__construct($logger, $scopeSetting);
+            parent::__construct($logger, $scopeSetting, $phoneFormatter);
             $this->apiMock = $apiMock;
         }
 
@@ -98,15 +99,22 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
     class StubAddress
     {
         private $phone;
+        private $countryId;
 
-        public function __construct($phone)
+        public function __construct($phone, $countryId = 'US')
         {
             $this->phone = $phone;
+            $this->countryId = $countryId;
         }
 
         public function getTelephone()
         {
             return $this->phone;
+        }
+
+        public function getCountryId()
+        {
+            return $this->countryId;
         }
     }
 
@@ -201,10 +209,10 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
 
     class SaveOrderMarketingConsentTest extends TestCase
     {
-        private function makeMagentoObserver($mobileConsent, $emailConsent, $storeId = 1)
+        private function makeMagentoObserver($mobileConsent, $emailConsent, $storeId = 1, $phone = '(202) 555-0100', $country = 'US')
         {
             $order = new StubOrder();
-            $address = new StubAddress('555-0100');
+            $address = new StubAddress($phone, $country);
             $quote = new StubQuote($mobileConsent, $emailConsent, $storeId, 'buyer@example.com', $address);
             $event = new StubEvent($order, $quote);
             return new StubObserver($event);
@@ -262,7 +270,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
                     })
                 );
 
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
             $observer->execute($magentoObserver);
 
             $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
@@ -287,7 +295,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
                     })
                 );
 
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
             $observer->execute($magentoObserver);
 
             $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
@@ -312,7 +320,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
                     })
                 );
 
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
             $observer->execute($magentoObserver);
 
             $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
@@ -343,7 +351,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
                     })
                 );
 
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
             $observer->execute($magentoObserver);
 
             $this->assertSame('email-list-id', $capturedListId);
@@ -366,7 +374,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
                     $calls[] = ['listId' => $listId, 'profiles' => $profiles];
                 });
 
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
             $observer->execute($magentoObserver);
 
             $this->assertCount(2, $calls);
@@ -402,7 +410,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
                 $paramTypes[] = $type ? $type->getName() : '';
             }
             $this->assertNotContains('Klaviyo\Reclaim\Helper\Webhook', $paramTypes);
-            $this->assertCount(2, $constructor->getParameters());
+            $this->assertCount(3, $constructor->getParameters());
         }
 
         public function test_v3_error_does_not_fail_order_execute_returns_observer()
@@ -414,9 +422,45 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
             $api->method('subscribeMembersToList')
                 ->willThrowException(new KlaviyoApiException('V3 error'));
 
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, $api);
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
             $result = $observer->execute($magentoObserver);
             $this->assertSame($observer, $result);
+        }
+
+        public function test_mobile_consent_phone_unparseable_skips_mobile_subscribe_call()
+        {
+            $scope = $this->makeScopeMock(true, false, ['sms']);
+            $api = $this->makeApiMock();
+            $magentoObserver = $this->makeMagentoObserver('1', null, 1, 'not-a-number', 'US');
+
+            $api->expects($this->never())->method('subscribeMembersToList');
+
+            $logger = $this->makeLoggerMock();
+            $logger->expects($this->atLeastOnce())
+                ->method('log')
+                ->with($this->stringContains('Mobile subscribe skipped'));
+
+            $observer = new TestableSaveOrderMarketingConsent($logger, $scope, new PhoneFormatter(), $api);
+            $observer->execute($magentoObserver);
+        }
+
+        public function test_email_consent_unaffected_by_mobile_phone_failure()
+        {
+            $scope = $this->makeScopeMock(true, true, ['sms']);
+            $api = $this->makeApiMock();
+            $magentoObserver = $this->makeMagentoObserver('1', '1', 1, 'not-a-number', 'US');
+
+            $calls = [];
+            $api->method('subscribeMembersToList')
+                ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
+                    $calls[] = ['listId' => $listId, 'profiles' => $profiles];
+                });
+
+            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+            $observer->execute($magentoObserver);
+
+            $this->assertCount(1, $calls, 'Only the email subscribe should fire when mobile phone is unparseable');
+            $this->assertSame('email-list-id', $calls[0]['listId']);
         }
     }
 }

--- a/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
+++ b/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
@@ -130,7 +130,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Observer {
             $this->address = $address;
         }
 
-        public function getKlMobileConsent()
+        public function getKlSmsConsent()
         {
             return $this->mobileConsent;
         }

--- a/Test/Unit/Plugin/CheckoutLayoutPluginTest.php
+++ b/Test/Unit/Plugin/CheckoutLayoutPluginTest.php
@@ -136,11 +136,10 @@ namespace Klaviyo\Reclaim\Test\Unit\Plugin {
             $fieldset = $result['components']['checkout']['children']['steps']['children']
                 ['shipping-step']['children']['shippingAddress']['children']
                 ['shipping-address-fieldset']['children'];
-            $this->assertArrayNotHasKey('kl_mobile_consent', $fieldset);
             $this->assertArrayNotHasKey('kl_sms_consent', $fieldset);
         }
 
-        public function test_afterProcess_mobile_active_no_default_address_adds_kl_mobile_consent_to_fieldset()
+        public function test_afterProcess_mobile_active_no_default_address_adds_kl_sms_consent_to_fieldset()
         {
             $scope = $this->makeScopeMock(true);
             $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
@@ -153,10 +152,9 @@ namespace Klaviyo\Reclaim\Test\Unit\Plugin {
             $fieldset = $result['components']['checkout']['children']['steps']['children']
                 ['shipping-step']['children']['shippingAddress']['children']
                 ['shipping-address-fieldset']['children'];
-            $this->assertArrayHasKey('kl_mobile_consent', $fieldset);
-            $this->assertArrayNotHasKey('kl_sms_consent', $fieldset);
-            $this->assertSame('kl_mobile_consent', $fieldset['kl_mobile_consent']['config']['id']);
-            $this->assertStringContainsString('kl_mobile_consent', $fieldset['kl_mobile_consent']['dataScope']);
+            $this->assertArrayHasKey('kl_sms_consent', $fieldset);
+            $this->assertSame('kl_sms_consent', $fieldset['kl_sms_consent']['config']['id']);
+            $this->assertStringContainsString('kl_sms_consent', $fieldset['kl_sms_consent']['dataScope']);
         }
 
         public function test_afterProcess_mobile_active_with_default_address_adds_mobile_consent_and_phone_to_before_form()
@@ -188,10 +186,8 @@ namespace Klaviyo\Reclaim\Test\Unit\Plugin {
             $beforeForm = $result['components']['checkout']['children']['steps']['children']
                 ['shipping-step']['children']['shippingAddress']['children']
                 ['before-form']['children'];
-            $this->assertArrayHasKey('kl_mobile_consent', $beforeForm);
-            $this->assertArrayHasKey('kl_mobile_phone_number', $beforeForm);
-            $this->assertArrayNotHasKey('kl_sms_consent', $beforeForm);
-            $this->assertArrayNotHasKey('kl_sms_phone_number', $beforeForm);
+            $this->assertArrayHasKey('kl_sms_consent', $beforeForm);
+            $this->assertArrayHasKey('kl_sms_phone_number', $beforeForm);
         }
     }
 }

--- a/Test/Unit/Plugin/CheckoutLayoutPluginTest.php
+++ b/Test/Unit/Plugin/CheckoutLayoutPluginTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Stub Magento\Framework\App\Helper\AbstractHelper so ScopeSetting can be loaded/mocked
+ * without the full Magento framework installed in the test environment.
+ */
+
+namespace Magento\Framework\App\Helper {
+    if (!class_exists(\Magento\Framework\App\Helper\AbstractHelper::class, false)) {
+        abstract class AbstractHelper
+        {
+            public function __construct($context = null)
+            {
+            }
+        }
+    }
+}
+
+/**
+ * Stub Magento Customer classes used by CheckoutLayoutPlugin.
+ */
+namespace Magento\Customer\Model {
+    if (!class_exists(\Magento\Customer\Model\Session::class, false)) {
+        class Session
+        {
+            public function isLoggedIn(): bool
+            {
+                return false;
+            }
+            public function getCustomer()
+            {
+                return null;
+            }
+        }
+    }
+    if (!class_exists(\Magento\Customer\Model\Customer::class, false)) {
+        class Customer
+        {
+            public function getData(): array
+            {
+                return [];
+            }
+            public function load($id): self
+            {
+                return $this;
+            }
+            public function getDefaultShippingAddress()
+            {
+                return false;
+            }
+        }
+    }
+    if (!class_exists(\Magento\Customer\Model\CustomerFactory::class, false)) {
+        class CustomerFactory
+        {
+            public function create(): Customer
+            {
+                return new Customer();
+            }
+        }
+    }
+}
+
+/**
+ * Stub the LayoutProcessor subject class.
+ */
+namespace Magento\Checkout\Block\Checkout {
+    if (!class_exists(\Magento\Checkout\Block\Checkout\LayoutProcessor::class, false)) {
+        class LayoutProcessor
+        {
+        }
+    }
+}
+
+namespace Klaviyo\Reclaim\Test\Unit\Plugin {
+
+    use PHPUnit\Framework\TestCase;
+    use Klaviyo\Reclaim\Plugin\CheckoutLayoutPlugin;
+    use Klaviyo\Reclaim\Helper\ScopeSetting;
+    use Magento\Customer\Model\Customer;
+    use Magento\Customer\Model\CustomerFactory;
+    use Magento\Customer\Model\Session;
+    use Magento\Checkout\Block\Checkout\LayoutProcessor;
+
+    class CheckoutLayoutPluginTest extends TestCase
+    {
+        private function buildBaseJsLayout(): array
+        {
+            return [
+                'components' => [
+                    'checkout' => [
+                        'children' => [
+                            'steps' => [
+                                'children' => [
+                                    'shipping-step' => [
+                                        'children' => [
+                                            'shippingAddress' => [
+                                                'children' => [
+                                                    'shipping-address-fieldset' => ['children' => []],
+                                                    'before-form' => ['children' => []],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+        }
+
+        private function makeScopeMock(bool $mobileActive): ScopeSetting
+        {
+            $mock = $this->getMockBuilder(ScopeSetting::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $mock->method('getMobileConsentIsActive')->willReturn($mobileActive ? '1' : null);
+            $mock->method('getMobileConsentLabelText')->willReturn('Mobile Label');
+            $mock->method('getMobileConsentText')->willReturn('Mobile Description');
+            $mock->method('getMobileConsentSortOrder')->willReturn('100');
+            $mock->method('getConsentAtCheckoutEmailIsActive')->willReturn(null);
+            return $mock;
+        }
+
+        public function test_afterProcess_mobile_inactive_no_consent_key_in_fieldset()
+        {
+            $scope = $this->makeScopeMock(false);
+            $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+            $session->method('isLoggedIn')->willReturn(false);
+            $factory = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()->getMock();
+
+            $plugin = new CheckoutLayoutPlugin($scope, $session, $factory);
+            $result = $plugin->afterProcess($this->createMock(LayoutProcessor::class), $this->buildBaseJsLayout());
+
+            $fieldset = $result['components']['checkout']['children']['steps']['children']
+                ['shipping-step']['children']['shippingAddress']['children']
+                ['shipping-address-fieldset']['children'];
+            $this->assertArrayNotHasKey('kl_mobile_consent', $fieldset);
+            $this->assertArrayNotHasKey('kl_sms_consent', $fieldset);
+        }
+
+        public function test_afterProcess_mobile_active_no_default_address_adds_kl_mobile_consent_to_fieldset()
+        {
+            $scope = $this->makeScopeMock(true);
+            $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+            $session->method('isLoggedIn')->willReturn(false);
+            $factory = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()->getMock();
+
+            $plugin = new CheckoutLayoutPlugin($scope, $session, $factory);
+            $result = $plugin->afterProcess($this->createMock(LayoutProcessor::class), $this->buildBaseJsLayout());
+
+            $fieldset = $result['components']['checkout']['children']['steps']['children']
+                ['shipping-step']['children']['shippingAddress']['children']
+                ['shipping-address-fieldset']['children'];
+            $this->assertArrayHasKey('kl_mobile_consent', $fieldset);
+            $this->assertArrayNotHasKey('kl_sms_consent', $fieldset);
+            $this->assertSame('kl_mobile_consent', $fieldset['kl_mobile_consent']['config']['id']);
+            $this->assertStringContainsString('kl_mobile_consent', $fieldset['kl_mobile_consent']['dataScope']);
+        }
+
+        public function test_afterProcess_mobile_active_with_default_address_adds_mobile_consent_and_phone_to_before_form()
+        {
+            $scope = $this->makeScopeMock(true);
+
+            $addressStub = new class {
+                public function getTelephone(): string
+                {
+                    return '555-1234';
+                }
+            };
+
+            $customerMock = $this->getMockBuilder(Customer::class)->disableOriginalConstructor()->getMock();
+            $customerMock->method('getData')->willReturn(['entity_id' => 42]);
+            $customerMock->method('load')->willReturnSelf();
+            $customerMock->method('getDefaultShippingAddress')->willReturn($addressStub);
+
+            $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+            $session->method('isLoggedIn')->willReturn(true);
+            $session->method('getCustomer')->willReturn($customerMock);
+
+            $factory = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()->getMock();
+            $factory->method('create')->willReturn($customerMock);
+
+            $plugin = new CheckoutLayoutPlugin($scope, $session, $factory);
+            $result = $plugin->afterProcess($this->createMock(LayoutProcessor::class), $this->buildBaseJsLayout());
+
+            $beforeForm = $result['components']['checkout']['children']['steps']['children']
+                ['shipping-step']['children']['shippingAddress']['children']
+                ['before-form']['children'];
+            $this->assertArrayHasKey('kl_mobile_consent', $beforeForm);
+            $this->assertArrayHasKey('kl_mobile_phone_number', $beforeForm);
+            $this->assertArrayNotHasKey('kl_sms_consent', $beforeForm);
+            $this->assertArrayNotHasKey('kl_sms_phone_number', $beforeForm);
+        }
+    }
+}

--- a/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
+++ b/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
@@ -174,6 +174,31 @@ namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data {
             $this->buildPatch($connection)->apply();
         }
 
+        public function test_apply_handles_null_source_row_value_without_typeerror()
+        {
+            // core_config_data.value is nullable; strict_types=1 in the patch
+            // would crash setup:upgrade if seedIfMissing rejected null values.
+            $smsRows = [[
+                'scope' => 'default',
+                'scope_id' => '0',
+                'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/label_text',
+                'value' => null,
+            ]];
+            $connection = $this->buildConnection($smsRows, false);
+            $insertedValues = [];
+            $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$insertedValues) {
+                $insertedValues[$data['path']] = $data['value'];
+            });
+            $this->buildPatch($connection)->apply();
+
+            $this->assertArrayHasKey(
+                'klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text',
+                $insertedValues,
+                'Null-valued source rows must still be copied (with null preserved)'
+            );
+            $this->assertNull($insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text']);
+        }
+
         public function test_apply_preserves_custom_label_text_when_is_active_iterated_before_label_text()
         {
             // Regression test for two-pass migration ordering.

--- a/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
+++ b/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
@@ -48,6 +48,26 @@ namespace Magento\Framework\DB {
     }
 }
 
+namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data\Stubs {
+    /**
+     * Query-builder shim used by the test mock. Cannot reuse
+     * Magento\Framework\DB\Select directly because the real Magento class
+     * (when autoloaded in a full Magento test environment) requires
+     * constructor args, which breaks the test stub instantiation.
+     */
+    class SelectStub
+    {
+        public function from($table, $cols = '*')
+        {
+            return $this;
+        }
+        public function where($condition, $value = null)
+        {
+            return $this;
+        }
+    }
+}
+
 namespace Magento\Framework\DB\Adapter {
     if (!interface_exists(\Magento\Framework\DB\Adapter\AdapterInterface::class)) {
         interface AdapterInterface
@@ -65,8 +85,8 @@ namespace Magento\Framework\DB\Adapter {
 namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data {
 
     use Klaviyo\Reclaim\Setup\Patch\Data\MigrateSmsToMobileConsent;
+    use Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data\Stubs\SelectStub;
     use Magento\Framework\DB\Adapter\AdapterInterface;
-    use Magento\Framework\DB\Select;
     use Magento\Framework\Setup\ModuleDataSetupInterface;
     use PHPUnit\Framework\TestCase;
 
@@ -74,7 +94,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data {
     {
         private function buildConnection(array $smsRows, bool $mobileRowExists): AdapterInterface
         {
-            $selectStub = new Select();
+            $selectStub = new SelectStub();
             $connection = $this->createMock(AdapterInterface::class);
             $connection->method('select')->willReturn($selectStub);
             $connection->method('fetchAll')->willReturn($smsRows);
@@ -97,7 +117,7 @@ namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data {
             $this->buildPatch($connection)->apply();
         }
 
-        public function test_apply_inserts_mobile_consent_rows_including_channels_when_sms_is_active_1()
+        public function test_apply_inserts_mobile_consent_rows_including_channels_and_sms_backfill_when_sms_is_active_1()
         {
             $smsRows = [[
                 'scope' => 'default',
@@ -106,9 +126,39 @@ namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data {
                 'value' => '1',
             ]];
             $connection = $this->buildConnection($smsRows, false);
-            // Expect 2 inserts: mobile_consent/is_active and mobile_consent/channels
-            $connection->expects($this->exactly(2))->method('insert');
+            // Expect 4 inserts: mobile_consent/is_active, /channels, /label_text, /consent_text
+            $connection->expects($this->exactly(4))->method('insert');
             $this->buildPatch($connection)->apply();
+        }
+
+        public function test_apply_seeds_sms_specific_label_and_consent_text_when_no_source_rows_exist()
+        {
+            $smsRows = [[
+                'scope' => 'default',
+                'scope_id' => '0',
+                'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
+                'value' => '1',
+            ]];
+            $connection = $this->buildConnection($smsRows, false);
+            $insertedPaths = [];
+            $insertedValues = [];
+            $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$insertedPaths, &$insertedValues) {
+                $insertedPaths[] = $data['path'];
+                $insertedValues[$data['path']] = $data['value'];
+            });
+            $this->buildPatch($connection)->apply();
+
+            $this->assertContains('klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text', $insertedPaths);
+            $this->assertContains('klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text', $insertedPaths);
+
+            $this->assertStringContainsString(
+                'Exclusive text messaging-only',
+                $insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text']
+            );
+            $this->assertStringContainsString(
+                'marketing texts (e.g., cart reminders)',
+                $insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text']
+            );
         }
 
         public function test_apply_does_not_insert_when_mobile_rows_already_exist()

--- a/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
+++ b/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
@@ -199,6 +199,57 @@ namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data {
             $this->assertNull($insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text']);
         }
 
+        public function test_apply_only_seeds_label_and_consent_defaults_at_default_scope_to_preserve_inheritance()
+        {
+            // Regression test for scope-inheritance breakage.
+            // Merchant had is_active=1 at a store scope and label_text customized
+            // at the default scope (inherited by the store). Previously pass 2
+            // seeded SMS_LABEL_DEFAULT at the store scope, explicitly overriding
+            // the inherited customization. Seeding only at the default scope
+            // lets Magento's scope-resolution chain deliver whatever value
+            // (custom or default) the parent scopes already provide.
+            $smsRows = [[
+                'scope' => 'stores',
+                'scope_id' => '1',
+                'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
+                'value' => '1',
+            ]];
+            $connection = $this->buildConnection($smsRows, false);
+            $insertedRows = [];
+            $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$insertedRows) {
+                $insertedRows[] = $data;
+            });
+            $this->buildPatch($connection)->apply();
+
+            $textPaths = [
+                'klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text',
+                'klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text',
+            ];
+            foreach ($insertedRows as $row) {
+                if (!in_array($row['path'], $textPaths, true)) {
+                    continue;
+                }
+                $this->assertSame(
+                    'default',
+                    $row['scope'],
+                    'label_text/consent_text defaults must only be seeded at default scope, not ' . $row['scope']
+                );
+                $this->assertSame(
+                    '0',
+                    (string) $row['scope_id'],
+                    'label_text/consent_text defaults must only be seeded at scope_id=0'
+                );
+            }
+
+            // Channels still seeded at the active scope (its own pre-migration semantics)
+            $channelsRows = array_values(array_filter($insertedRows, function ($r) {
+                return $r['path'] === 'klaviyo_reclaim_consent_at_checkout/mobile_consent/channels';
+            }));
+            $this->assertCount(1, $channelsRows);
+            $this->assertSame('stores', $channelsRows[0]['scope']);
+            $this->assertSame('1', (string) $channelsRows[0]['scope_id']);
+        }
+
         public function test_apply_preserves_custom_label_text_when_is_active_iterated_before_label_text()
         {
             // Regression test for two-pass migration ordering.

--- a/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
+++ b/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
@@ -173,5 +173,44 @@ namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data {
             $connection->expects($this->never())->method('insert');
             $this->buildPatch($connection)->apply();
         }
+
+        public function test_apply_preserves_custom_label_text_when_is_active_iterated_before_label_text()
+        {
+            // Regression test for two-pass migration ordering.
+            // Merchant set is_active=1 first (lower config_id) and later
+            // customized label_text. Single-pass logic would have seeded the
+            // SMS default label_text during the is_active iteration before
+            // reaching the merchant's customized row, silently dropping the
+            // customization. Two-pass logic copies all source rows first, then
+            // backfills only what's still missing.
+            $smsRows = [
+                [
+                    'scope' => 'default',
+                    'scope_id' => '0',
+                    'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
+                    'value' => '1',
+                ],
+                [
+                    'scope' => 'default',
+                    'scope_id' => '0',
+                    'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/label_text',
+                    'value' => 'My Custom SMS Copy',
+                ],
+            ];
+            $connection = $this->buildConnection($smsRows, false);
+            $firstValueByPath = [];
+            $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$firstValueByPath) {
+                if (!isset($firstValueByPath[$data['path']])) {
+                    $firstValueByPath[$data['path']] = $data['value'];
+                }
+            });
+            $this->buildPatch($connection)->apply();
+
+            $this->assertSame(
+                'My Custom SMS Copy',
+                $firstValueByPath['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text'] ?? null,
+                'Custom merchant label_text must be copied before the SMS default backfill runs'
+            );
+        }
     }
 }

--- a/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
+++ b/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+// Stub Magento framework interfaces so MigrateSmsToMobileConsent can load without the full Magento stack.
+namespace Magento\Framework\Setup\Patch {
+    if (!interface_exists(\Magento\Framework\Setup\Patch\DataPatchInterface::class)) {
+        interface DataPatchInterface
+        {
+            public function apply();
+            public function getAliases();
+            public static function getDependencies();
+        }
+    }
+    if (!interface_exists(\Magento\Framework\Setup\Patch\PatchVersionInterface::class)) {
+        interface PatchVersionInterface
+        {
+            public static function getVersion();
+        }
+    }
+}
+
+namespace Magento\Framework\Setup {
+    if (!interface_exists(\Magento\Framework\Setup\ModuleDataSetupInterface::class)) {
+        interface ModuleDataSetupInterface
+        {
+            public function getConnection();
+            public function getTable($tableName);
+            public function startSetup();
+            public function endSetup();
+        }
+    }
+}
+
+namespace Magento\Framework\DB {
+    if (!class_exists(\Magento\Framework\DB\Select::class)) {
+        class Select
+        {
+            public function from($table, $cols = '*')
+            {
+                return $this;
+            }
+            public function where($condition, $value = null)
+            {
+                return $this;
+            }
+        }
+    }
+}
+
+namespace Magento\Framework\DB\Adapter {
+    if (!interface_exists(\Magento\Framework\DB\Adapter\AdapterInterface::class)) {
+        interface AdapterInterface
+        {
+            public function startSetup();
+            public function endSetup();
+            public function select();
+            public function fetchAll($select);
+            public function fetchOne($select);
+            public function insert($table, array $data);
+        }
+    }
+}
+
+namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data {
+
+    use Klaviyo\Reclaim\Setup\Patch\Data\MigrateSmsToMobileConsent;
+    use Magento\Framework\DB\Adapter\AdapterInterface;
+    use Magento\Framework\DB\Select;
+    use Magento\Framework\Setup\ModuleDataSetupInterface;
+    use PHPUnit\Framework\TestCase;
+
+    class MigrateSmsToMobileConsentTest extends TestCase
+    {
+        private function buildConnection(array $smsRows, bool $mobileRowExists): AdapterInterface
+        {
+            $selectStub = new Select();
+            $connection = $this->createMock(AdapterInterface::class);
+            $connection->method('select')->willReturn($selectStub);
+            $connection->method('fetchAll')->willReturn($smsRows);
+            $connection->method('fetchOne')->willReturn($mobileRowExists ? '1' : false);
+            return $connection;
+        }
+
+        private function buildPatch(AdapterInterface $connection): MigrateSmsToMobileConsent
+        {
+            $setup = $this->createMock(ModuleDataSetupInterface::class);
+            $setup->method('getConnection')->willReturn($connection);
+            $setup->method('getTable')->willReturn('core_config_data');
+            return new MigrateSmsToMobileConsent($setup);
+        }
+
+        public function test_apply_writes_nothing_when_no_sms_rows_exist()
+        {
+            $connection = $this->buildConnection([], false);
+            $connection->expects($this->never())->method('insert');
+            $this->buildPatch($connection)->apply();
+        }
+
+        public function test_apply_inserts_mobile_consent_rows_including_channels_when_sms_is_active_1()
+        {
+            $smsRows = [[
+                'scope' => 'default',
+                'scope_id' => '0',
+                'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
+                'value' => '1',
+            ]];
+            $connection = $this->buildConnection($smsRows, false);
+            // Expect 2 inserts: mobile_consent/is_active and mobile_consent/channels
+            $connection->expects($this->exactly(2))->method('insert');
+            $this->buildPatch($connection)->apply();
+        }
+
+        public function test_apply_does_not_insert_when_mobile_rows_already_exist()
+        {
+            $smsRows = [[
+                'scope' => 'default',
+                'scope_id' => '0',
+                'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
+                'value' => '1',
+            ]];
+            $connection = $this->buildConnection($smsRows, true);
+            $connection->expects($this->never())->method('insert');
+            $this->buildPatch($connection)->apply();
+        }
+    }
+}

--- a/Test/Unit/Util/PhoneFormatterTest.php
+++ b/Test/Unit/Util/PhoneFormatterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Klaviyo\Reclaim\Test\Unit\Util;
+
+use Klaviyo\Reclaim\Util\PhoneFormatter;
+use PHPUnit\Framework\TestCase;
+
+class PhoneFormatterTest extends TestCase
+{
+    private PhoneFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new PhoneFormatter();
+    }
+
+    public function test_formatE164_us_national_number_returns_e164(): void
+    {
+        $this->assertSame('+12025550100', $this->formatter->formatE164('2025550100', 'US'));
+    }
+
+    public function test_formatE164_us_punctuated_number_returns_e164(): void
+    {
+        $this->assertSame('+12025550100', $this->formatter->formatE164('(202) 555-0100', 'US'));
+    }
+
+    public function test_formatE164_already_e164_returns_e164_unchanged(): void
+    {
+        $this->assertSame('+12025550100', $this->formatter->formatE164('+1 (202) 555-0100', 'US'));
+    }
+
+    public function test_formatE164_uk_national_number_returns_e164(): void
+    {
+        $this->assertSame('+442079460958', $this->formatter->formatE164('020 7946 0958', 'GB'));
+    }
+
+    public function test_formatE164_empty_phone_returns_null(): void
+    {
+        $this->assertNull($this->formatter->formatE164('', 'US'));
+    }
+
+    public function test_formatE164_null_phone_returns_null(): void
+    {
+        $this->assertNull($this->formatter->formatE164(null, 'US'));
+    }
+
+    public function test_formatE164_empty_country_returns_null(): void
+    {
+        $this->assertNull($this->formatter->formatE164('2025550100', ''));
+    }
+
+    public function test_formatE164_null_country_returns_null(): void
+    {
+        $this->assertNull($this->formatter->formatE164('2025550100', null));
+    }
+
+    public function test_formatE164_unparseable_input_returns_null(): void
+    {
+        $this->assertNull($this->formatter->formatE164('not-a-number', 'US'));
+    }
+
+    public function test_formatE164_too_short_number_returns_null(): void
+    {
+        $this->assertNull($this->formatter->formatE164('123', 'US'));
+    }
+}

--- a/Test/Unit/Util/PhoneFormatterTest.php
+++ b/Test/Unit/Util/PhoneFormatterTest.php
@@ -9,7 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class PhoneFormatterTest extends TestCase
 {
-    private PhoneFormatter $formatter;
+    /** @var PhoneFormatter */
+    private $formatter;
 
     protected function setUp(): void
     {

--- a/Test/Unit/View/Adminhtml/MobileConsentFormJsTest.php
+++ b/Test/Unit/View/Adminhtml/MobileConsentFormJsTest.php
@@ -117,4 +117,13 @@ class MobileConsentFormJsTest extends TestCase
             'JS must have consentDefault per-channel for auto-populate'
         );
     }
+
+    public function test_mobile_consent_form_js_handles_inherit_checkbox_for_field_writes(): void
+    {
+        $this->assertStringContainsString(
+            '_inherit',
+            $this->jsContent,
+            'JS must reference the Use Default _inherit checkbox so store/website-scope writes persist on Save Config'
+        );
+    }
 }

--- a/Test/Unit/View/Adminhtml/MobileConsentFormJsTest.php
+++ b/Test/Unit/View/Adminhtml/MobileConsentFormJsTest.php
@@ -64,15 +64,6 @@ class MobileConsentFormJsTest extends TestCase
         );
     }
 
-    public function test_mobile_consent_form_js_has_dirty_flag_tracking(): void
-    {
-        $this->assertStringContainsString(
-            'dirty',
-            $this->jsContent,
-            'JS must implement dirty-flag tracking per field'
-        );
-    }
-
     public function test_mobile_consent_form_js_has_channels_change_listener(): void
     {
         $this->assertStringContainsString(

--- a/Test/Unit/View/Adminhtml/MobileConsentFormJsTest.php
+++ b/Test/Unit/View/Adminhtml/MobileConsentFormJsTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Klaviyo\Reclaim\Test\Unit\View\Adminhtml;
+
+use PHPUnit\Framework\TestCase;
+
+class MobileConsentFormJsTest extends TestCase
+{
+    /** @var string */
+    private $jsPath;
+
+    /** @var string */
+    private $jsContent;
+
+    protected function setUp(): void
+    {
+        $this->jsPath = dirname(__DIR__, 4) . '/view/adminhtml/web/js/mobile-consent-form.js';
+        $this->jsContent = file_exists($this->jsPath) ? file_get_contents($this->jsPath) : '';
+    }
+
+    public function test_mobile_consent_form_js_file_exists(): void
+    {
+        $this->assertFileExists(
+            $this->jsPath,
+            'view/adminhtml/web/js/mobile-consent-form.js must exist'
+        );
+    }
+
+    public function test_mobile_consent_form_js_uses_requirejs_define(): void
+    {
+        $this->assertStringContainsString(
+            'define([',
+            $this->jsContent,
+            'JS must use RequireJS define()'
+        );
+    }
+
+    public function test_mobile_consent_form_js_has_sms_channel_config(): void
+    {
+        $this->assertStringContainsString(
+            'sms:',
+            $this->jsContent,
+            'JS must have sms channel config entry'
+        );
+    }
+
+    public function test_mobile_consent_form_js_has_whatsapp_channel_config(): void
+    {
+        $this->assertStringContainsString(
+            'whatsapp:',
+            $this->jsContent,
+            'JS must have whatsapp channel config entry'
+        );
+    }
+
+    public function test_mobile_consent_form_js_has_both_channel_config(): void
+    {
+        $this->assertStringContainsString(
+            'both:',
+            $this->jsContent,
+            'JS must have both channel config entry'
+        );
+    }
+
+    public function test_mobile_consent_form_js_has_dirty_flag_tracking(): void
+    {
+        $this->assertStringContainsString(
+            'dirty',
+            $this->jsContent,
+            'JS must implement dirty-flag tracking per field'
+        );
+    }
+
+    public function test_mobile_consent_form_js_has_channels_change_listener(): void
+    {
+        $this->assertStringContainsString(
+            "'change'",
+            $this->jsContent,
+            'JS must attach a change listener for channels multiselect'
+        );
+    }
+
+    public function test_mobile_consent_form_js_updates_channels_note(): void
+    {
+        $this->assertStringContainsString(
+            'channelsNote',
+            $this->jsContent,
+            'JS must update channelsNote helper text'
+        );
+    }
+
+    public function test_mobile_consent_form_js_updates_consent_note(): void
+    {
+        $this->assertStringContainsString(
+            'consentNote',
+            $this->jsContent,
+            'JS must update consentNote helper text'
+        );
+    }
+
+    public function test_mobile_consent_form_js_has_sms_text_message_helper_text(): void
+    {
+        $this->assertStringContainsString(
+            'Text message must be set up',
+            $this->jsContent,
+            'SMS channelsNote must mention "Text message must be set up"'
+        );
+    }
+
+    public function test_mobile_consent_form_js_auto_populates_label_default(): void
+    {
+        $this->assertStringContainsString(
+            'labelDefault',
+            $this->jsContent,
+            'JS must have labelDefault per-channel for auto-populate'
+        );
+    }
+
+    public function test_mobile_consent_form_js_auto_populates_consent_default(): void
+    {
+        $this->assertStringContainsString(
+            'consentDefault',
+            $this->jsContent,
+            'JS must have consentDefault per-channel for auto-populate'
+        );
+    }
+}

--- a/Test/Unit/View/Adminhtml/MobileConsentLayoutTest.php
+++ b/Test/Unit/View/Adminhtml/MobileConsentLayoutTest.php
@@ -88,11 +88,15 @@ class MobileConsentLayoutTest extends TestCase
     public function test_template_has_no_php_syntax_errors(): void
     {
         $this->assertFileExists($this->templatePath);
-        $output = shell_exec('php -l ' . escapeshellarg($this->templatePath) . ' 2>&1');
-        $this->assertStringContainsString(
-            'No syntax errors',
-            (string) $output,
-            'Template phtml must have no PHP syntax errors'
-        );
+        $source = file_get_contents($this->templatePath);
+        try {
+            // TOKEN_PARSE flag (PHP 7+) makes token_get_all throw on syntax
+            // errors. Mixed PHP/HTML phtml source is supported as input.
+            // Avoids shell_exec; safer for SAST scanners.
+            token_get_all((string) $source, TOKEN_PARSE);
+            $this->assertTrue(true);
+        } catch (\ParseError $e) {
+            $this->fail('Template phtml has a PHP syntax error: ' . $e->getMessage());
+        }
     }
 }

--- a/Test/Unit/View/Adminhtml/MobileConsentLayoutTest.php
+++ b/Test/Unit/View/Adminhtml/MobileConsentLayoutTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Klaviyo\Reclaim\Test\Unit\View\Adminhtml;
+
+use PHPUnit\Framework\TestCase;
+
+class MobileConsentLayoutTest extends TestCase
+{
+    /** @var string */
+    private $repoRoot;
+
+    /** @var string */
+    private $layoutPath;
+
+    /** @var string */
+    private $templatePath;
+
+    protected function setUp(): void
+    {
+        $this->repoRoot = dirname(__DIR__, 4);
+        $this->layoutPath = $this->repoRoot . '/view/adminhtml/layout/adminhtml_system_config_edit.xml';
+        $this->templatePath = $this->repoRoot . '/view/adminhtml/templates/adminhtml/mobile-consent-form.phtml';
+    }
+
+    public function test_layout_xml_file_exists(): void
+    {
+        $this->assertFileExists(
+            $this->layoutPath,
+            'view/adminhtml/layout/adminhtml_system_config_edit.xml must exist'
+        );
+    }
+
+    public function test_layout_xml_references_mobile_consent_js(): void
+    {
+        $this->assertFileExists($this->layoutPath);
+        $content = file_get_contents($this->layoutPath);
+        $this->assertStringContainsString(
+            'mobile-consent-form',
+            $content,
+            'Layout XML must reference mobile-consent-form JS/template'
+        );
+    }
+
+    public function test_layout_xml_is_valid_xml(): void
+    {
+        $this->assertFileExists($this->layoutPath);
+        $content = file_get_contents($this->layoutPath);
+        libxml_use_internal_errors(true);
+        $doc = simplexml_load_string($content);
+        $errors = libxml_get_errors();
+        libxml_clear_errors();
+        $this->assertNotFalse($doc, 'adminhtml_system_config_edit.xml must be valid XML');
+        $this->assertEmpty($errors, 'adminhtml_system_config_edit.xml must have no XML parse errors');
+    }
+
+    public function test_template_file_exists(): void
+    {
+        $this->assertFileExists(
+            $this->templatePath,
+            'view/adminhtml/templates/adminhtml/mobile-consent-form.phtml must exist'
+        );
+    }
+
+    public function test_template_requires_mobile_consent_form_js_module(): void
+    {
+        $this->assertFileExists($this->templatePath);
+        $content = file_get_contents($this->templatePath);
+        $this->assertStringContainsString(
+            'Klaviyo_Reclaim/js/mobile-consent-form',
+            $content,
+            'Template must require Klaviyo_Reclaim/js/mobile-consent-form'
+        );
+    }
+
+    public function test_template_calls_mobile_consent_form_init(): void
+    {
+        $this->assertFileExists($this->templatePath);
+        $content = file_get_contents($this->templatePath);
+        $this->assertStringContainsString(
+            'mobileConsentForm.init',
+            $content,
+            'Template must call mobileConsentForm.init()'
+        );
+    }
+
+    public function test_template_has_no_php_syntax_errors(): void
+    {
+        $this->assertFileExists($this->templatePath);
+        $output = shell_exec('php -l ' . escapeshellarg($this->templatePath) . ' 2>&1');
+        $this->assertStringContainsString(
+            'No syntax errors',
+            (string) $output,
+            'Template phtml must have no PHP syntax errors'
+        );
+    }
+}

--- a/Test/e2e/api/whatsapp-consent.spec.js
+++ b/Test/e2e/api/whatsapp-consent.spec.js
@@ -1,0 +1,185 @@
+const { test, expect } = require('@playwright/test');
+const { backOff } = require('exponential-backoff');
+const Admin = require('../locators/admin');
+const Storefront = require('../locators/storefront');
+const { checkProfileSubscriptions } = require('../utils/klaviyo-api');
+
+test.describe.configure({ mode: 'serial' });
+
+const DEFAULT_SHIPPING = {
+    firstName: 'Test',
+    lastName: 'Buyer',
+    phone: '5555550100',
+    street: '123 Main St',
+    city: 'Austin',
+    regionCode: 'Texas',
+    zip: '78701',
+    countryId: 'US',
+};
+
+/**
+ * Configures the admin mobile consent settings and saves.
+ * @param {import('@playwright/test').Page} page
+ * @param {import('@playwright/test').Browser} browser
+ * @param {boolean} isActive
+ * @param {string[]} channels - e.g. ['sms'], ['whatsapp'], or ['sms', 'whatsapp']
+ */
+async function configureMobileConsent(page, browser, isActive, channels) {
+    const baseUrl = process.env.M2_BASE_URL;
+    if (!baseUrl) throw new Error('M2_BASE_URL environment variable is not set');
+
+    const admin = new Admin(page);
+    await admin.page.goto(`${baseUrl}/admin/admin/dashboard`);
+    await admin.page.locator('.admin__menu').waitFor();
+
+    await admin.navigateToKlaviyoConsentAtCheckoutConfig();
+    await admin.setMobileConsentIsActive(isActive);
+    if (isActive) {
+        await admin.setMobileConsentChannels(channels);
+    }
+    await admin.saveConsentAtCheckoutConfig();
+    console.log(`Mobile consent configured: isActive=${isActive}, channels=${JSON.stringify(channels)}`);
+}
+
+/**
+ * Performs a guest checkout with the given consent options and returns the buyer email.
+ * Asserts no requests to the legacy webhook endpoint during checkout.
+ * @param {import('@playwright/test').Page} page
+ * @param {{ checkMobile?: boolean, checkEmail?: boolean }} consentOptions
+ * @returns {Promise<string>} The email used for checkout
+ */
+async function doGuestCheckoutWithConsent(page, consentOptions = {}) {
+    const { checkMobile = false, checkEmail = false } = consentOptions;
+    const storefront = new Storefront(page);
+
+    // Track any calls to the old webhook endpoint — there must be zero
+    const legacyWebhookCalls = [];
+    page.on('request', req => {
+        if (req.url().includes('/api/webhook/integration/magento_two') && req.method() === 'POST') {
+            legacyWebhookCalls.push(req.url());
+        }
+    });
+
+    // Add a product to cart
+    await storefront.goToProductPageAndGetProductName();
+    await storefront.addProductToCart();
+
+    // Navigate to checkout
+    await storefront.goToCheckout();
+    await storefront.fillGuestCheckoutEmail();
+    await storefront.fillGuestShippingInfo(DEFAULT_SHIPPING);
+    await storefront.selectFlatRateShipping();
+
+    if (checkMobile) {
+        await storefront.checkMobileConsentAtCheckout();
+    }
+    if (checkEmail) {
+        await storefront.checkEmailConsentAtCheckout();
+    }
+
+    await storefront.proceedToPayment();
+    await storefront.placeOrder();
+
+    // Assert no legacy webhook calls were made during checkout
+    expect(legacyWebhookCalls).toHaveLength(0);
+
+    return storefront.email;
+}
+
+/**
+ * Polls the Klaviyo API until the profile's subscriptions object is populated.
+ * @param {string} email
+ * @returns {Promise<object>} The subscriptions object
+ */
+async function waitForProfileSubscriptions(email) {
+    return backOff(
+        async () => {
+            const subscriptions = await checkProfileSubscriptions(email);
+            if (!subscriptions) {
+                throw new Error('Profile not found yet');
+            }
+            return subscriptions;
+        },
+        {
+            numOfAttempts: 11,
+            retry: (error, attemptNumber) => {
+                console.log(`Attempt ${attemptNumber} failed. Error: ${error.message}`);
+                return true;
+            }
+        }
+    );
+}
+
+/**
+ * Tests the WhatsApp / mobile consent channel-enable matrix at checkout.
+ *
+ * Each test configures the Magento admin with a specific set of enabled channels,
+ * performs a guest checkout with the mobile consent checkbox checked, then verifies
+ * via the Klaviyo V3 API that only the expected subscription channels are present.
+ *
+ * Also asserts that zero outbound POST requests are sent to the legacy consent webhook
+ * (/api/webhook/integration/magento_two) during checkout.
+ *
+ * @see Observer/SaveOrderMarketingConsent.php
+ * @see Plugin/CheckoutLayoutPlugin.php
+ */
+test.describe('WhatsApp / Mobile Consent Channel Matrix', () => {
+    test('sms_only_mobile_consent: SMS-only channel config → only sms.marketing subscription', async ({ page, browser }) => {
+        await configureMobileConsent(page, browser, true, ['sms']);
+
+        const email = await doGuestCheckoutWithConsent(page, { checkMobile: true });
+
+        const subscriptions = await waitForProfileSubscriptions(email);
+
+        // SMS subscription must be present and SUBSCRIBED
+        expect(subscriptions?.sms?.marketing?.consent).toBe('SUBSCRIBED');
+        // WhatsApp subscription must NOT be present
+        expect(subscriptions?.whatsapp).toBeUndefined();
+
+        console.log(`sms_only_mobile_consent: verified sms.marketing=SUBSCRIBED for ${email}`);
+    });
+
+    test('whatsapp_only_mobile_consent: WhatsApp-only channel config → only whatsapp.marketing subscription', async ({ page, browser }) => {
+        await configureMobileConsent(page, browser, true, ['whatsapp']);
+
+        const email = await doGuestCheckoutWithConsent(page, { checkMobile: true });
+
+        const subscriptions = await waitForProfileSubscriptions(email);
+
+        // WhatsApp subscription must be present and SUBSCRIBED
+        expect(subscriptions?.whatsapp?.marketing?.consent).toBe('SUBSCRIBED');
+        // SMS subscription must NOT be present
+        expect(subscriptions?.sms).toBeUndefined();
+
+        console.log(`whatsapp_only_mobile_consent: verified whatsapp.marketing=SUBSCRIBED for ${email}`);
+    });
+
+    test('both_channels_mobile_consent: SMS+WhatsApp config → both sms and whatsapp subscriptions', async ({ page, browser }) => {
+        await configureMobileConsent(page, browser, true, ['sms', 'whatsapp']);
+
+        const email = await doGuestCheckoutWithConsent(page, { checkMobile: true });
+
+        const subscriptions = await waitForProfileSubscriptions(email);
+
+        // Both channels must be SUBSCRIBED
+        expect(subscriptions?.sms?.marketing?.consent).toBe('SUBSCRIBED');
+        expect(subscriptions?.whatsapp?.marketing?.consent).toBe('SUBSCRIBED');
+
+        console.log(`both_channels_mobile_consent: verified sms+whatsapp for ${email}`);
+    });
+
+    test('email_and_both_channels: email + mobile consent → email, sms, and whatsapp all SUBSCRIBED', async ({ page, browser }) => {
+        await configureMobileConsent(page, browser, true, ['sms', 'whatsapp']);
+
+        const email = await doGuestCheckoutWithConsent(page, { checkMobile: true, checkEmail: true });
+
+        const subscriptions = await waitForProfileSubscriptions(email);
+
+        // All three channels must be SUBSCRIBED
+        expect(subscriptions?.email?.marketing?.consent).toBe('SUBSCRIBED');
+        expect(subscriptions?.sms?.marketing?.consent).toBe('SUBSCRIBED');
+        expect(subscriptions?.whatsapp?.marketing?.consent).toBe('SUBSCRIBED');
+
+        console.log(`email_and_both_channels: verified email+sms+whatsapp for ${email}`);
+    });
+});

--- a/Test/e2e/locators/admin.js
+++ b/Test/e2e/locators/admin.js
@@ -116,9 +116,54 @@ class Admin {
     await this.klaviyoConfigLink.scrollIntoViewIfNeeded();
     await this.klaviyoConfigLink.click();
     await this.klaviyoConsentAtCheckoutLink.scrollIntoViewIfNeeded();
-    await this.klaviyoConsentAtCheckoutLink.click();
-    await this.page.waitForLoadState();
+    await Promise.all([
+      this.page.waitForResponse(
+        resp => resp.request().url().includes('/admin/admin/system_config/edit/section/klaviyo_reclaim_consent_at_checkout') && resp.status() === 200,
+        { timeout: 15000 }
+      ),
+      this.klaviyoConsentAtCheckoutLink.click()
+    ]);
+  }
+
+  /**
+   * Enables or disables the mobile consent "is_active" field.
+   * Unchecks the "Use Default" checkbox before setting the value.
+   * @param {boolean} isActive
+   */
+  async setMobileConsentIsActive(isActive) {
+    const inheritId = '#klaviyo_reclaim_consent_at_checkout_mobile_consent_is_active_inherit';
+    const fieldId = '#klaviyo_reclaim_consent_at_checkout_mobile_consent_is_active';
+    const inherit = this.page.locator(inheritId);
+    if (await inherit.isChecked()) {
+      await inherit.uncheck();
+    }
+    await this.page.selectOption(fieldId, isActive ? '1' : '0');
+  }
+
+  /**
+   * Sets the mobile consent channels multiselect.
+   * Unchecks the "Use Default" checkbox before setting values.
+   * @param {string[]} channels - e.g. ['sms'], ['whatsapp'], or ['sms', 'whatsapp']
+   */
+  async setMobileConsentChannels(channels) {
+    const inheritId = '#klaviyo_reclaim_consent_at_checkout_mobile_consent_channels_inherit';
+    const fieldId = '#klaviyo_reclaim_consent_at_checkout_mobile_consent_channels';
+    const inherit = this.page.locator(inheritId);
+    if (await inherit.isChecked()) {
+      await inherit.uncheck();
+    }
+    await this.page.selectOption(fieldId, channels);
+  }
+
+  /**
+   * Saves the config form and waits for the success message.
+   */
+  async saveConsentAtCheckoutConfig() {
+    const saveButton = this.page.getByRole('button', { name: 'Save Config' });
+    await saveButton.click();
+    await this.page.locator('.message-success').waitFor({ timeout: 15000 });
   }
 }
+
 
 module.exports = Admin;

--- a/Test/e2e/locators/storefront.js
+++ b/Test/e2e/locators/storefront.js
@@ -116,6 +116,90 @@ class Storefront {
             await this.page.locator('.message-success').waitFor({ state: 'visible', timeout: 5000 });
         });
     }
+
+    /**
+     * Navigates to the Magento 2 checkout page and waits for it to be ready.
+     */
+    async goToCheckout() {
+        await this.page.goto(`${process.env.M2_BASE_URL}/checkout/`);
+        await this.page.locator('#checkout').waitFor({ timeout: 30000 });
+    }
+
+    /**
+     * Fills the guest email field shown at the top of the checkout shipping step.
+     */
+    async fillGuestCheckoutEmail() {
+        const emailField = this.page.locator('[name="username"]');
+        await emailField.waitFor({ timeout: 15000 });
+        await emailField.fill(this.email);
+    }
+
+    /**
+     * Fills the shipping address form in the checkout shipping step.
+     * @param {{ firstName: string, lastName: string, phone: string, street: string, city: string, regionCode: string, zip: string, countryId?: string }} info
+     */
+    async fillGuestShippingInfo(info) {
+        const { firstName, lastName, phone, street, city, regionCode, zip, countryId = 'US' } = info;
+        await this.page.fill('[name="firstname"]', firstName);
+        await this.page.fill('[name="lastname"]', lastName);
+        await this.page.fill('[name="street[0]"]', street);
+        await this.page.fill('[name="city"]', city);
+        await this.page.selectOption('[name="country_id"]', countryId);
+        // State/region may be a select or text input depending on country
+        const regionSelect = this.page.locator('[name="region_id"]');
+        if (await regionSelect.count() > 0) {
+            await regionSelect.selectOption({ label: regionCode });
+        } else {
+            await this.page.fill('[name="region"]', regionCode);
+        }
+        await this.page.fill('[name="postcode"]', zip);
+        await this.page.fill('[name="telephone"]', phone);
+    }
+
+    /**
+     * Selects the flat rate shipping method and waits for it to be checked.
+     */
+    async selectFlatRateShipping() {
+        const shippingMethod = this.page.locator('[value="flatrate_flatrate"]');
+        await shippingMethod.waitFor({ timeout: 15000 });
+        await shippingMethod.check();
+    }
+
+    /**
+     * Checks the mobile consent checkbox in the shipping form.
+     */
+    async checkMobileConsentAtCheckout() {
+        const checkbox = this.page.locator('[name="custom_attributes[kl_mobile_consent]"]');
+        await checkbox.waitFor({ timeout: 10000 });
+        await checkbox.check();
+    }
+
+    /**
+     * Checks the email consent checkbox in the shipping form.
+     */
+    async checkEmailConsentAtCheckout() {
+        const checkbox = this.page.locator('[name="custom_attributes[kl_email_consent]"]');
+        await checkbox.waitFor({ timeout: 10000 });
+        await checkbox.check();
+    }
+
+    /**
+     * Clicks "Next" to proceed from the shipping step to the payment step.
+     */
+    async proceedToPayment() {
+        await this.page.locator('button.continue').click();
+        await this.page.locator('.payment-method').waitFor({ timeout: 20000 });
+    }
+
+    /**
+     * Clicks "Place Order" and waits for the order success page.
+     */
+    async placeOrder() {
+        const placeOrderBtn = this.page.locator('button.action.primary.checkout');
+        await placeOrderBtn.waitFor({ timeout: 15000 });
+        await placeOrderBtn.click();
+        await this.page.locator('.checkout-success').waitFor({ timeout: 30000 });
+    }
 }
 
 module.exports = Storefront;

--- a/Test/e2e/locators/storefront.js
+++ b/Test/e2e/locators/storefront.js
@@ -169,7 +169,7 @@ class Storefront {
      * Checks the mobile consent checkbox in the shipping form.
      */
     async checkMobileConsentAtCheckout() {
-        const checkbox = this.page.locator('[name="custom_attributes[kl_mobile_consent]"]');
+        const checkbox = this.page.locator('[name="custom_attributes[kl_sms_consent]"]');
         await checkbox.waitFor({ timeout: 10000 });
         await checkbox.check();
     }

--- a/Test/e2e/utils/klaviyo-api.js
+++ b/Test/e2e/utils/klaviyo-api.js
@@ -79,9 +79,29 @@ async function checkProfileListRelationships(profileId) {
     return response.data.data;
 }
 
+/**
+ * Fetches all subscription channels for a profile by email.
+ * Returns the `subscriptions` object from the profile attributes, or null if not found.
+ * @param {string} email - Email address to look up
+ * @returns {Promise<object|null>} Subscriptions object or null
+ */
+async function checkProfileSubscriptions(email) {
+    const response = await axios.get(`https://${klaviyoV3Url}/profiles/`, {
+        headers: getHeaders(),
+        params: {
+            filter: `equals(email,"${email}")`,
+            'additional-fields[profile]': 'subscriptions'
+        }
+    });
+    const profiles = response.data.data;
+    if (profiles.length === 0) return null;
+    return profiles[0].attributes.subscriptions;
+}
+
 module.exports = {
     createProfileInKlaviyo,
     checkEvent,
     checkProfileInKlaviyo,
-    checkProfileListRelationships
+    checkProfileListRelationships,
+    checkProfileSubscriptions
 };

--- a/Util/PhoneFormatter.php
+++ b/Util/PhoneFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Klaviyo\Reclaim\Util;
+
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
+
+class PhoneFormatter
+{
+    public function formatE164(?string $phone, ?string $isoCountry): ?string
+    {
+        if (empty($phone) || empty($isoCountry)) {
+            return null;
+        }
+        try {
+            $util = PhoneNumberUtil::getInstance();
+            $parsed = $util->parse($phone, $isoCountry);
+            if (!$util->isValidNumber($parsed)) {
+                return null;
+            }
+            return $util->format($parsed, PhoneNumberFormat::E164);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-dev",
     "description": "The local development composer file. This is used for local and continuous integration setup/testing.",
     "type": "magento2-module",
-    "version": "4.5.0",
+    "version": "5.0.0",
     "autoload": {
         "psr-4": {
             "Klaviyo\\Reclaim\\": ""

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-dev",
     "description": "The local development composer file. This is used for local and continuous integration setup/testing.",
     "type": "magento2-module",
-    "version": "4.4.4",
+    "version": "4.5.0",
     "autoload": {
         "psr-4": {
             "Klaviyo\\Reclaim\\": ""

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
         "optimize-autoloader": true
     },
     "require": {
+        "php": "^8.1",
         "magento/module-quote": ">=101.1.3",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "giggsey/libphonenumber-for-php": "^9.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.5.0",
+    "version": "5.0.0",
     "autoload": {
         "files": [
             "registration.php"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.4.4",
+    "version": "4.5.0",
     "autoload": {
         "files": [
             "registration.php"

--- a/composer.lock
+++ b/composer.lock
@@ -4,331 +4,6801 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "292a42e30ce4da5a5d19584095468bb6",
-    "packages": [],
-    "packages-dev": [
+    "content-hash": "c4ba3d8ebfc0b92d93824563e5cf5d3f",
+    "packages": [
         {
-            "name": "2bj/phanybar",
-            "version": "v1.0.0",
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/2bj/Phanybar.git",
-                "reference": "88ff671e18f30c2047a34f8cf2465a7ff93c819b"
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/2bj/Phanybar/zipball/88ff671e18f30c2047a34f8cf2465a7ff93c819b",
-                "reference": "88ff671e18f30c2047a34f8cf2465a7ff93c819b",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
-            },
-            "bin": [
-                "bin/phanybar"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Bakyt\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bakyt Turgumbaev",
-                    "email": "dev2bj@gmail.com"
-                }
-            ],
-            "description": "Control AnyBar from your php",
-            "keywords": [
-                "anybar",
-                "phanybar"
-            ],
-            "time": "2015-03-06T12:14:28+00:00"
-        },
-        {
-            "name": "codedungeon/php-cli-colors",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mikeerickson/php-cli-colors.git",
-                "reference": "9f60ac692cc790755dad47b01c1d607fe5f43b94"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mikeerickson/php-cli-colors/zipball/9f60ac692cc790755dad47b01c1d607fe5f43b94",
-                "reference": "9f60ac692cc790755dad47b01c1d607fe5f43b94",
-                "shasum": ""
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=5.2"
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Codedungeon\\PHPCliColors\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "Apache-2.0"
             ],
             "authors": [
                 {
-                    "name": "Mike Erickson",
-                    "email": "codedungeon@gmail.com"
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
                 }
             ],
-            "description": "PHP Package for using color output in CLI commands",
-            "homepage": "https://github.com/mikeerickson/php-cli-colors",
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
             "keywords": [
-                "color",
-                "colors",
-                "composer",
-                "package",
-                "php"
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
             ],
-            "time": "2019-12-29T22:29:29+00:00"
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
         },
         {
-            "name": "codedungeon/phpunit-result-printer",
-            "version": "0.27.0",
+            "name": "aws/aws-sdk-php",
+            "version": "3.382.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikeerickson/phpunit-pretty-result-printer.git",
-                "reference": "b1321647ef3eacfb145fcc9559483b22d0c86cfe"
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "6844cc6421c47d6b96633ab8039045012acbeb27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikeerickson/phpunit-pretty-result-printer/zipball/b1321647ef3eacfb145fcc9559483b22d0c86cfe",
-                "reference": "b1321647ef3eacfb145fcc9559483b22d0c86cfe",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6844cc6421c47d6b96633ab8039045012acbeb27",
+                "reference": "6844cc6421c47d6b96633ab8039045012acbeb27",
                 "shasum": ""
             },
             "require": {
-                "2bj/phanybar": "^1.0",
-                "codedungeon/php-cli-colors": "^1.10.2",
-                "hassankhan/config": "^0.11.2",
-                "php": "^7.1",
-                "phpunit/phpunit": "^8.0|^9.0",
-                "symfony/yaml": "^2.7|^3.0|^4.0"
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.8.0",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
             },
             "require-dev": {
-                "spatie/phpunit-watcher": "^1.6"
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
             },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Codedungeon\\PHPUnitPrettyResultPrinter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike Erickson",
-                    "email": "codedungeon@gmail.com"
-                }
-            ],
-            "description": "PHPUnit Pretty Result Printer",
-            "keywords": [
-                "TDD",
-                "composer",
-                "package",
-                "phpunit",
-                "printer",
-                "result-printer",
-                "testing"
-            ],
-            "time": "2020-02-29T21:59:20+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^6.0",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
                 "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.382.2"
+            },
+            "time": "2026-05-27T18:11:41+00:00"
+        },
+        {
+            "name": "brick/math",
+            "version": "0.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/fc7ed316430118cc7836bf45faff18d5dfc8de04",
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "6.8.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "bignumber",
+                "brick",
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/0.13.1"
+            },
+            "funding": [
                 {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
                 }
             ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2019-10-21T16:45:58+00:00"
+            "time": "2025-03-29T13:50:30+00:00"
         },
         {
-            "name": "hassankhan/config",
-            "version": "0.11.2",
+            "name": "colinmollenhour/credis",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/hassankhan/config.git",
-                "reference": "7fbc236c32dc6cc53a7b00992a2739cf8b41c085"
+                "url": "https://github.com/colinmollenhour/credis.git",
+                "reference": "418f7031f31d1481c3ac19c918348e131bf8d3bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hassankhan/config/zipball/7fbc236c32dc6cc53a7b00992a2739cf8b41c085",
-                "reference": "7fbc236c32dc6cc53a7b00992a2739cf8b41c085",
+                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/418f7031f31d1481c3ac19c918348e131bf8d3bf",
+                "reference": "418f7031f31d1481c3ac19c918348e131bf8d3bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0",
-                "scrutinizer/ocular": "~1.1",
-                "squizlabs/php_codesniffer": "~2.2"
+                "php": ">=7.4.0"
             },
             "suggest": {
-                "symfony/yaml": "~2.5"
+                "ext-redis": "Improved performance for communicating with redis"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Noodlehaus\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Hassan Khan",
-                    "homepage": "http://hassankhan.me/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Lightweight configuration file loader that supports PHP, INI, XML, JSON, and YAML files",
-            "homepage": "http://hassankhan.me/config/",
-            "keywords": [
-                "config",
-                "configuration",
-                "ini",
-                "json",
-                "microphp",
-                "unframework",
-                "xml",
-                "yaml",
-                "yml"
-            ],
-            "time": "2017-11-07T22:49:43+00:00"
-        },
-        {
-            "name": "myclabs/deep-copy",
-            "version": "1.9.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
+                "classmap": [
+                    "Client.php",
+                    "Cluster.php",
+                    "Sentinel.php",
+                    "Module.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
+            "authors": [
+                {
+                    "name": "Colin Mollenhour",
+                    "email": "colin@mollenhour.com"
+                }
             ],
-            "time": "2020-01-17T21:11:47+00:00"
+            "description": "Credis is a lightweight interface to the Redis key-value store which wraps the phpredis library when available for better performance.",
+            "homepage": "https://github.com/colinmollenhour/credis",
+            "support": {
+                "issues": "https://github.com/colinmollenhour/credis/issues",
+                "source": "https://github.com/colinmollenhour/credis/tree/v1.17.1"
+            },
+            "time": "2026-03-03T06:50:28+00:00"
         },
         {
-            "name": "phar-io/manifest",
-            "version": "1.0.3",
+            "name": "colinmollenhour/php-redis-session-abstract",
+            "version": "v1.5.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+                "url": "https://github.com/colinmollenhour/php-redis-session-abstract.git",
+                "reference": "5d93866cd53701ef8f866cb41cb5c6d7259d4416"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "url": "https://api.github.com/repos/colinmollenhour/php-redis-session-abstract/zipball/5d93866cd53701ef8f866cb41cb5c6d7259d4416",
+                "reference": "5d93866cd53701ef8f866cb41cb5c6d7259d4416",
                 "shasum": ""
             },
             "require": {
+                "colinmollenhour/credis": "~1.6",
+                "php": "^5.5 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Cm\\RedisSession\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin Mollenhour"
+                }
+            ],
+            "description": "A Redis-based session handler with optimistic locking",
+            "homepage": "https://github.com/colinmollenhour/php-redis-session-abstract",
+            "support": {
+                "issues": "https://github.com/colinmollenhour/php-redis-session-abstract/issues",
+                "source": "https://github.com/colinmollenhour/php-redis-session-abstract/tree/v1.5.5"
+            },
+            "time": "2024-02-03T06:04:45+00:00"
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.5.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8 || ^9",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/process": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.12"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-19T11:26:22+00:00"
+        },
+        {
+            "name": "composer/class-map-generator",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/class-map-generator.git",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^2.1 || ^3.1",
+                "php": "^7.2 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7 || ^8"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
+                "phpstan/phpstan-phpunit": "^1 || ^2",
+                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
+                "phpunit/phpunit": "^8",
+                "symfony/filesystem": "^5.4 || ^6 || ^7 || ^8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\ClassMapGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Utilities to scan PHP code and generate class maps.",
+            "keywords": [
+                "classmap"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/class-map-generator/issues",
+                "source": "https://github.com/composer/class-map-generator/tree/1.7.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-05T09:17:07+00:00"
+        },
+        {
+            "name": "composer/composer",
+            "version": "2.9.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/composer.git",
+                "reference": "39ee8baff8e97a1b657bbfcd6a236ff93a5efbb2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/composer/zipball/39ee8baff8e97a1b657bbfcd6a236ff93a5efbb2",
+                "reference": "39ee8baff8e97a1b657bbfcd6a236ff93a5efbb2",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.5",
+                "composer/class-map-generator": "^1.4.0",
+                "composer/metadata-minifier": "^1.0",
+                "composer/pcre": "^2.3 || ^3.3",
+                "composer/semver": "^3.3",
+                "composer/spdx-licenses": "^1.5.7",
+                "composer/xdebug-handler": "^2.0.2 || ^3.0.3",
+                "ext-json": "*",
+                "justinrainbow/json-schema": "^6.5.1",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "react/promise": "^3.3",
+                "seld/jsonlint": "^1.4",
+                "seld/phar-utils": "^1.2",
+                "seld/signal-handler": "^2.0",
+                "symfony/console": "^5.4.47 || ^6.4.25 || ^7.1.10 || ^8.0",
+                "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.1.10 || ^8.0",
+                "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.1.10 || ^8.0",
+                "symfony/polyfill-php73": "^1.24",
+                "symfony/polyfill-php80": "^1.24",
+                "symfony/polyfill-php81": "^1.24",
+                "symfony/polyfill-php84": "^1.30",
+                "symfony/process": "^5.4.47 || ^6.4.25 || ^7.1.10 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11.8",
+                "phpstan/phpstan-deprecation-rules": "^1.2.0",
+                "phpstan/phpstan-phpunit": "^1.4.0",
+                "phpstan/phpstan-strict-rules": "^1.6.0",
+                "phpstan/phpstan-symfony": "^1.4.0",
+                "symfony/phpunit-bridge": "^6.4.25 || ^7.3.3 || ^8.0"
+            },
+            "suggest": {
+                "ext-curl": "Provides HTTP support (will fallback to PHP streams if missing)",
+                "ext-openssl": "Enables access to repositories and packages over HTTPS",
+                "ext-zip": "Allows direct extraction of ZIP archives (unzip/7z binaries will be used instead if available)",
+                "ext-zlib": "Enables gzip for HTTP requests"
+            },
+            "bin": [
+                "bin/composer"
+            ],
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "phpstan/rules.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\": "src/Composer/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "https://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Composer helps you declare, manage and install dependencies of PHP projects. It ensures you have the right stack everywhere.",
+            "homepage": "https://getcomposer.org/",
+            "keywords": [
+                "autoload",
+                "dependency",
+                "package"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/composer/issues",
+                "security": "https://github.com/composer/composer/security/policy",
+                "source": "https://github.com/composer/composer/tree/2.9.8"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-13T07:28:38+00:00"
+        },
+        {
+            "name": "composer/metadata-minifier",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/metadata-minifier.git",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/metadata-minifier/zipball/c549d23829536f0d0e984aaabbf02af91f443207",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2",
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\MetadataMinifier\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Small utility library that handles metadata minification and expansion.",
+            "keywords": [
+                "composer",
+                "compression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/metadata-minifier/issues",
+                "source": "https://github.com/composer/metadata-minifier/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-07T13:37:33+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "composer/spdx-licenses",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/spdx-licenses.git",
+                "reference": "5ecd0cb4177696f9fd48f1605dda81db3dee7889"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/5ecd0cb4177696f9fd48f1605dda81db3dee7889",
+                "reference": "5ecd0cb4177696f9fd48f1605dda81db3dee7889",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^6.4.25 || ^7.3.3 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Spdx\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "SPDX licenses list and validation library.",
+            "keywords": [
+                "license",
+                "spdx",
+                "validator"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/spdx-licenses/issues",
+                "source": "https://github.com/composer/spdx-licenses/tree/1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-08T20:18:39+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "cerdic/css-tidy": "^1.7 || ^2.0",
+                "simpletest/simpletest": "dev-master"
+            },
+            "suggest": {
+                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
+                "ext-bcmath": "Used for unit conversion and imagecrash protection",
+                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
+                "ext-tidy": "Used for pretty-printing HTML"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "issues": "https://github.com/ezyang/htmlpurifier/issues",
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.19.0"
+            },
+            "time": "2025-10-17T16:34:55+00:00"
+        },
+        {
+            "name": "giggsey/libphonenumber-for-php",
+            "version": "9.0.30",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/libphonenumber-for-php.git",
+                "reference": "585ce999a2d404ed48bf5b37a22ba369a885f2b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/585ce999a2d404ed48bf5b37a22ba369a885f2b9",
+                "reference": "585ce999a2d404ed48bf5b37a22ba369a885f2b9",
+                "shasum": ""
+            },
+            "require": {
+                "giggsey/locale": "^2.7",
+                "php": "^8.1",
+                "symfony/polyfill-mbstring": "^1.31"
+            },
+            "replace": {
+                "giggsey/libphonenumber-for-php-lite": "self.version"
+            },
+            "require-dev": {
                 "ext-dom": "*",
+                "friendsofphp/php-cs-fixer": "^3.71",
+                "infection/infection": "^0.29|^0.31.0",
+                "nette/php-generator": "^4.1",
+                "php-coveralls/php-coveralls": "^2.7",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.7",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpstan/phpstan-phpunit": "^2.0.4",
+                "phpstan/phpstan-strict-rules": "^2.0.3",
+                "phpunit/phpunit": "^10.5.45",
+                "symfony/console": "^6.4",
+                "symfony/filesystem": "^6.4",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "libphonenumber\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "A library for parsing, formatting, storing and validating international phone numbers, a PHP Port of Google's libphonenumber.",
+            "homepage": "https://github.com/giggsey/libphonenumber-for-php",
+            "keywords": [
+                "geocoding",
+                "geolocation",
+                "libphonenumber",
+                "mobile",
+                "phonenumber",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/giggsey/libphonenumber-for-php/issues",
+                "source": "https://github.com/giggsey/libphonenumber-for-php"
+            },
+            "time": "2026-05-07T12:07:12+00:00"
+        },
+        {
+            "name": "giggsey/locale",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/Locale.git",
+                "reference": "fe741e99ae6ccbe8132f3d63d8ec89924e689778"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/Locale/zipball/fe741e99ae6ccbe8132f3d63d8ec89924e689778",
+                "reference": "fe741e99ae6ccbe8132f3d63d8ec89924e689778",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "friendsofphp/php-cs-fixer": "^3.66",
+                "infection/infection": "^0.29|^0.32.0",
+                "php-coveralls/php-coveralls": "^2.7",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.7",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpstan/phpstan-phpunit": "^2.0.4",
+                "phpstan/phpstan-strict-rules": "^2.0.3",
+                "phpunit/phpunit": "^10.5.45",
+                "symfony/console": "^6.4",
+                "symfony/filesystem": "^6.4",
+                "symfony/finder": "^6.4",
+                "symfony/process": "^6.4",
+                "symfony/var-exporter": "^6.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Giggsey\\Locale\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "Locale functions required by libphonenumber-for-php",
+            "support": {
+                "issues": "https://github.com/giggsey/Locale/issues",
+                "source": "https://github.com/giggsey/Locale/tree/2.9.0"
+            },
+            "time": "2026-02-24T15:32:13+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.10.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7c8d84b39e680315f687e8662a9d6fb0865c5148",
+                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.4",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T11:53:46+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/09e8a212562fb1fb6a512c4156ed71525969d6c2",
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T22:57:30+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "7c1472269227dc6f18930bd903d7a88fe6c52130"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7c1472269227dc6f18930bd903d7a88fe6c52130",
+                "reference": "7c1472269227dc6f18930bd903d7a88fe6c52130",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.10.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T11:48:20+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "6.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jsonrainbow/json-schema.git",
+                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "marc-mabe/php-enum": "^4.4",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.3.0",
+                "json-schema/json-schema-test-suite": "dev-main",
+                "marc-mabe/php-enum-phpstan": "^2.0",
+                "phpspec/prophecy": "^1.19",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^8.5"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/jsonrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/jsonrainbow/json-schema/issues",
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.2"
+            },
+            "time": "2026-05-05T05:39:01+00:00"
+        },
+        {
+            "name": "laminas/laminas-captcha",
+            "version": "2.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-captcha.git",
+                "reference": "4c0965b31ec310ec95c72acd76a016b5030182fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-captcha/zipball/4c0965b31ec310ec95c72acd76a016b5030182fe",
+                "reference": "4c0965b31ec310ec95c72acd76a016b5030182fe",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-recaptcha": "^3.4.0",
+                "laminas/laminas-session": "^2.12",
+                "laminas/laminas-stdlib": "^3.10.1",
+                "laminas/laminas-text": "^2.9.0",
+                "laminas/laminas-validator": "^2.19.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zend-captcha": "*"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.1"
+            },
+            "suggest": {
+                "laminas/laminas-i18n-resources": "Translations of captcha messages"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Captcha\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Generate and validate CAPTCHAs using Figlets, images, ReCaptcha, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "captcha",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-captcha/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-captcha/issues",
+                "rss": "https://github.com/laminas/laminas-captcha/releases.atom",
+                "source": "https://github.com/laminas/laminas-captcha"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-01-06T20:04:41+00:00"
+        },
+        {
+            "name": "laminas/laminas-code",
+            "version": "4.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-code.git",
+                "reference": "1793e78dad4108b594084d05d1fb818b85b110af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/1793e78dad4108b594084d05d1fb818b85b110af",
+                "reference": "1793e78dad4108b594084d05d1fb818b85b110af",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0.1",
                 "ext-phar": "*",
-                "phar-io/version": "^2.0",
-                "php": "^5.6 || ^7.0"
+                "laminas/laminas-coding-standard": "^3.0.0",
+                "laminas/laminas-stdlib": "^3.18.0",
+                "phpunit/phpunit": "^10.5.37",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.15.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "laminas/laminas-stdlib": "Laminas\\Stdlib component"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Extensions to the PHP Reflection API, static code scanning, and code generation",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "code",
+                "laminas",
+                "laminasframework"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-code/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-code/issues",
+                "rss": "https://github.com/laminas/laminas-code/releases.atom",
+                "source": "https://github.com/laminas/laminas-code"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-11-20T13:15:13+00:00"
+        },
+        {
+            "name": "laminas/laminas-config",
+            "version": "3.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-config.git",
+                "reference": "b816433bd36ddc4ba93e190eaac18497b0b6948c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/b816433bd36ddc4ba93e190eaac18497b0b6948c",
+                "reference": "b816433bd36ddc4ba93e190eaac18497b0b6948c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "^8.1.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2.0",
+                "zendframework/zend-config": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-filter": "^2.39.0",
+                "laminas/laminas-i18n": "^2.29.0",
+                "laminas/laminas-servicemanager": "^3.23.0",
+                "phpunit/phpunit": "^10.5.38"
+            },
+            "suggest": {
+                "laminas/laminas-filter": "^2.7.2; install if you want to use the Filter processor",
+                "laminas/laminas-i18n": "^2.7.4; install if you want to use the Translator processor",
+                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3; if you need an extensible plugin manager for use with the Config Factory"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Config\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a nested object property based user interface for accessing this configuration data within application code",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "config",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-config/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-config/issues",
+                "rss": "https://github.com/laminas/laminas-config/releases.atom",
+                "source": "https://github.com/laminas/laminas-config"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "abandoned": true,
+            "time": "2026-01-29T12:14:07+00:00"
+        },
+        {
+            "name": "laminas/laminas-crypt",
+            "version": "3.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-crypt.git",
+                "reference": "ceab630494fc7a0d82ec39ad63947ef889a21be7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-crypt/zipball/ceab630494fc7a0d82ec39ad63947ef889a21be7",
+                "reference": "ceab630494fc7a0d82ec39ad63947ef889a21be7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "laminas/laminas-math": "^3.4",
+                "laminas/laminas-stdlib": "^3.8",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+                "psr/container": "^1.1"
+            },
+            "conflict": {
+                "zendframework/zend-crypt": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "phpunit/phpunit": "^9.5.25"
+            },
+            "suggest": {
+                "ext-openssl": "Required for most features of Laminas\\Crypt"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Crypt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Strong cryptography tools and password hashing",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "crypt",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-crypt/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-crypt/issues",
+                "rss": "https://github.com/laminas/laminas-crypt/releases.atom",
+                "source": "https://github.com/laminas/laminas-crypt"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "abandoned": true,
+            "time": "2024-07-15T09:11:42+00:00"
+        },
+        {
+            "name": "laminas/laminas-db",
+            "version": "2.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-db.git",
+                "reference": "758c2ca28c831188edb8d4dd1eaf46ee28b85625"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/758c2ca28c831188edb8d4dd1eaf46ee28b85625",
+                "reference": "758c2ca28c831188edb8d4dd1eaf46ee28b85625",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.7.1",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zend-db": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^2.4.0",
+                "laminas/laminas-eventmanager": "^3.6.0",
+                "laminas/laminas-hydrator": "^4.7",
+                "laminas/laminas-servicemanager": "^3.19.0",
+                "phpunit/phpunit": "^9.6.34"
+            },
+            "suggest": {
+                "laminas/laminas-eventmanager": "Laminas\\EventManager component",
+                "laminas/laminas-hydrator": "(^3.2 || ^4.3) Laminas\\Hydrator component for using HydratingResultSets",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Db",
+                    "config-provider": "Laminas\\Db\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Db\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Database abstraction layer, SQL abstraction, result set abstraction, and RowDataGateway and TableDataGateway implementations",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "db",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-db/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-db/issues",
+                "rss": "https://github.com/laminas/laminas-db/releases.atom",
+                "source": "https://github.com/laminas/laminas-db"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2026-03-20T16:11:27+00:00"
+        },
+        {
+            "name": "laminas/laminas-escaper",
+            "version": "2.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-escaper.git",
+                "reference": "df1ef9503299a8e3920079a16263b578eaf7c3ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/df1ef9503299a8e3920079a16263b578eaf7c3ba",
+                "reference": "df1ef9503299a8e3920079a16263b578eaf7c3ba",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-mbstring": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zend-escaper": "*"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29.8",
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "vimeo/psalm": "^6.6.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "escaper",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-escaper/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-escaper/issues",
+                "rss": "https://github.com/laminas/laminas-escaper/releases.atom",
+                "source": "https://github.com/laminas/laminas-escaper"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-05-06T19:29:36+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "1837cafaaaee74437f6d8ec9ff7da03e6f81d809"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/1837cafaaaee74437f6d8ec9ff7da03e6f81d809",
+                "reference": "1837cafaaaee74437f6d8ec9ff7da03e6f81d809",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2",
+                "zendframework/zend-eventmanager": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "laminas/laminas-stdlib": "^3.20",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/container": "^1.1.2 || ^2.0.2",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
+                "psr/container": "^1.1.2 || ^2.0.2, to use the lazy listeners feature"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-eventmanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-eventmanager/issues",
+                "rss": "https://github.com/laminas/laminas-eventmanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-eventmanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-11-21T11:31:22+00:00"
+        },
+        {
+            "name": "laminas/laminas-file",
+            "version": "2.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-file.git",
+                "reference": "09ef45c63875c226093efe893ada3ebe656072ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-file/zipball/09ef45c63875c226093efe893ada3ebe656072ff",
+                "reference": "09ef45c63875c226093efe893ada3ebe656072ff",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^2.7.7 || ^3.15.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+            },
+            "conflict": {
+                "zendframework/zend-file": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-filter": "^2.23.2",
+                "laminas/laminas-i18n": "^2.7.4",
+                "laminas/laminas-progressbar": "^2.5.2",
+                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
+                "laminas/laminas-session": "^2.8",
+                "laminas/laminas-validator": "^2.10.1",
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "suggest": {
+                "laminas/laminas-filter": "Laminas\\Filter component",
+                "laminas/laminas-i18n": "Laminas\\I18n component",
+                "laminas/laminas-validator": "Laminas\\Validator component"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\File\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Locate PHP classfiles",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "file",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-file/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-file/issues",
+                "rss": "https://github.com/laminas/laminas-file/releases.atom",
+                "source": "https://github.com/laminas/laminas-file"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "abandoned": true,
+            "time": "2024-12-05T15:04:21+00:00"
+        },
+        {
+            "name": "laminas/laminas-filter",
+            "version": "2.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-filter.git",
+                "reference": "eaa00111231bf6669826ae84d3abe85b94477585"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/eaa00111231bf6669826ae84d3abe85b94477585",
+                "reference": "eaa00111231bf6669826ae84d3abe85b94477585",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.19.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "laminas/laminas-validator": "<2.10.1",
+                "zendframework/zend-filter": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.0",
+                "laminas/laminas-crypt": "^3.12",
+                "laminas/laminas-i18n": "^2.28.1",
+                "laminas/laminas-uri": "^2.12",
+                "pear/archive_tar": "^1.5.0",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/http-factory": "^1.1.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
+                "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",
+                "laminas/laminas-uri": "Laminas\\Uri component, for the UriNormalize filter",
+                "psr/http-factory-implementation": "psr/http-factory-implementation, for creating file upload instances when consuming PSR-7 in file upload filters"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Filter",
+                    "config-provider": "Laminas\\Filter\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Filter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Programmatically filter and normalize data and files",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "filter",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-filter/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-filter/issues",
+                "rss": "https://github.com/laminas/laminas-filter/releases.atom",
+                "source": "https://github.com/laminas/laminas-filter"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-05-05T02:02:31+00:00"
+        },
+        {
+            "name": "laminas/laminas-http",
+            "version": "2.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-http.git",
+                "reference": "5052177fb8176e00b0d4b89108648f557be072b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/5052177fb8176e00b0d4b89108648f557be072b7",
+                "reference": "5052177fb8176e00b0d4b89108648f557be072b7",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-loader": "^2.10",
+                "laminas/laminas-stdlib": "^3.6",
+                "laminas/laminas-uri": "^2.11",
+                "laminas/laminas-validator": "^2.15 || ^3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zend-http": "*"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "phpunit/phpunit": "^10.5.38"
+            },
+            "suggest": {
+                "paragonie/certainty": "For automated management of cacert.pem"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Http\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "http",
+                "http client",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-http/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-http/issues",
+                "rss": "https://github.com/laminas/laminas-http/releases.atom",
+                "source": "https://github.com/laminas/laminas-http"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-05-06T08:24:40+00:00"
+        },
+        {
+            "name": "laminas/laminas-i18n",
+            "version": "2.30.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-i18n.git",
+                "reference": "397907ee061e147939364df9d6c485ac1e0fed87"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/397907ee061e147939364df9d6c485ac1e0fed87",
+                "reference": "397907ee061e147939364df9d6c485ac1e0fed87",
+                "shasum": ""
+            },
+            "require": {
+                "ext-intl": "*",
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.0",
+                "laminas/laminas-translator": "^1.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "laminas/laminas-view": "<2.20.0",
+                "zendframework/zend-i18n": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-cache": "^3.13.0",
+                "laminas/laminas-cache-storage-adapter-memory": "^2.4.0",
+                "laminas/laminas-cache-storage-deprecated-factory": "^1.3",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-config": "^3.10.1",
+                "laminas/laminas-eventmanager": "^3.14.0",
+                "laminas/laminas-filter": "^2.40",
+                "laminas/laminas-validator": "^2.64.2",
+                "laminas/laminas-view": "^2.36",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.0"
+            },
+            "suggest": {
+                "laminas/laminas-cache": "You should install this package to cache the translations",
+                "laminas/laminas-config": "You should install this package to use the INI translation format",
+                "laminas/laminas-eventmanager": "You should install this package to use the events in the translator",
+                "laminas/laminas-filter": "You should install this package to use the provided filters",
+                "laminas/laminas-i18n-resources": "This package provides validator and captcha translations",
+                "laminas/laminas-validator": "You should install this package to use the provided validators",
+                "laminas/laminas-view": "You should install this package to use the provided view helpers"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\I18n",
+                    "config-provider": "Laminas\\I18n\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\I18n\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provide translations for your application, and filter and validate internationalized values",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-i18n/issues",
+                "rss": "https://github.com/laminas/laminas-i18n/releases.atom",
+                "source": "https://github.com/laminas/laminas-i18n"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-04-15T09:07:02+00:00"
+        },
+        {
+            "name": "laminas/laminas-loader",
+            "version": "2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-loader.git",
+                "reference": "ec8cee33fb254ee4d9c8e8908c870e5c797e1272"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/ec8cee33fb254ee4d9c8e8908c870e5c797e1272",
+                "reference": "ec8cee33fb254ee4d9c8e8908c870e5c797e1272",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0.0"
+            },
+            "conflict": {
+                "zendframework/zend-loader": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "phpunit/phpunit": "~9.5.25"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Loader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Autoloading and plugin loading strategies",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "loader"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-loader/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-loader/issues",
+                "rss": "https://github.com/laminas/laminas-loader/releases.atom",
+                "source": "https://github.com/laminas/laminas-loader"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "abandoned": true,
+            "time": "2025-12-30T11:30:39+00:00"
+        },
+        {
+            "name": "laminas/laminas-mail",
+            "version": "2.25.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-mail.git",
+                "reference": "110e04497395123998220e244cceecb167cc6dda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-mail/zipball/110e04497395123998220e244cceecb167cc6dda",
+                "reference": "110e04497395123998220e244cceecb167cc6dda",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "laminas/laminas-loader": "^2.9.0",
+                "laminas/laminas-mime": "^2.11.0",
+                "laminas/laminas-stdlib": "^3.17.0",
+                "laminas/laminas-validator": "^2.31.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "symfony/polyfill-intl-idn": "^1.27.0",
+                "symfony/polyfill-mbstring": "^1.27.0",
+                "webmozart/assert": "^1.11.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-db": "^2.18",
+                "laminas/laminas-servicemanager": "^3.22.1",
+                "phpunit/phpunit": "^10.4.2",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "symfony/process": "^6.3.4",
+                "vimeo/psalm": "^5.15"
+            },
+            "suggest": {
+                "laminas/laminas-servicemanager": "^3.21 when using SMTP to deliver messages"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Mail",
+                    "config-provider": "Laminas\\Mail\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Mail\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provides generalized functionality to compose and send both text and MIME-compliant multipart e-mail messages",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "mail"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-mail/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-mail/issues",
+                "rss": "https://github.com/laminas/laminas-mail/releases.atom",
+                "source": "https://github.com/laminas/laminas-mail"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "abandoned": "symfony/mailer",
+            "time": "2023-11-02T10:32:34+00:00"
+        },
+        {
+            "name": "laminas/laminas-math",
+            "version": "3.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-math.git",
+                "reference": "a9e54f68accf5f8a3e66dd01fc6b32180e520018"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-math/zipball/a9e54f68accf5f8a3e66dd01fc6b32180e520018",
+                "reference": "a9e54f68accf5f8a3e66dd01fc6b32180e520018",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zend-math": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "phpunit/phpunit": "~9.5.25"
+            },
+            "suggest": {
+                "ext-bcmath": "If using the bcmath functionality",
+                "ext-gmp": "If using the gmp functionality"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Create cryptographically secure pseudo-random numbers, and manage big integers",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "math"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-math/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-math/issues",
+                "rss": "https://github.com/laminas/laminas-math/releases.atom",
+                "source": "https://github.com/laminas/laminas-math"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "abandoned": true,
+            "time": "2024-12-05T13:49:56+00:00"
+        },
+        {
+            "name": "laminas/laminas-mime",
+            "version": "2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-mime.git",
+                "reference": "08cc544778829b7d68d27a097885bd6e7130135e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-mime/zipball/08cc544778829b7d68d27a097885bd6e7130135e",
+                "reference": "08cc544778829b7d68d27a097885bd6e7130135e",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^2.7 || ^3.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
+            },
+            "conflict": {
+                "zendframework/zend-mime": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-mail": "^2.19.0",
+                "phpunit/phpunit": "~9.5.25"
+            },
+            "suggest": {
+                "laminas/laminas-mail": "Laminas\\Mail component"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Mime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Create and parse MIME messages and parts",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "mime"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-mime/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-mime/issues",
+                "rss": "https://github.com/laminas/laminas-mime/releases.atom",
+                "source": "https://github.com/laminas/laminas-mime"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "abandoned": "symfony/mime",
+            "time": "2023-11-02T16:47:19+00:00"
+        },
+        {
+            "name": "laminas/laminas-oauth",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-oauth.git",
+                "reference": "5182456ec570c6dd6c04003349ab65d9bd553850"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-oauth/zipball/5182456ec570c6dd6c04003349ab65d9bd553850",
+                "reference": "5182456ec570c6dd6c04003349ab65d9bd553850",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-config": "^3.7",
+                "laminas/laminas-crypt": "^3.6.0",
+                "laminas/laminas-http": "^2.15",
+                "laminas/laminas-i18n": "^2.13.0",
+                "laminas/laminas-loader": "^2.8",
+                "laminas/laminas-math": "^3.5",
+                "laminas/laminas-stdlib": "^3.10",
+                "laminas/laminas-uri": "^2.9",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zendoauth": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "phpunit/phpunit": "^9.6.20"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\OAuth\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "oauth"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-oauth/issues",
+                "rss": "https://github.com/laminas/laminas-oauth/releases.atom",
+                "source": "https://github.com/laminas/laminas-oauth"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "abandoned": true,
+            "time": "2024-10-23T13:17:27+00:00"
+        },
+        {
+            "name": "laminas/laminas-permissions-acl",
+            "version": "2.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-permissions-acl.git",
+                "reference": "96d710d0a8e6cfa781b2ba184a3dd397634ae2e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-permissions-acl/zipball/96d710d0a8e6cfa781b2ba184a3dd397634ae2e7",
+                "reference": "96d710d0a8e6cfa781b2ba184a3dd397634ae2e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "laminas/laminas-servicemanager": "<3.0",
+                "zendframework/zend-permissions-acl": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-servicemanager": "^3.21",
+                "phpbench/phpbench": "^1.2.10",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "laminas/laminas-servicemanager": "To support Laminas\\Permissions\\Acl\\Assertion\\AssertionManager plugin manager usage"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Permissions\\Acl\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provides a lightweight and flexible access control list (ACL) implementation for privileges management",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "acl",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-permissions-acl/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-permissions-acl/issues",
+                "rss": "https://github.com/laminas/laminas-permissions-acl/releases.atom",
+                "source": "https://github.com/laminas/laminas-permissions-acl"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-11-25T10:38:49+00:00"
+        },
+        {
+            "name": "laminas/laminas-recaptcha",
+            "version": "3.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-recaptcha.git",
+                "reference": "ab4efc2768b1d9e90df9a49301158ec288cd48dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-recaptcha/zipball/ab4efc2768b1d9e90df9a49301158ec288cd48dd",
+                "reference": "ab4efc2768b1d9e90df9a49301158ec288cd48dd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laminas/laminas-http": "^2.15",
+                "laminas/laminas-stdlib": "^3.10.1",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zendservice-recaptcha": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-config": "^3.9",
+                "laminas/laminas-validator": "^2.30.1",
+                "phpunit/phpunit": "^9.6.15",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.19"
+            },
+            "suggest": {
+                "laminas/laminas-validator": "~2.0, if using ReCaptcha's Mailhide API"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ReCaptcha\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "OOP wrapper for the ReCaptcha web service",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "recaptcha"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-recaptcha/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-recaptcha/issues",
+                "rss": "https://github.com/laminas/laminas-recaptcha/releases.atom",
+                "source": "https://github.com/laminas/laminas-recaptcha"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-24T08:57:20+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "06594db3a644447521eace9b5efdb12dc8446a33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/06594db3a644447521eace9b5efdb12dc8446a33",
+                "reference": "06594db3a644447521eace9b5efdb12dc8446a33",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.19",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<4.10.0",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11.99.5",
+                "friendsofphp/proxy-manager-lts": "^1.0.18",
+                "laminas/laminas-code": "^4.16.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-container-config-test": "^0.8",
+                "mikey179/vfsstream": "^1.6.12",
+                "phpbench/phpbench": "^1.4.1",
+                "phpunit/phpunit": "^10.5.51",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-08-12T08:44:02+00:00"
+        },
+        {
+            "name": "laminas/laminas-session",
+            "version": "2.25.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-session.git",
+                "reference": "17b5fd6aa9889dc8362c26d4c7500c93ff4347cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-session/zipball/17b5fd6aa9889dc8362c26d4c7500c93ff4347cb",
+                "reference": "17b5fd6aa9889dc8362c26d4c7500c93ff4347cb",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-eventmanager": "^3.12",
+                "laminas/laminas-servicemanager": "^3.22",
+                "laminas/laminas-stdlib": "^3.18",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "amphp/amp": "<2.6.4",
+                "zendframework/zend-session": "*"
+            },
+            "require-dev": {
+                "ext-xdebug": "*",
+                "laminas/laminas-cache": "^3.12.2",
+                "laminas/laminas-cache-storage-adapter-memory": "^2.3",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-db": "^2.20.0",
+                "laminas/laminas-http": "^2.20",
+                "laminas/laminas-validator": "^2.64.1",
+                "mongodb/mongodb": "~2.1.0",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "laminas/laminas-cache": "Laminas\\Cache component",
+                "laminas/laminas-db": "Laminas\\Db component",
+                "laminas/laminas-http": "Laminas\\Http component",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component",
+                "laminas/laminas-validator": "Laminas\\Validator component",
+                "mongodb/mongodb": "If you want to use the MongoDB session save handler"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Session",
+                    "config-provider": "Laminas\\Session\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Session\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Object-oriented interface to PHP sessions and storage",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "session"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-session/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-session/issues",
+                "rss": "https://github.com/laminas/laminas-session/releases.atom",
+                "source": "https://github.com/laminas/laminas-session"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-11T09:26:06+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/8974a1213be42c3e2f70b2c27b17f910291ab2f4",
+                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zend-stdlib": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.0",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-stdlib/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-stdlib/issues",
+                "rss": "https://github.com/laminas/laminas-stdlib/releases.atom",
+                "source": "https://github.com/laminas/laminas-stdlib"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-29T13:46:07+00:00"
+        },
+        {
+            "name": "laminas/laminas-text",
+            "version": "2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-text.git",
+                "reference": "d18a04f97dad73f55ca1c66a70a981e663d13003"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-text/zipball/d18a04f97dad73f55ca1c66a70a981e663d13003",
+                "reference": "d18a04f97dad73f55ca1c66a70a981e663d13003",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-servicemanager": "^3.22.0",
+                "laminas/laminas-stdlib": "^3.7.1",
+                "php": "^8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-text": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Text\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Create FIGlets and text-based tables",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "text"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-text/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-text/issues",
+                "rss": "https://github.com/laminas/laminas-text/releases.atom",
+                "source": "https://github.com/laminas/laminas-text"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "abandoned": true,
+            "time": "2026-01-27T12:27:12+00:00"
+        },
+        {
+            "name": "laminas/laminas-translator",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-translator.git",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "reference": "12897e710e21413c1f93fc38fe9dead6b51c5218",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "vimeo/psalm": "^5.24.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Interfaces for the Translator component of laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-translator/issues",
+                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
+                "source": "https://github.com/laminas/laminas-translator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-10-21T15:33:01+00:00"
+        },
+        {
+            "name": "laminas/laminas-uri",
+            "version": "2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-uri.git",
+                "reference": "de53600ae8153b3605bb6edce8aeeef524eaafba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/de53600ae8153b3605bb6edce8aeeef524eaafba",
+                "reference": "de53600ae8153b3605bb6edce8aeeef524eaafba",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-escaper": "^2.9",
+                "laminas/laminas-validator": "^2.39 || ^3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zend-uri": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "phpunit/phpunit": "^9.6.20"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "uri"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-uri/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-uri/issues",
+                "rss": "https://github.com/laminas/laminas-uri/releases.atom",
+                "source": "https://github.com/laminas/laminas-uri"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-12-03T12:27:51+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "2.64.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "e2e6631f599a9b0db1e23adb633c09a2f0c68bed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/e2e6631f599a9b0db1e23adb633c09a2f0c68bed",
+                "reference": "e2e6631f599a9b0db1e23adb633c09a2f0c68bed",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
+            },
+            "conflict": {
+                "zendframework/zend-validator": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^2.5",
+                "laminas/laminas-db": "^2.20",
+                "laminas/laminas-filter": "^2.35.2",
+                "laminas/laminas-i18n": "^2.26.0",
+                "laminas/laminas-session": "^2.20",
+                "laminas/laminas-uri": "^2.11.0",
+                "phpunit/phpunit": "^10.5.20",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/http-client": "^1.0.3",
+                "psr/http-factory": "^1.1.0",
+                "vimeo/psalm": "^5.24.0"
+            },
+            "suggest": {
+                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
+                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
+                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
+                "laminas/laminas-i18n-resources": "Translations of validator messages",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
+                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Validator",
+                    "config-provider": "Laminas\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "validator"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-validator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-validator/issues",
+                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
+                "source": "https://github.com/laminas/laminas-validator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-06-16T14:38:00+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "8aaffb653c5777781b0f7f69a5d937baf7ab6cdb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/8aaffb653c5777781b0f7f69a5d937baf7ab6cdb",
+                "reference": "8aaffb653c5777781b0f7f69a5d937baf7ab6cdb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^7.2 || ^8.0"
+            },
+            "conflict": {
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "require-dev": {
+                "async-aws/s3": "^1.5",
+                "async-aws/simple-s3": "^1.0",
+                "aws/aws-sdk-php": "^3.132.4",
+                "composer/semver": "^3.0",
+                "ext-fileinfo": "*",
+                "ext-ftp": "*",
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "google/cloud-storage": "^1.23",
+                "phpseclib/phpseclib": "^2.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpunit/phpunit": "^8.5 || ^9.4",
+                "sabre/dav": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "File storage abstraction for PHP",
+            "keywords": [
+                "WebDAV",
+                "aws",
+                "cloud",
+                "file",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://ecologi.com/frankdejonge",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-09-17T21:02:32+00:00"
+        },
+        {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "2ae435f7177fd5d3afc0090bc7f849093d8361e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/2ae435f7177fd5d3afc0090bc7f849093d8361e8",
+                "reference": "2ae435f7177fd5d3afc0090bc7f849093d8361e8",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.132.4",
+                "league/flysystem": "^2.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^7.2 || ^8.0"
+            },
+            "conflict": {
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3V3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem-aws-s3-v3/issues",
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://ecologi.com/frankdejonge",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-09-09T19:33:51+00:00"
+        },
+        {
+            "name": "league/mime-type-detection",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/mime-type-detection.git",
+                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^0.12.68",
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\MimeTypeDetection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-21T08:32:55+00:00"
+        },
+        {
+            "name": "magento/composer-dependency-version-audit-plugin",
+            "version": "0.1.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/composer-dependency-version-audit-plugin/magento-composer-dependency-version-audit-plugin-0.1.6.0.zip",
+                "shasum": "62f455a259a54aa1869127f7b911345266105bf7"
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer/composer": "^1.9 || ^2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Magento\\ComposerDependencyVersionAuditPlugin\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Magento\\ComposerDependencyVersionAuditPlugin\\": "src/"
+                }
+            },
+            "license": [
+                "OSL-3.0"
+            ],
+            "description": "Validating packages through a composer plugin"
+        },
+        {
+            "name": "magento/framework",
+            "version": "103.0.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/framework/magento-framework-103.0.7.0-patch10.zip",
+                "shasum": "90c44ee6ae6b43c314389c1d4284d1582dcfe690"
+            },
+            "require": {
+                "colinmollenhour/php-redis-session-abstract": "~1.5.3",
+                "composer/composer": "^2.0, !=2.2.16",
+                "ext-bcmath": "*",
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "ext-gd": "*",
+                "ext-hash": "*",
+                "ext-iconv": "*",
+                "ext-intl": "*",
+                "ext-openssl": "*",
+                "ext-simplexml": "*",
+                "ext-sodium": "*",
+                "ext-xsl": "*",
+                "ezyang/htmlpurifier": "^4.17",
+                "guzzlehttp/guzzle": "^7.5",
+                "laminas/laminas-code": "^4.13",
+                "laminas/laminas-escaper": "^2.13",
+                "laminas/laminas-file": "^2.13",
+                "laminas/laminas-filter": "^2.33",
+                "laminas/laminas-http": "^2.15",
+                "laminas/laminas-i18n": "^2.17",
+                "laminas/laminas-mail": "^2.16",
+                "laminas/laminas-mime": "^2.9",
+                "laminas/laminas-oauth": "^2.6",
+                "laminas/laminas-permissions-acl": "^2.10",
+                "laminas/laminas-stdlib": "^3.11",
+                "laminas/laminas-uri": "^2.9",
+                "laminas/laminas-validator": "^2.23",
+                "lib-libxml": "*",
+                "magento/composer-dependency-version-audit-plugin": "^0.1",
+                "magento/zend-cache": "^1.16",
+                "magento/zend-db": "^1.16",
+                "magento/zend-pdf": "^1.16",
+                "monolog/monolog": "^2.7",
+                "php": "~8.1.0||~8.2.0||~8.3.0",
+                "psr/log": "^2 || ^3",
+                "ramsey/uuid": "^4.2",
+                "symfony/console": "^6.4",
+                "symfony/intl": "^6.4",
+                "symfony/process": "^6.4",
+                "tedivm/jshrink": "^1.4",
+                "webonyx/graphql-php": "^15.0",
+                "wikimedia/less.php": "^3.2"
+            },
+            "suggest": {
+                "ext-imagick": "Use Image Magick >=3.0.0 as an optional alternative image processing library"
+            },
+            "type": "magento2-library",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Framework\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/framework-amqp",
+            "version": "100.4.5-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/framework-amqp/magento-framework-amqp-100.4.5.0-patch8.zip",
+                "shasum": "8503c38aadd5c3c0e41faf00dff976014f322094"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0",
+                "php-amqplib/php-amqplib": "~3.2.0"
+            },
+            "type": "magento2-library",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Framework\\Amqp\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/framework-bulk",
+            "version": "101.0.3",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/framework-bulk/magento-framework-bulk-101.0.3.0.zip",
+                "shasum": "f50334fb3ef6e72ba5a85be1db44bb0a269e6bc6"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-library",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Framework\\Bulk\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/framework-message-queue",
+            "version": "100.4.7-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/framework-message-queue/magento-framework-message-queue-100.4.7.0-patch8.zip",
+                "shasum": "c614871243f86ee33ebcc9d14575a8eb8d71c9b1"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-library",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Framework\\MessageQueue\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-asynchronous-operations",
+            "version": "100.4.7-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-asynchronous-operations/magento-module-asynchronous-operations-100.4.7.0-patch8.zip",
+                "shasum": "c7dcda142c912c0a41d4d96fff860a9abfc6684b"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/framework-bulk": "101.0.*",
+                "magento/framework-message-queue": "100.4.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-admin-notification": "100.4.*",
+                "magento/module-logging": "*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\AsynchronousOperations\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-authorization",
+            "version": "100.4.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-authorization/magento-module-authorization-100.4.7.0.zip",
+                "shasum": "7664117a2d2949071391b6402aad9d4d2251fe7a"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Authorization\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "Authorization module provides access to Magento ACL functionality."
+        },
+        {
+            "name": "magento/module-aws-s3",
+            "version": "100.4.5",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-aws-s3/magento-module-aws-s3-100.4.5.0.zip",
+                "shasum": "6b86030cb90b1244796cc51aa18d5cdbb50a5244"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-remote-storage": "100.4.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\AwsS3\\": ""
+                }
+            },
+            "license": [
+                "proprietary"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-backend",
+            "version": "102.0.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-backend/magento-module-backend-102.0.7.0-patch10.zip",
+                "shasum": "f572c28dcd9a800198e4622a92c6fdfc97a14e3b"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backup": "100.4.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-developer": "100.4.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-reports": "100.4.*",
+                "magento/module-require-js": "100.4.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-security": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-translation": "100.4.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-user": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-theme": "101.1.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php",
+                    "cli_commands.php"
+                ],
+                "psr-4": {
+                    "Magento\\Backend\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-backup",
+            "version": "100.4.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-backup/magento-module-backup-100.4.7.0.zip",
+                "shasum": "7fccb02649feb173fc64841c3ba512134db0a200"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-cron": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Backup\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-bundle",
+            "version": "101.0.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-bundle/magento-module-bundle-101.0.7.0-patch10.zip",
+                "shasum": "01c4ec762901db3ec4feb74e427f9aefa908023c"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-catalog-rule": "101.2.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-gift-message": "100.4.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-bundle-sample-data": "Sample Data version: 100.4.*",
+                "magento/module-sales-rule": "101.2.*",
+                "magento/module-webapi": "100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Bundle\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-captcha",
+            "version": "100.4.7-p5",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-captcha/magento-module-captcha-100.4.7.0-patch5.zip",
+                "shasum": "d312529fb94a65f342b7937ce78a17f8bc41df6e"
+            },
+            "require": {
+                "laminas/laminas-captcha": "^2.12",
+                "laminas/laminas-db": "^2.19",
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Captcha\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-catalog",
+            "version": "104.0.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-catalog/magento-module-catalog-104.0.7.0-patch10.zip",
+                "shasum": "2a85d76ce572a17fa3356363d12fafb39b7a093a"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/framework-bulk": "101.0.*",
+                "magento/module-asynchronous-operations": "100.4.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-aws-s3": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-catalog-rule": "101.2.*",
+                "magento/module-catalog-url-rewrite": "100.4.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-indexer": "100.4.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-msrp": "100.4.*",
+                "magento/module-page-cache": "100.4.*",
+                "magento/module-product-alert": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-url-rewrite": "102.0.*",
+                "magento/module-widget": "101.2.*",
+                "magento/module-wishlist": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-catalog-sample-data": "Sample Data version: 100.4.*",
+                "magento/module-cookie": "100.4.*",
+                "magento/module-sales": "103.0.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Catalog\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-catalog-import-export",
+            "version": "101.1.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-catalog-import-export/magento-module-catalog-import-export-101.1.7.0-patch10.zip",
+                "shasum": "5104ca396165f3edc65accfa665ebb3f6ea7a817"
+            },
+            "require": {
+                "ext-ctype": "*",
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-aws-s3": "100.4.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-catalog-url-rewrite": "100.4.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-downloadable": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-import-export": "101.0.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\CatalogImportExport\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-catalog-inventory",
+            "version": "100.4.7-p5",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-catalog-inventory/magento-module-catalog-inventory-100.4.7.0-patch5.zip",
+                "shasum": "aefa2c471b5c7fe6e6f767b5182fe4dbc85640ee"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\CatalogInventory\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-catalog-rule",
+            "version": "101.2.7-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-catalog-rule/magento-module-catalog-rule-101.2.7.0-patch8.zip",
+                "shasum": "4e5d862bec98f27b4e935ff38006ae1355822282"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-rule": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-catalog-rule-sample-data": "Sample Data version: 100.4.*",
+                "magento/module-import-export": "101.0.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\CatalogRule\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-catalog-url-rewrite",
+            "version": "100.4.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-catalog-url-rewrite/magento-module-catalog-url-rewrite-100.4.7.0.zip",
+                "shasum": "a184b1209dda87d71d3c3e8d0798d18aa40a4bf8"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-import-export": "101.1.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-import-export": "101.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-url-rewrite": "102.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-webapi": "100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\CatalogUrlRewrite\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-checkout",
+            "version": "100.4.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-checkout/magento-module-checkout-100.4.7.0-patch10.zip",
+                "shasum": "ba32803bd13bfb8abe20946858dc55119f82218f"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-captcha": "100.4.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-csp": "100.4.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-msrp": "100.4.*",
+                "magento/module-page-cache": "100.4.*",
+                "magento/module-payment": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-sales-rule": "101.2.*",
+                "magento/module-security": "100.4.*",
+                "magento/module-shipping": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-cookie": "100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Checkout\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-cms",
+            "version": "104.0.7-p9",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-cms/magento-module-cms-104.0.7.0-patch9.zip",
+                "shasum": "dc9b1c0cb06f1fca1ef8b63c2d34309208d6d4b8"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-email": "101.1.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-variable": "100.4.*",
+                "magento/module-widget": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-cms-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Cms\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-cms-url-rewrite",
+            "version": "100.4.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-cms-url-rewrite/magento-module-cms-url-rewrite-100.4.6.0.zip",
+                "shasum": "4ab1a22d3429c93a5963fdb2bcf4b49868db2793"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-url-rewrite": "102.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\CmsUrlRewrite\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-config",
+            "version": "101.2.7-p5",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-config/magento-module-config-101.2.7.0-patch5.zip",
+                "shasum": "51e73777eaf619a859d9d10931c5a4b69aa220a5"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-cron": "100.4.*",
+                "magento/module-deploy": "100.4.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-email": "101.1.*",
+                "magento/module-encryption-key": "100.4.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Config\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-contact",
+            "version": "100.4.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-contact/magento-module-contact-100.4.6.0.zip",
+                "shasum": "d00dd1689b897b65fef2823cd821ea7548b1976d"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Contact\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-cron",
+            "version": "100.4.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-cron/magento-module-cron-100.4.7.0.zip",
+                "shasum": "da3a0cb5c3161aa4e3fc77a1d5b4b20a441a4af9"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-config": "101.2.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Cron\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-csp",
+            "version": "100.4.6-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-csp/magento-module-csp-100.4.6.0-patch8.zip",
+                "shasum": "f1be4b3cd04cdf611ae154fba7eb2853302dab4b"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-deploy": "100.4.*",
+                "magento/module-require-js": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Csp\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "CSP module enables Content Security Policies for Magento"
+        },
+        {
+            "name": "magento/module-customer",
+            "version": "103.0.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-customer/magento-module-customer-103.0.7.0-patch10.zip",
+                "shasum": "24e0260baf2dafdd49506711e2ee87a6156533cc"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-integration": "100.4.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-newsletter": "100.4.*",
+                "magento/module-page-cache": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-wishlist": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-asynchronous-operations": "100.4.*",
+                "magento/module-cookie": "100.4.*",
+                "magento/module-customer-sample-data": "Sample Data version: 100.4.*",
+                "magento/module-webapi": "100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Customer\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-deploy",
+            "version": "100.4.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-deploy/magento-module-deploy-100.4.7.0.zip",
+                "shasum": "78d5924a55a58a320f106ba8cf0d97b4ac00af44"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-require-js": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-user": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "cli_commands.php",
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Deploy\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-developer",
+            "version": "100.4.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-developer/magento-module-developer-100.4.7.0.zip",
+                "shasum": "b3e7a74e1d0929b4b1b33ea715d31d7aac2d891b"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Developer\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-directory",
+            "version": "100.4.7-p4",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-directory/magento-module-directory-100.4.7.0-patch4.zip",
+                "shasum": "8db844be54e71521742fb2ae2511498e83f7c547"
+            },
+            "require": {
+                "lib-libxml": "*",
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Directory\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-downloadable",
+            "version": "100.4.7-p7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-downloadable/magento-module-downloadable-100.4.7.0-patch7.zip",
+                "shasum": "01da6699cb17fefed417ac53543fbd89389c8dd0"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-gift-message": "100.4.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-downloadable-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Downloadable\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-eav",
+            "version": "102.1.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-eav/magento-module-eav-102.1.7.0.zip",
+                "shasum": "2b4cafbe9a1bd303f95208f303792a9e3344fd10"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Eav\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-email",
+            "version": "101.1.7-p9",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-email/magento-module-email-101.1.7.0-patch9.zip",
+                "shasum": "702e179f2e9c2112ed1258c0d5838d874499d526"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-require-js": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-variable": "100.4.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-theme": "101.1.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Email\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-encryption-key",
+            "version": "100.4.5-p4",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-encryption-key/magento-module-encryption-key-100.4.5.0-patch4.zip",
+                "shasum": "c5db3b1a8090383b30592582e2dd49704b3a19e3"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-config": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\EncryptionKey\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-gift-message",
+            "version": "100.4.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-gift-message/magento-module-gift-message-100.4.6.0.zip",
+                "shasum": "27098f7ad1071183049acc2d8560fb5c12ea3b32"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-eav": "102.1.*",
+                "magento/module-multishipping": "100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\GiftMessage\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-import-export",
+            "version": "101.0.7-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-import-export/magento-module-import-export-101.0.7.0-patch8.zip",
+                "shasum": "ae32b89d9797463138897a62dee73cecaecfed21"
+            },
+            "require": {
+                "ext-ctype": "*",
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\ImportExport\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-indexer",
+            "version": "100.4.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-indexer/magento-module-indexer-100.4.7.0.zip",
+                "shasum": "5ba18a0e76f51c95e6d4a1eeb998789cc74b06db"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/framework-amqp": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-customer": "103.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Indexer\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-integration",
+            "version": "100.4.7-p2",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-integration/magento-module-integration-100.4.7.0-patch2.zip",
+                "shasum": "24f3e80ad5ead6f2e719e06ed9f7eb80989b28ad"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-security": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-user": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Integration\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-media-storage",
+            "version": "100.4.6-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-media-storage/magento-module-media-storage-100.4.6.0-patch8.zip",
+                "shasum": "ccf2d1aa53b2b21eb309b255bce4d89806351252"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/framework-bulk": "101.0.*",
+                "magento/module-asynchronous-operations": "100.4.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-theme": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\MediaStorage\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-msrp",
+            "version": "100.4.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-msrp/magento-module-msrp-100.4.6.0.zip",
+                "shasum": "5c08a65a5c3d26f914326c4ccbb65226fa6c5ea7"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-downloadable": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-bundle": "101.0.*",
+                "magento/module-msrp-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Msrp\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-newsletter",
+            "version": "100.4.7-p9",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-newsletter/magento-module-newsletter-100.4.7.0-patch9.zip",
+                "shasum": "cf110b8c1bc0bee5f9a305bc380e7af35f64fe1f"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-email": "101.1.*",
+                "magento/module-require-js": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-widget": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Newsletter\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-page-cache",
+            "version": "100.4.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-page-cache/magento-module-page-cache-100.4.7.0.zip",
+                "shasum": "35149c1ba6e9511c203d0697cfc1af89203cd173"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\PageCache\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-payment",
+            "version": "100.4.7",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-payment/magento-module-payment-100.4.7.0.zip",
+                "shasum": "f242e4d51677f47de207c345e148ccd4c06439c4"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Payment\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-product-alert",
+            "version": "100.4.6-p9",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-product-alert/magento-module-product-alert-100.4.6.0-patch9.zip",
+                "shasum": "1f53dd1f9f6f65f80d4b8f56af13afdbcfe26cdf"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/framework-bulk": "101.0.*",
+                "magento/module-asynchronous-operations": "100.4.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-theme": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-config": "101.2.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\ProductAlert\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-quote",
+            "version": "101.2.7-p9",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-quote/magento-module-quote-101.2.7.0-patch9.zip",
+                "shasum": "d9594789d9adcad340936e2fa3f220367f97e8e0"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-payment": "100.4.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-sales-sequence": "100.4.*",
+                "magento/module-shipping": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-webapi": "100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Quote\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-remote-storage",
+            "version": "100.4.5",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-remote-storage/magento-module-remote-storage-100.4.5.0.zip",
+                "shasum": "dae65c973aa0d0966a80069876ca22f217005f02"
+            },
+            "require": {
+                "league/flysystem": "^2.4",
+                "league/flysystem-aws-s3-v3": "^2.4",
+                "magento/framework": "103.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-import-export": "101.1.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-downloadable": "100.4.*",
+                "magento/module-downloadable-import-export": "100.4.*",
+                "magento/module-import-export": "101.0.*",
+                "magento/module-media-gallery-metadata": "100.4.*",
+                "magento/module-media-gallery-synchronization": "100.4.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-sitemap": "100.4.*",
+                "predis/predis": "*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\RemoteStorage\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-reports",
+            "version": "100.4.7-p9",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-reports/magento-module-reports-100.4.7.0-patch9.zip",
+                "shasum": "0dc76ddfb3e0268302e306623c0208f1d3c8907f"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-downloadable": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-review": "100.4.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-sales-rule": "101.2.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "magento/module-widget": "101.2.*",
+                "magento/module-wishlist": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Reports\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-require-js",
+            "version": "100.4.3",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-require-js/magento-module-require-js-100.4.3.0.zip",
+                "shasum": "28a2e7b1c42b097ce48d47d06943fa070e58861b"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\RequireJs\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-review",
+            "version": "100.4.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-review/magento-module-review-100.4.7.0-patch10.zip",
+                "shasum": "bb2ed7ce3bc9c6a6ac0a96ad71cc8b4ed2e6163c"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-newsletter": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-cookie": "100.4.*",
+                "magento/module-review-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Review\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-rss",
+            "version": "100.4.5",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-rss/magento-module-rss-100.4.5.0.zip",
+                "shasum": "07cd33c74ded5583b5a9c57a9ba58d7c9aed4de1"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Rss\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-rule",
+            "version": "100.4.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-rule/magento-module-rule-100.4.6.0.zip",
+                "shasum": "5f1a8aa08243925ec2029fe6ff800dbc57c34786"
+            },
+            "require": {
+                "lib-libxml": "*",
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Rule\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-sales",
+            "version": "103.0.7-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-sales/magento-module-sales-103.0.7.0-patch8.zip",
+                "shasum": "4c5c80b26e6887446929b3f414ed8014831c6ed4"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-bundle": "101.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-encryption-key": "100.4.*",
+                "magento/module-gift-message": "100.4.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-payment": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-reports": "100.4.*",
+                "magento/module-sales-rule": "101.2.*",
+                "magento/module-sales-sequence": "100.4.*",
+                "magento/module-shipping": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-widget": "101.2.*",
+                "magento/module-wishlist": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-sales-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Sales\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-sales-rule",
+            "version": "101.2.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-sales-rule/magento-module-sales-rule-101.2.7.0-patch10.zip",
+                "shasum": "091cd57f41bef36159aa4189b1276022007fd907"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/framework-bulk": "101.0.*",
+                "magento/module-asynchronous-operations": "100.4.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-captcha": "100.4.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-rule": "101.2.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-payment": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-reports": "100.4.*",
+                "magento/module-rule": "100.4.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-shipping": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-widget": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-sales-rule-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\SalesRule\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-sales-sequence",
+            "version": "100.4.4",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-sales-sequence/magento-module-sales-sequence-100.4.4.0.zip",
+                "shasum": "19993cdfd44d129bb946a3088f79d2958767a067"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\SalesSequence\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-security",
+            "version": "100.4.7-p9",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-security/magento-module-security-100.4.7.0-patch9.zip",
+                "shasum": "6c87ade68d59f313b7aeef3508406f3f10c7c810"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-user": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-customer": "103.0.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Security\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "Security management module"
+        },
+        {
+            "name": "magento/module-shipping",
+            "version": "100.4.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-shipping/magento-module-shipping-100.4.7.0-patch10.zip",
+                "shasum": "7d147d76c74ff1a894e75ca5373fd6667135cebd"
+            },
+            "require": {
+                "ext-gd": "*",
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-contact": "100.4.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-payment": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-user": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-config": "101.2.*",
+                "magento/module-fedex": "100.4.*",
+                "magento/module-ups": "100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Shipping\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-store",
+            "version": "101.1.7-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-store/magento-module-store-101.1.7.0-patch8.zip",
+                "shasum": "e9cc571366189406e204af9b3d09f61b011af838"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-deploy": "100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Store\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-tax",
+            "version": "100.4.7-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-tax/magento-module-tax-100.4.7.0-patch8.zip",
+                "shasum": "b4143078bf538ff8ca763f10da25f76d8749276e"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-page-cache": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-reports": "100.4.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-shipping": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-tax-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Tax\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-theme",
+            "version": "101.1.7-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-theme/magento-module-theme-101.1.7.0-patch8.zip",
+                "shasum": "614bfa9f007dee63b9880bb0d6cd47004dec0fdd"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-require-js": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-widget": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-deploy": "100.4.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-theme-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Theme\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-translation",
+            "version": "100.4.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-translation/magento-module-translation-100.4.7.0-patch10.zip",
+                "shasum": "fa021290e2ebd872b772bef9947e10bb328fbea0"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-deploy": "100.4.*",
+                "magento/module-developer": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-theme": "101.1.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-deploy": "100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Translation\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-ui",
+            "version": "101.2.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-ui/magento-module-ui-101.2.7.0-patch10.zip",
+                "shasum": "0d0a40569aaa0b266ea7f7513a7a04644a28fd6a"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-user": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-config": "101.2.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Ui\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-url-rewrite",
+            "version": "102.0.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-url-rewrite/magento-module-url-rewrite-102.0.6.0.zip",
+                "shasum": "1a67f8aab1f2d9549c9b9eb24c9ef7ce959aaaa4"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-url-rewrite": "100.4.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-cms-url-rewrite": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\UrlRewrite\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-user",
+            "version": "101.2.7-p8",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-user/magento-module-user-101.2.7.0-patch8.zip",
+                "shasum": "a0f4b44907f8c4c7cd0adb3ddb1508cb68bc2118"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-authorization": "100.4.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-email": "101.1.*",
+                "magento/module-integration": "100.4.*",
+                "magento/module-security": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\User\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-variable",
+            "version": "100.4.5",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-variable/magento-module-variable-100.4.5.0.zip",
+                "shasum": "8c308edb6caeaf9edd499841af8ffb5dfb34c4f5"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Variable\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-widget",
+            "version": "101.2.7-p10",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-widget/magento-module-widget-101.2.7.0-patch10.zip",
+                "shasum": "2823e5ce4d82c88b3d19350919c5acdad9254371"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-email": "101.1.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-variable": "100.4.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-widget-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Widget\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-wishlist",
+            "version": "101.2.7-p3",
+            "dist": {
+                "type": "zip",
+                "url": "https://repo.magento.com/archives/magento/module-wishlist/magento-module-wishlist-101.2.7.0-patch3.zip",
+                "shasum": "cc1e2a380e6e4ba0c5d26a9108b84f99b00aa983"
+            },
+            "require": {
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-captcha": "100.4.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-checkout": "100.4.*",
+                "magento/module-customer": "103.0.*",
+                "magento/module-rss": "100.4.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "php": "~8.1.0||~8.2.0||~8.3.0"
+            },
+            "suggest": {
+                "magento/module-bundle": "101.0.*",
+                "magento/module-configurable-product": "100.4.*",
+                "magento/module-cookie": "100.4.*",
+                "magento/module-downloadable": "100.4.*",
+                "magento/module-grouped-product": "100.4.*",
+                "magento/module-wishlist-sample-data": "Sample Data version: 100.4.*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\Wishlist\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/zend-cache",
+            "version": "1.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/magento-zend-cache.git",
+                "reference": "815ef459560be6a3f0907016d8fc40f111f34209"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/magento/magento-zend-cache/zipball/815ef459560be6a3f0907016d8fc40f111f34209",
+                "reference": "815ef459560be6a3f0907016d8fc40f111f34209",
+                "shasum": ""
+            },
+            "require": {
+                "magento/zend-exception": "^1.16",
+                "magento/zend-log": "^1.16",
+                "php": ">=7.0.0"
+            },
+            "replace": {
+                "zf1/zend-cache": "^1.12",
+                "zfs1/zend-cache": "^1.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Zend_Cache": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework 1 Cache package",
+            "homepage": "http://framework.zend.com/",
+            "keywords": [
+                "ZF1",
+                "cache",
+                "framework",
+                "zend"
+            ],
+            "support": {
+                "issues": "https://github.com/magento/magento-zend-cache/issues",
+                "source": "https://github.com/magento/magento-zend-cache/tree/1.16.1"
+            },
+            "time": "2024-12-18T14:42:52+00:00"
+        },
+        {
+            "name": "magento/zend-db",
+            "version": "1.16.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/magento-zend-db.git",
+                "reference": "aefb2019b0eb8423ee05c9e4008360e8dd0497f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/magento/magento-zend-db/zipball/aefb2019b0eb8423ee05c9e4008360e8dd0497f9",
+                "reference": "aefb2019b0eb8423ee05c9e4008360e8dd0497f9",
+                "shasum": ""
+            },
+            "require": {
+                "magento/zend-exception": "^1.16",
+                "magento/zend-loader": "^1.16",
+                "php": ">=7.0.0"
+            },
+            "replace": {
+                "zf1/zend-db": "^1.12",
+                "zfs1/zend-db": "^1.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Zend_Db": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework 1 Db package",
+            "homepage": "http://framework.zend.com/",
+            "keywords": [
+                "ZF1",
+                "db",
+                "framework",
+                "zend"
+            ],
+            "support": {
+                "issues": "https://github.com/magento/magento-zend-db/issues",
+                "source": "https://github.com/magento/magento-zend-db/tree/1.16.3"
+            },
+            "time": "2025-12-22T11:59:33+00:00"
+        },
+        {
+            "name": "magento/zend-exception",
+            "version": "1.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/magento-zend-exception.git",
+                "reference": "2aa533f83aebc3963df099da27427fda7d32585e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/magento/magento-zend-exception/zipball/2aa533f83aebc3963df099da27427fda7d32585e",
+                "reference": "2aa533f83aebc3963df099da27427fda7d32585e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "replace": {
+                "zf1/zend-exception": "^1.12",
+                "zfs1/zend-exception": "^1.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Zend_Exception": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework 1 Exception package",
+            "homepage": "http://framework.zend.com/",
+            "keywords": [
+                "ZF1",
+                "exception",
+                "framework",
+                "zend"
+            ],
+            "support": {
+                "issues": "https://github.com/magento/magento-zend-exception/issues",
+                "source": "https://github.com/magento/magento-zend-exception/tree/1.16.1"
+            },
+            "time": "2024-12-18T10:09:19+00:00"
+        },
+        {
+            "name": "magento/zend-loader",
+            "version": "1.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/magento-zend-loader.git",
+                "reference": "7eca22970a6b7cdaa3d3a6a6d117e4c0d3bef5e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/magento/magento-zend-loader/zipball/7eca22970a6b7cdaa3d3a6a6d117e4c0d3bef5e9",
+                "reference": "7eca22970a6b7cdaa3d3a6a6d117e4c0d3bef5e9",
+                "shasum": ""
+            },
+            "require": {
+                "magento/zend-exception": "^1.16.0",
+                "php": ">=7.0.0"
+            },
+            "replace": {
+                "zf1/zend-loader": "^1.12",
+                "zf1s/zend-loader": "^1.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Zend_Loader": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework 1 Loader package",
+            "homepage": "http://framework.zend.com/",
+            "keywords": [
+                "ZF1",
+                "framework",
+                "loader",
+                "zend"
+            ],
+            "support": {
+                "issues": "https://github.com/magento/magento-zend-loader/issues",
+                "source": "https://github.com/magento/magento-zend-loader/tree/1.16.1"
+            },
+            "time": "2023-08-25T13:52:37+00:00"
+        },
+        {
+            "name": "magento/zend-log",
+            "version": "1.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/magento-zend-log.git",
+                "reference": "4069130d58e1aaf8f3a0a2593a05083b5c2a85f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/magento/magento-zend-log/zipball/4069130d58e1aaf8f3a0a2593a05083b5c2a85f8",
+                "reference": "4069130d58e1aaf8f3a0a2593a05083b5c2a85f8",
+                "shasum": ""
+            },
+            "require": {
+                "magento/zend-exception": "^1.16",
+                "php": ">=7.0.0"
+            },
+            "replace": {
+                "zf1/zend-log": "^1.12",
+                "zfs1/zend-log": "^1.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Zend_Log": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework 1 Log package",
+            "homepage": "http://framework.zend.com/",
+            "keywords": [
+                "ZF1",
+                "framework",
+                "log",
+                "zend"
+            ],
+            "support": {
+                "issues": "https://github.com/magento/magento-zend-log/issues",
+                "source": "https://github.com/magento/magento-zend-log/tree/1.16.1"
+            },
+            "time": "2024-12-18T11:34:38+00:00"
+        },
+        {
+            "name": "magento/zend-memory",
+            "version": "1.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/magento-zend-memory.git",
+                "reference": "781e666c33223589552ab78c43c3a93c6bf0ddff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/magento/magento-zend-memory/zipball/781e666c33223589552ab78c43c3a93c6bf0ddff",
+                "reference": "781e666c33223589552ab78c43c3a93c6bf0ddff",
+                "shasum": ""
+            },
+            "require": {
+                "magento/zend-cache": "^1.16",
+                "magento/zend-exception": "^1.16",
+                "php": ">=7.0.0"
+            },
+            "replace": {
+                "zf1/zend-memory": "^1.12",
+                "zfs1/zend-memory": "^1.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Zend_Memory": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework 1 Memory package",
+            "homepage": "http://framework.zend.com/",
+            "keywords": [
+                "ZF1",
+                "framework",
+                "memory",
+                "zend"
+            ],
+            "support": {
+                "issues": "https://github.com/magento/magento-zend-memory/issues",
+                "source": "https://github.com/magento/magento-zend-memory/tree/1.16.1"
+            },
+            "time": "2025-12-11T10:34:55+00:00"
+        },
+        {
+            "name": "magento/zend-pdf",
+            "version": "1.16.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/magento-zend-pdf.git",
+                "reference": "26a51f45b09be173447f5957254311bdda5c4a8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/magento/magento-zend-pdf/zipball/26a51f45b09be173447f5957254311bdda5c4a8a",
+                "reference": "26a51f45b09be173447f5957254311bdda5c4a8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-gd": "*",
+                "ext-iconv": "*",
+                "ext-zlib": "*",
+                "magento/zend-exception": "^1.16",
+                "magento/zend-log": "^1.16",
+                "magento/zend-memory": "^1.16",
+                "php": ">=7.0.0"
+            },
+            "replace": {
+                "zf1/zend-pdf": "^1.12",
+                "zfs1/zend-pdf": "^1.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Zend_Pdf": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework 1 Pdf package",
+            "homepage": "http://framework.zend.com/",
+            "keywords": [
+                "ZF1",
+                "framework",
+                "pdf",
+                "zend"
+            ],
+            "support": {
+                "issues": "https://github.com/magento/magento-zend-pdf/issues",
+                "source": "https://github.com/magento/magento-zend-pdf/tree/1.16.6"
+            },
+            "time": "2025-12-11T10:52:59+00:00"
+        },
+        {
+            "name": "marc-mabe/php-enum",
+            "version": "v4.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "bb426fcdd65c60fb3638ef741e8782508fda7eef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/bb426fcdd65c60fb3638ef741e8782508fda7eef",
+                "reference": "bb426fcdd65c60fb3638ef741e8782508fda7eef",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": "^7.1 | ^8.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.16.10 || ^1.0.4",
+                "phpstan/phpstan": "^1.3.1",
+                "phpunit/phpunit": "^7.5.20 | ^8.5.22 | ^9.5.11",
+                "vimeo/psalm": "^4.17.0 | ^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.2-dev",
+                    "dev-master": "4.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "https://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enumerator",
+                "enummap",
+                "enumset",
+                "map",
+                "set",
+                "type",
+                "type-hint",
+                "typehint"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum/issues",
+                "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.2"
+            },
+            "time": "2025-09-14T11:18:39+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "37308608e599f34a1a4845b16440047ec98a172a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/37308608e599f34a1a4845b16440047ec98a172a",
+                "reference": "37308608e599f34a1a4845b16440047ec98a172a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2@dev",
+                "guzzlehttp/guzzle": "^7.4",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8 || ^2.0",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpspec/prophecy": "^1.15",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.5.38 || ^9.6.19",
+                "predis/predis": "^1.1 || ^2.0",
+                "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                "ruflin/elastica": "^7",
+                "swiftmailer/swiftmailer": "^5.3|^6.0",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/2.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-01T13:05:00+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.33"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+            },
+            "time": "2024-09-04T18:46:31+00:00"
+        },
+        {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8"
+            },
+            "require-dev": {
+                "infection/infection": "^0",
+                "nikic/php-fuzzer": "^0",
+                "phpunit/phpunit": "^9|^10|^11",
+                "vimeo/psalm": "^4|^5|^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2025-09-24T15:06:41+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "php-amqplib/php-amqplib",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-amqplib/php-amqplib.git",
+                "reference": "0bec5b392428e0ac3b3f34fbc4e02d706995833e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/0bec5b392428e0ac3b3f34fbc4e02d706995833e",
+                "reference": "0bec5b392428e0ac3b3f34fbc4e02d706995833e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-sockets": "*",
+                "php": "^7.1||^8.0",
+                "phpseclib/phpseclib": "^2.0|^3.0"
+            },
+            "conflict": {
+                "php": "7.4.0 - 7.4.1"
+            },
+            "replace": {
+                "videlalvaro/php-amqplib": "self.version"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "nategood/httpful": "^0.2.20",
+                "phpunit/phpunit": "^7.5|^9.5",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpAmqpLib\\": "PhpAmqpLib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alvaro Videla",
+                    "role": "Original Maintainer"
+                },
+                {
+                    "name": "Raúl Araya",
+                    "email": "nubeiro@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Luke Bakken",
+                    "email": "luke@bakken.io",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Ramūnas Dronga",
+                    "email": "github@ramuno.lt",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Formerly videlalvaro/php-amqplib.  This library is a pure PHP implementation of the AMQP protocol. It's been tested against RabbitMQ.",
+            "homepage": "https://github.com/php-amqplib/php-amqplib/",
+            "keywords": [
+                "message",
+                "queue",
+                "rabbitmq"
+            ],
+            "support": {
+                "issues": "https://github.com/php-amqplib/php-amqplib/issues",
+                "source": "https://github.com/php-amqplib/php-amqplib/tree/v3.2.0"
+            },
+            "time": "2022-03-10T19:16:00+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "3.0.52",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1|^2|^3",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "ext-dom": "Install the DOM extension to load XML formatted public keys.",
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib3\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-27T07:02:15+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
+            },
+            "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -337,110 +6807,8 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2018-07-08T19:23:20+00:00"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "time": "2018-07-08T19:19:57+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
+                    "Psr\\Http\\Client\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -449,95 +6817,532 @@
             ],
             "authors": [
                 {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
             "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
             ],
-            "time": "2018-08-07T13:53:10+00:00"
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "5.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-filter": "^7.1",
-                "php": "^7.2",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpdocumentor/type-resolver": "^1.0",
-                "webmozart/assert": "^1"
-            },
-            "require-dev": {
-                "doctrine/instantiator": "^1",
-                "mockery/mockery": "^1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-02-22T12:28:44+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
+            "name": "psr/http-factory",
             "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
-                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2",
-                "phpdocumentor/reflection-common": "^2.0"
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
             },
             "require-dev": {
-                "ext-tokenizer": "^7.2",
-                "mockery/mockery": "~1"
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "ramsey/collection",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/collection.git",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "captainhook/plugin-composer": "^5.3",
+                "ergebnis/composer-normalize": "^2.45",
+                "fakerphp/faker": "^1.24",
+                "hamcrest/hamcrest-php": "^2.0",
+                "jangregor/phpstan-prophecy": "^2.1",
+                "mockery/mockery": "^1.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpspec/prophecy-phpunit": "^2.3",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "ramsey/coding-standard": "^2.3",
+                "ramsey/conventional-commits": "^1.6",
+                "roave/security-advisories": "dev-latest"
+            },
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "force-install": true
+                },
+                "ramsey/conventional-commits": {
+                    "configFile": "conventional-commits.json"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Collection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "A PHP library for representing and manipulating collections.",
+            "keywords": [
+                "array",
+                "collection",
+                "hash",
+                "map",
+                "queue",
+                "set"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/collection/issues",
+                "source": "https://github.com/ramsey/collection/tree/2.1.1"
+            },
+            "time": "2025-03-22T05:38:12+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "4.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "8429c78ca35a09f27565311b98101e2826affde0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8429c78ca35a09f27565311b98101e2826affde0",
+                "reference": "8429c78ca35a09f27565311b98101e2826affde0",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.8.16 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
+                "php": "^8.0",
+                "ramsey/collection": "^1.2 || ^2.0"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "captainhook/captainhook": "^5.25",
+                "captainhook/plugin-composer": "^5.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "ergebnis/composer-normalize": "^2.47",
+                "mockery/mockery": "^1.6",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock": "^2.6",
+                "php-mock/php-mock-mockery": "^1.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpbench/phpbench": "^1.2.14",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "slevomat/coding-standard": "^8.18",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "suggest": {
+                "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
+                "ext-gmp": "Enables faster math with arbitrary-precision integers using GMP.",
+                "ext-uuid": "Enables the use of PeclUuidTimeGenerator and PeclUuidRandomGenerator.",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "force-install": true
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/uuid/issues",
+                "source": "https://github.com/ramsey/uuid/tree/4.9.2"
+            },
+            "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-11T14:55:45+00:00"
+        },
+        {
+            "name": "seld/phar-utils",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/phar-utils.git",
+                "reference": "ea2f4014f163c1be4c601b9b7bd6af81ba8d701c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/ea2f4014f163c1be4c601b9b7bd6af81ba8d701c",
+                "reference": "ea2f4014f163c1be4c601b9b7bd6af81ba8d701c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
             },
             "type": "library",
             "extra": {
@@ -547,7 +7352,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
+                    "Seld\\PharUtils\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -556,47 +7361,54 @@
             ],
             "authors": [
                 {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
                 }
             ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-02-18T18:59:58+00:00"
+            "description": "PHAR file format utilities, for when PHP phars you up",
+            "keywords": [
+                "phar"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/phar-utils/issues",
+                "source": "https://github.com/Seldaek/phar-utils/tree/1.2.1"
+            },
+            "time": "2022-08-31T10:31:18+00:00"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.10.3",
+            "name": "seld/signal-handler",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+                "url": "https://github.com/Seldaek/signal-handler.git",
+                "reference": "04a6112e883ad76c0ada8e4a9f7520bbfdb6bb98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "url": "https://api.github.com/repos/Seldaek/signal-handler/zipball/04a6112e883ad76c0ada8e4a9f7520bbfdb6bb98",
+                "reference": "04a6112e883ad76c0ada8e4a9f7520bbfdb6bb98",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+                "php": ">=7.2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5 || ^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+                "phpstan/phpstan": "^1",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpstan/phpstan-strict-rules": "^1.3",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23",
+                "psr/log": "^1 || ^2 || ^3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
+                    "Seld\\Signal\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -605,1122 +7417,456 @@
             ],
             "authors": [
                 {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Simple unix signal handler that silently fails where signals are not supported for easy cross-platform development",
+            "keywords": [
+                "posix",
+                "sigint",
+                "signal",
+                "sigterm",
+                "unix"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/signal-handler/issues",
+                "source": "https://github.com/Seldaek/signal-handler/tree/2.0.2"
+            },
+            "time": "2023-09-03T09:24:00+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v6.4.41",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "d21b17ed158e79180fac3895ff751707970eeb57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d21b17ed158e79180fac3895ff751707970eeb57",
+                "reference": "d21b17ed158e79180fac3895ff751707970eeb57",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^5.4|^6.0|^7.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<5.4",
+                "symfony/dotenv": "<5.4",
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/lock": "<5.4",
+                "symfony/process": "<5.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 },
                 {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
             "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
             ],
-            "time": "2020-03-05T15:02:03+00:00"
-        },
-        {
-            "name": "phpunit/php-code-coverage",
-            "version": "8.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a"
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v6.4.41"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/31e94ccc084025d6abee0585df533eb3a792b96a",
-                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.3",
-                "phpunit/php-file-iterator": "^3.0",
-                "phpunit/php-text-template": "^2.0",
-                "phpunit/php-token-stream": "^4.0",
-                "sebastian/code-unit-reverse-lookup": "^2.0",
-                "sebastian/environment": "^5.0",
-                "sebastian/version": "^3.0",
-                "theseer/tokenizer": "^1.1.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "8.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "time": "2020-02-19T13:41:19+00:00"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/354d4a5faa7449a377a18b94a2026ca3415e3d7a",
-                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-            "keywords": [
-                "filesystem",
-                "iterator"
-            ],
-            "time": "2020-02-07T06:05:22+00:00"
-        },
-        {
-            "name": "phpunit/php-invoker",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/7579d5a1ba7f3ac11c80004d205877911315ae7a",
-                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.0"
-            },
-            "suggest": {
-                "ext-pcntl": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Invoke callables with a timeout",
-            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
-            "keywords": [
-                "process"
-            ],
-            "time": "2020-02-07T06:06:11+00:00"
-        },
-        {
-            "name": "phpunit/php-text-template",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
-                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "time": "2020-02-01T07:43:44+00:00"
+            "time": "2026-05-24T08:48:41+00:00"
         },
         {
-            "name": "phpunit/php-timer",
-            "version": "3.1.2",
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "35e732ff964693cb91ef4690f1f6016833b68f9d"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/35e732ff964693cb91ef4690f1f6016833b68f9d",
-                "reference": "35e732ff964693cb91ef4690f1f6016833b68f9d",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "time": "2020-04-17T15:08:36+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/b2560a0c33f7710e4d7f8780964193e8e8f8effe",
-                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "time": "2020-02-07T06:19:00+00:00"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "9.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "848f6521c906500e66229668768576d35de0227e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/848f6521c906500e66229668768576d35de0227e",
-                "reference": "848f6521c906500e66229668768576d35de0227e",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.2.0",
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-libxml": "*",
-                "ext-mbstring": "*",
-                "ext-xml": "*",
-                "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.9.1",
-                "phar-io/manifest": "^1.0.3",
-                "phar-io/version": "^2.0.1",
-                "php": "^7.3",
-                "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^8.0.1",
-                "phpunit/php-file-iterator": "^3.0",
-                "phpunit/php-invoker": "^3.0",
-                "phpunit/php-text-template": "^2.0",
-                "phpunit/php-timer": "^3.0",
-                "sebastian/code-unit": "^1.0",
-                "sebastian/comparator": "^4.0",
-                "sebastian/diff": "^4.0",
-                "sebastian/environment": "^5.0.1",
-                "sebastian/exporter": "^4.0",
-                "sebastian/global-state": "^4.0",
-                "sebastian/object-enumerator": "^4.0",
-                "sebastian/resource-operations": "^3.0",
-                "sebastian/type": "^2.0",
-                "sebastian/version": "^3.0"
-            },
-            "require-dev": {
-                "ext-pdo": "*"
-            },
-            "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
-            },
-            "bin": [
-                "phpunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "9.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
-                    "src/Framework/Assert/Functions.php"
+                    "function.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
-            "time": "2020-04-03T14:40:04+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
-            "name": "sebastian/code-unit",
-            "version": "1.0.0",
+            "name": "symfony/filesystem",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "8d8f09bd47c75159921e6e84fdef146343962866"
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "c507b077756b4e3e09adbbe7975fac81cd3722ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/8d8f09bd47c75159921e6e84fdef146343962866",
-                "reference": "8d8f09bd47c75159921e6e84fdef146343962866",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c507b077756b4e3e09adbbe7975fac81cd3722ca",
+                "reference": "c507b077756b4e3e09adbbe7975fac81cd3722ca",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3"
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "symfony/process": "^5.4|^6.4|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
-                "classmap": [
-                    "src/"
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "time": "2020-03-30T11:59:20+00:00"
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.39"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-07T13:11:42+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.0",
+            "name": "symfony/finder",
+            "version": "v6.4.34",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e"
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "9590e86be1d1c57bfbb16d0dd040345378c20896"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5b5dbe0044085ac41df47e79d34911a15b96d82e",
-                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/9590e86be1d1c57bfbb16d0dd040345378c20896",
+                "reference": "9590e86be1d1c57bfbb16d0dd040345378c20896",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "symfony/filesystem": "^6.0|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
             "autoload": {
-                "classmap": [
-                    "src/"
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2020-02-07T06:20:13+00:00"
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v6.4.34"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-28T15:16:37+00:00"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "4.0.0",
+            "name": "symfony/intl",
+            "version": "v6.4.36",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8"
+                "url": "https://github.com/symfony/intl.git",
+                "reference": "026d246f3d2f6136db43d17b4ccb14b34d8e779a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85b3435da967696ed618ff745f32be3ff4a2b8e8",
-                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/026d246f3d2f6136db43d17b4ccb14b34d8e779a",
+                "reference": "026d246f3d2f6136db43d17b4ccb14b34d8e779a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
             "autoload": {
-                "classmap": [
-                    "src/"
+                "psr-4": {
+                    "Symfony\\Component\\Intl\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/Resources/data/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                }
-            ],
-            "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "https://github.com/sebastianbergmann/comparator",
-            "keywords": [
-                "comparator",
-                "compare",
-                "equality"
-            ],
-            "time": "2020-02-07T06:08:51+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c0c26c9188b538bfa985ae10c9f05d278f12060d",
-                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0",
-                "symfony/process": "^4 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "time": "2020-02-07T06:09:38+00:00"
-        },
-        {
-            "name": "sebastian/environment",
-            "version": "5.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "c753f04d68cd489b6973cf9b4e505e191af3b05c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/c753f04d68cd489b6973cf9b4e505e191af3b05c",
-                "reference": "c753f04d68cd489b6973cf9b4e505e191af3b05c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "suggest": {
-                "ext-posix": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
-            "keywords": [
-                "Xdebug",
-                "environment",
-                "hhvm"
-            ],
-            "time": "2020-04-14T13:36:52+00:00"
-        },
-        {
-            "name": "sebastian/exporter",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "80c26562e964016538f832f305b2286e1ec29566"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/80c26562e964016538f832f305b2286e1ec29566",
-                "reference": "80c26562e964016538f832f305b2286e1ec29566",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3",
-                "sebastian/recursion-context": "^4.0"
-            },
-            "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                },
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
-            "keywords": [
-                "export",
-                "exporter"
-            ],
-            "time": "2020-02-07T06:10:52+00:00"
-        },
-        {
-            "name": "sebastian/global-state",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
-                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "phpunit/phpunit": "^9.0"
-            },
-            "suggest": {
-                "ext-uopz": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
-            "keywords": [
-                "global state"
-            ],
-            "time": "2020-02-07T06:11:37+00:00"
-        },
-        {
-            "name": "sebastian/object-enumerator",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "e67516b175550abad905dc952f43285957ef4363"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67516b175550abad905dc952f43285957ef4363",
-                "reference": "e67516b175550abad905dc952f43285957ef4363",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2020-02-07T06:12:23+00:00"
-        },
-        {
-            "name": "sebastian/object-reflector",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
-                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2020-02-07T06:19:40+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cdd86616411fc3062368b720b0425de10bd3d579"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cdd86616411fc3062368b720b0425de10bd3d579",
-                "reference": "cdd86616411fc3062368b720b0425de10bd3d579",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 },
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
+                    "name": "Eriksen Costa",
+                    "email": "eriksen.costa@infranology.com.br"
                 },
                 {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2020-02-07T06:18:20+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
-                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2020-02-07T06:13:02+00:00"
-        },
-        {
-            "name": "sebastian/type",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/9e8f42f740afdea51f5f4e8cec2035580e797ee1",
-                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
+            "description": "Provides access to the localization data of the ICU library",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "i18n",
+                "icu",
+                "internationalization",
+                "intl",
+                "l10n",
+                "localization"
             ],
-            "authors": [
+            "support": {
+                "source": "https://github.com/symfony/intl/tree/v6.4.36"
+            },
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the types of the PHP type system",
-            "homepage": "https://github.com/sebastianbergmann/type",
-            "time": "2020-02-07T06:13:43+00:00"
-        },
-        {
-            "name": "sebastian/version",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "0411bde656dce64202b39c2f4473993a9081d39e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/0411bde656dce64202b39c2f4473993a9081d39e",
-                "reference": "0411bde656dce64202b39c2f4473993a9081d39e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-            "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2020-01-21T06:36:37+00:00"
+            "time": "2026-03-24T11:36:52+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.15.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
-                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.15-dev"
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1744,44 +7890,713 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-02-27T09:26:54+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v4.4.7",
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "ef166890d821518106da3560086bfcbeb4fadfec"
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ef166890d821518106da3560086bfcbeb4fadfec",
-                "reference": "ef166890d821518106da3560086bfcbeb4fadfec",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "^3.4|^4.0|^5.0"
+                "php": ">=7.2"
             },
             "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-intl": "For best performance"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
                 "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T05:58:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T15:22:23+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:51:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php84",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:51:13+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v6.4.41",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "c8fc09bdfe9fde9aaa89b415a4477feaccec16a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c8fc09bdfe9fde9aaa89b415a4477feaccec16a7",
+                "reference": "c8fc09bdfe9fde9aaa89b415a4477feaccec16a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
                 },
                 "exclude-from-classmap": [
                     "/Tests/"
@@ -1801,35 +8616,234 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Yaml Component",
+            "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
-            "time": "2020-03-30T11:41:10+00:00"
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v6.4.41"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-23T13:47:21+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.1.3",
+            "name": "symfony/service-contracts",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-28T09:44:51+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v6.4.39",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/62e3c927de664edadb5bef260987eb047a17a113",
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^6.2|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
                 ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v6.4.39"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-12T11:44:19+00:00"
+        },
+        {
+            "name": "tedivm/jshrink",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tedious/JShrink.git",
+                "reference": "f76454d4c48ddae6354a2f0eeb16633d4e755c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tedious/JShrink/zipball/f76454d4c48ddae6354a2f0eeb16633d4e755c9a",
+                "reference": "f76454d4c48ddae6354a2f0eeb16633d4e755c9a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "php-coveralls/php-coveralls": "^2.5.0",
+                "phpunit/phpunit": "^9|^10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JShrink": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1837,39 +8851,63 @@
             ],
             "authors": [
                 {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "name": "Robert Hafner",
+                    "email": "tedivm@tedivm.com"
                 }
             ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-06-13T22:48:21+00:00"
+            "description": "Javascript Minifier built in PHP",
+            "homepage": "http://github.com/tedious/JShrink",
+            "keywords": [
+                "javascript",
+                "minifier"
+            ],
+            "support": {
+                "issues": "https://github.com/tedious/JShrink/issues",
+                "source": "https://github.com/tedious/JShrink/tree/v1.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tedivm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/tedivm/jshrink",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-11-20T14:34:30+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.7.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
-                "symfony/polyfill-ctype": "^1.8"
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0"
             },
-            "conflict": {
-                "vimeo/psalm": "<3.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -1891,14 +8929,178 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-02-14T12:15:55+00:00"
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+            },
+            "time": "2025-10-29T15:56:20+00:00"
+        },
+        {
+            "name": "webonyx/graphql-php",
+            "version": "v15.32.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webonyx/graphql-php.git",
+                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/993bf0bea17f870412ad8a90f60c41cb8d5f1145",
+                "reference": "993bf0bea17f870412ad8a90f60c41cb8d5f1145",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.6 || ^3",
+                "amphp/http-server": "^2.1 || ^3",
+                "dms/phpunit-arraysubset-asserts": "dev-master",
+                "ergebnis/composer-normalize": "^2.28",
+                "friendsofphp/php-cs-fixer": "3.95.1",
+                "mll-lab/php-cs-fixer-config": "5.13.0",
+                "nyholm/psr7": "^1.5",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "2.1.51",
+                "phpstan/phpstan-phpunit": "2.0.16",
+                "phpstan/phpstan-strict-rules": "2.0.10",
+                "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
+                "psr/http-message": "^1 || ^2",
+                "react/http": "^1.6",
+                "react/promise": "^2.0 || ^3.0",
+                "rector/rector": "^2.0",
+                "symfony/polyfill-php81": "^1.23",
+                "symfony/var-exporter": "^5 || ^6 || ^7 || ^8",
+                "thecodingmachine/safe": "^1.3 || ^2 || ^3",
+                "ticketswap/phpstan-error-formatter": "1.3.0"
+            },
+            "suggest": {
+                "amphp/amp": "To leverage async resolving on AMPHP platform (v3 with AmpFutureAdapter, v2 with AmpPromiseAdapter)",
+                "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
+                "psr/http-message": "To use standard GraphQL server",
+                "react/promise": "To leverage async resolving on React PHP platform"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GraphQL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP port of GraphQL reference implementation",
+            "homepage": "https://github.com/webonyx/graphql-php",
+            "keywords": [
+                "api",
+                "graphql"
+            ],
+            "support": {
+                "issues": "https://github.com/webonyx/graphql-php/issues",
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.32.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spawnia",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/webonyx-graphql-php",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2026-04-24T13:49:35+00:00"
+        },
+        {
+            "name": "wikimedia/less.php",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/less.php.git",
+                "reference": "0d5b30ba792bdbf8991a646fc9c30561b38a5559"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/0d5b30ba792bdbf8991a646fc9c30561b38a5559",
+                "reference": "0d5b30ba792bdbf8991a646fc9c30561b38a5559",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.9"
+            },
+            "require-dev": {
+                "mediawiki/mediawiki-codesniffer": "40.0.1",
+                "mediawiki/mediawiki-phan-config": "0.12.0",
+                "mediawiki/minus-x": "1.1.1",
+                "php-parallel-lint/php-console-highlighter": "1.0.0",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpunit/phpunit": "^8.5"
+            },
+            "bin": [
+                "bin/lessc"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Less": "lib/"
+                },
+                "classmap": [
+                    "lessc.inc.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Timo Tijhof",
+                    "homepage": "https://timotijhof.net"
+                },
+                {
+                    "name": "Josh Schmidt",
+                    "homepage": "https://github.com/oyejorge"
+                },
+                {
+                    "name": "Matt Agar",
+                    "homepage": "https://github.com/agar"
+                },
+                {
+                    "name": "Martin Jantošovič",
+                    "homepage": "https://github.com/Mordred"
+                }
+            ],
+            "description": "PHP port of the LESS processor",
+            "homepage": "https://gerrit.wikimedia.org/g/mediawiki/libs/less.php",
+            "keywords": [
+                "css",
+                "less",
+                "less.js",
+                "lesscss",
+                "php",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/wikimedia/less.php/issues",
+                "source": "https://github.com/wikimedia/less.php/tree/v3.2.1"
+            },
+            "time": "2023-02-03T06:43:41+00:00"
         }
     ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": []
+    "platform": {
+        "php": "^8.1",
+        "ext-curl": "*"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.magento-coding-standard.dev.json
+++ b/composer.magento-coding-standard.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-coding-standard-dev",
     "description": "The development composer file for coding standard.",
     "type": "magento2-module",
-    "version": "4.5.0",
+    "version": "5.0.0",
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.magento-coding-standard.dev.json
+++ b/composer.magento-coding-standard.dev.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension-coding-standard-dev",
     "description": "The development composer file for coding standard.",
     "type": "magento2-module",
-    "version": "4.4.4",
+    "version": "4.5.0",
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -88,21 +88,21 @@
             </group>
             <group id="mobile_consent" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Mobile</label>
-                <field id="is_active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Collect text message &amp; WhatsApp subscribers at checkout</label>
+                <field id="is_active" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Collect text message &amp; WhatsApp subscribers</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment><![CDATA[Adds a checkbox to the checkout page for mobile opt in. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up SMS in Klaviyo</a>]]></comment>
+                    <comment>Add a text message and/or WhatsApp opt-in checkbox at checkout.</comment>
                 </field>
-                <field id="channels" translate="label" type="multiselect" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Channels</label>
+                <field id="channels" translate="label comment" type="multiselect" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Select channels for consent collection</label>
                     <source_model>Klaviyo\Reclaim\Model\Config\Source\MobileChannels</source_model>
-                    <comment><![CDATA[Select which mobile channels to collect consent for. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp in Klaviyo</a>]]></comment>
+                    <comment><![CDATA[Text message must be set up to collect consent. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a>]]></comment>
                     <depends>
                         <field id="is_active">1</field>
                     </depends>
                 </field>
                 <field id="list_id" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Mobile list to sync</label>
+                    <label>Select Klaviyo list for new subscribers</label>
                     <source_model>Klaviyo\Reclaim\Model\Config\Source\ListOptions</source_model>
                     <frontend_model>Klaviyo\Reclaim\Block\System\Config\Form\Field\Consent</frontend_model>
                     <validate>validate-length minimum-length-5</validate>
@@ -111,16 +111,16 @@
                     </depends>
                 </field>
                 <field id="label_text" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Mobile opt-in checkbox text</label>
-                    <comment>This is the text that will appear next to the checkbox for mobile marketing</comment>
+                    <label>Consent checkbox label</label>
+                    <comment>Appears next to the consent checkbox at checkout.</comment>
                     <validate>required-entry</validate>
                     <depends>
                         <field id="is_active">1</field>
                     </depends>
                 </field>
                 <field id="consent_text" translate="label comment" type="textarea" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Mobile disclosure text</label>
-                    <comment><![CDATA[You must include disclosure language for TCPA compliance. You should also update your Terms of Service and Privacy Policy to include the terms of your SMS marketing program. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn more about SMS consent and compliance</a>]]></comment>
+                    <label>Consent disclosure text</label>
+                    <comment><![CDATA[Add disclosure language to adhere to compliance laws when collecting consent for text messaging. Update your Terms of Service and Privacy Policy for mobile messaging. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn about text message compliance</a>]]></comment>
                     <validate>required-entry</validate>
                     <depends>
                         <field id="is_active">1</field>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -96,7 +96,7 @@
                 <field id="channels" translate="label comment" type="multiselect" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Select channels for consent collection</label>
                     <source_model>Klaviyo\Reclaim\Model\Config\Source\MobileChannels</source_model>
-                    <comment><![CDATA[Text message must be set up to collect consent. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a>]]></comment>
+                    <comment><![CDATA[Text message must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a>]]></comment>
                     <depends>
                         <field id="is_active">1</field>
                     </depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -86,15 +86,23 @@
                     </depends>
                 </field>
             </group>
-            <group id="sms_consent" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>SMS</label>
+            <group id="mobile_consent" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Mobile</label>
                 <field id="is_active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Subscribe contacts to SMS marketing at checkout</label>
+                    <label>Collect text message &amp; WhatsApp subscribers at checkout</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment><![CDATA[Adds a checkbox to the checkout page for SMS opt in. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up SMS in Klaviyo</a>]]></comment>
+                    <comment><![CDATA[Adds a checkbox to the checkout page for mobile opt in. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up SMS in Klaviyo</a>]]></comment>
+                </field>
+                <field id="channels" translate="label" type="multiselect" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Channels</label>
+                    <source_model>Klaviyo\Reclaim\Model\Config\Source\MobileChannels</source_model>
+                    <comment><![CDATA[Select which mobile channels to collect consent for. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp in Klaviyo</a>]]></comment>
+                    <depends>
+                        <field id="is_active">1</field>
+                    </depends>
                 </field>
                 <field id="list_id" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>SMS list to sync</label>
+                    <label>Mobile list to sync</label>
                     <source_model>Klaviyo\Reclaim\Model\Config\Source\ListOptions</source_model>
                     <frontend_model>Klaviyo\Reclaim\Block\System\Config\Form\Field\Consent</frontend_model>
                     <validate>validate-length minimum-length-5</validate>
@@ -103,15 +111,15 @@
                     </depends>
                 </field>
                 <field id="label_text" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>SMS opt-in checkbox text</label>
-                    <comment>This is the text that will appear next to the checkbox for SMS marketing</comment>
+                    <label>Mobile opt-in checkbox text</label>
+                    <comment>This is the text that will appear next to the checkbox for mobile marketing</comment>
                     <validate>required-entry</validate>
                     <depends>
                         <field id="is_active">1</field>
                     </depends>
                 </field>
                 <field id="consent_text" translate="label comment" type="textarea" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>SMS disclosure text</label>
+                    <label>Mobile disclosure text</label>
                     <comment><![CDATA[You must include disclosure language for TCPA compliance. You should also update your Terms of Service and Privacy Policy to include the terms of your SMS marketing program. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn more about SMS consent and compliance</a>]]></comment>
                     <validate>required-entry</validate>
                     <depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -96,7 +96,7 @@
                 <field id="channels" translate="label comment" type="multiselect" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Select channels for consent collection</label>
                     <source_model>Klaviyo\Reclaim\Model\Config\Source\MobileChannels</source_model>
-                    <comment><![CDATA[Text message must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a>]]></comment>
+                    <comment><![CDATA[Text message must be set up to collect consent.<br><a target="_blank" href="https://www.klaviyo.com/settings/sms">Set up text message</a>]]></comment>
                     <depends>
                         <field id="is_active">1</field>
                     </depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -23,8 +23,8 @@
                 <sort_order>0</sort_order>
             </email_consent>
             <mobile_consent>
-                <label_text>Subscribe for SMS updates*</label_text>
-                <consent_text>*By checking this box and entering your phone number above, you consent to receive marketing text messages (e.g. [promos], [cart reminders]) from [company name] at the number provided, including messages sent by autodialer. Consent is not a condition of purchase. Msg &amp; data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] &amp; Terms of Service [link].</consent_text>
+                <label_text>Check this box to receive promotional marketing texts (Exclusive text messaging-only deals, offers, and coupons)*</label_text>
+                <consent_text>*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts (e.g., cart reminders) from [company name] including texts sent by autodialer. Consent is not a condition of purchase. Msg &amp; data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] &amp; Terms [link].</consent_text>
                 <sort_order>200</sort_order>
             </mobile_consent>
         </klaviyo_reclaim_consent_at_checkout>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -20,27 +20,13 @@
         <klaviyo_reclaim_consent_at_checkout>
             <email_consent>
                 <consent_text>Subscribe for email updates</consent_text>
-            </email_consent>
-        </klaviyo_reclaim_consent_at_checkout>
-        <klaviyo_reclaim_consent_at_checkout>
-            <sms_consent>
-                <consent_text>*By checking this box and entering your phone number above, you consent to receive marketing text messages (e.g. [promos], [cart reminders]) from [company name] at the number provided, including messages sent by autodialer. Consent is not a condition of purchase. Msg &amp; data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] &amp; Terms of Service [link].</consent_text>
-            </sms_consent>
-        </klaviyo_reclaim_consent_at_checkout>
-        <klaviyo_reclaim_consent_at_checkout>
-            <sms_consent>
-                <sort_order>200</sort_order>
-            </sms_consent>
-        </klaviyo_reclaim_consent_at_checkout>
-        <klaviyo_reclaim_consent_at_checkout>
-            <email_consent>
                 <sort_order>0</sort_order>
             </email_consent>
-        </klaviyo_reclaim_consent_at_checkout>
-        <klaviyo_reclaim_consent_at_checkout>
-            <sms_consent>
+            <mobile_consent>
                 <label_text>Subscribe for SMS updates*</label_text>
-            </sms_consent>
+                <consent_text>*By checking this box and entering your phone number above, you consent to receive marketing text messages (e.g. [promos], [cart reminders]) from [company name] at the number provided, including messages sent by autodialer. Consent is not a condition of purchase. Msg &amp; data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] &amp; Terms of Service [link].</consent_text>
+                <sort_order>200</sort_order>
+            </mobile_consent>
         </klaviyo_reclaim_consent_at_checkout>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -23,8 +23,9 @@
                 <sort_order>0</sort_order>
             </email_consent>
             <mobile_consent>
-                <label_text>Check this box to receive promotional marketing texts (Exclusive text messaging-only deals, offers, and coupons)*</label_text>
-                <consent_text>*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts (e.g., cart reminders) from [company name] including texts sent by autodialer. Consent is not a condition of purchase. Msg &amp; data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] &amp; Terms [link].</consent_text>
+                <channels>sms,whatsapp</channels>
+                <label_text>Check this box to receive promotional marketing messages (WhatsApp and text messaging-only deals, offers, and coupons)</label_text>
+                <consent_text>By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts and/or messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Msg &amp; data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP. Privacy Policy &amp; Terms. Privacy Policy [link] &amp; Terms [link].</consent_text>
                 <sort_order>200</sort_order>
             </mobile_consent>
         </klaviyo_reclaim_consent_at_checkout>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -74,11 +74,11 @@
         </index>
     </table>
     <table name="quote" resource="default">
-        <column xsi:type="text" name="kl_sms_consent" nullable="true" comment="SMS Consent"/>
+        <column xsi:type="text" name="kl_sms_consent" nullable="true" comment="Mobile consent checkbox (fans out to SMS/WhatsApp per merchant config)"/>
         <column xsi:type="text" name="kl_email_consent" nullable="true" comment="Email Consent"/>
     </table>
     <table name="sales_order" resource="default">
-        <column xsi:type="text" name="kl_sms_consent" nullable="true" comment="SMS Consent"/>
+        <column xsi:type="text" name="kl_sms_consent" nullable="true" comment="Mobile consent checkbox (fans out to SMS/WhatsApp per merchant config)"/>
         <column xsi:type="text" name="kl_email_consent" nullable="true" comment="Email Consent"/>
     </table>
 </schema>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,6 +16,6 @@
         </arguments>
     </type>
     <type name="Magento\Checkout\Model\ShippingInformationManagement">
-        <plugin name="save-sms-consent" type="Klaviyo\Reclaim\Model\Checkout\ShippingInformationManagement" sortOrder="10"/>
+        <plugin name="save-mobile-consent" type="Klaviyo\Reclaim\Model\Checkout\ShippingInformationManagement" sortOrder="10"/>
     </type>
 </config>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Magento\Checkout\Api\Data\ShippingInformationInterface">
-        <attribute code="kl_sms_consent" type="string"/>
+        <attribute code="kl_mobile_consent" type="string"/>
         <attribute code="kl_email_consent" type="string"/>
     </extension_attributes>
     <extension_attributes for="Magento\Quote\Api\Data\AddressInterface">
-        <attribute code="kl_sms_consent" type="string"/>
+        <attribute code="kl_mobile_consent" type="string"/>
         <attribute code="kl_email_consent" type="string"/>
     </extension_attributes>
     <extension_attributes for="Magento\Quote\Api\Data\CartInterface">

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Magento\Checkout\Api\Data\ShippingInformationInterface">
-        <attribute code="kl_mobile_consent" type="string"/>
+        <attribute code="kl_sms_consent" type="string"/>
         <attribute code="kl_email_consent" type="string"/>
     </extension_attributes>
     <extension_attributes for="Magento\Quote\Api\Data\AddressInterface">
-        <attribute code="kl_mobile_consent" type="string"/>
+        <attribute code="kl_sms_consent" type="string"/>
         <attribute code="kl_email_consent" type="string"/>
     </extension_attributes>
     <extension_attributes for="Magento\Quote\Api\Data\CartInterface">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.4.4" schema_version="4.4.4">
+  <module name="Klaviyo_Reclaim" setup_version="4.5.0" schema_version="4.5.0">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.5.0" schema_version="4.5.0">
+  <module name="Klaviyo_Reclaim" setup_version="5.0.0" schema_version="5.0.0">
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>

--- a/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="before.body.end">
+            <block class="Magento\Framework\View\Element\Template"
+                   name="klaviyo_reclaim.mobile_consent_form_js"
+                   template="Klaviyo_Reclaim::adminhtml/mobile-consent-form.phtml"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/templates/adminhtml/mobile-consent-form.phtml
+++ b/view/adminhtml/templates/adminhtml/mobile-consent-form.phtml
@@ -1,0 +1,9 @@
+<?php
+/** @var \Magento\Framework\View\Element\Template $block */
+?>
+<script>
+require(['Klaviyo_Reclaim/js/mobile-consent-form'], function (mobileConsentForm) {
+    'use strict';
+    mobileConsentForm.init();
+});
+</script>

--- a/view/adminhtml/web/js/mobile-consent-form.js
+++ b/view/adminhtml/web/js/mobile-consent-form.js
@@ -45,6 +45,18 @@ define(['jquery'], function ($) {
         $('#row_' + PREFIX + 'consent_text .note span').html(cfg.consentNote);
     }
 
+    // At store/website scope each field has a "Use Default" / "Use Website"
+    // checkbox (`#{fieldId}_inherit`). When checked, the field is disabled and
+    // Magento excludes it from the POST. Auto-population has to clear that
+    // first so the new value persists on Save Config.
+    function setInheritableFieldValue(fieldId, value) {
+        var $inherit = $('#' + fieldId + '_inherit');
+        if ($inherit.length && $inherit.is(':checked')) {
+            $inherit.prop('checked', false);
+        }
+        $('#' + fieldId).prop('disabled', false).val(value);
+    }
+
     function handleChange() {
         var cfg = currentConfig();
         if (cfg === null) {
@@ -52,8 +64,8 @@ define(['jquery'], function ($) {
         }
         applyHelperText(cfg);
         // Field values are only overwritten on merchant interaction, not on load.
-        $('#' + PREFIX + 'label_text').val(cfg.labelDefault);
-        $('#' + PREFIX + 'consent_text').val(cfg.consentDefault);
+        setInheritableFieldValue(PREFIX + 'label_text', cfg.labelDefault);
+        setInheritableFieldValue(PREFIX + 'consent_text', cfg.consentDefault);
     }
 
     return {

--- a/view/adminhtml/web/js/mobile-consent-form.js
+++ b/view/adminhtml/web/js/mobile-consent-form.js
@@ -3,25 +3,25 @@ define(['jquery'], function ($) {
 
     var PREFIX = 'klaviyo_reclaim_consent_at_checkout_mobile_consent_';
 
-    // Centralized per-channel content: helper texts and field defaults
+    // Per-channel copy. Strings are verbatim from Figma design 12257:10184.
     var CONTENT = {
         sms: {
-            channelsNote: 'Text message must be set up in Klaviyo. US merchants must comply with TCPA requirements for SMS marketing.',
-            labelDefault: 'Subscribe for SMS updates*',
-            consentDefault: '*By checking this box and entering your phone number above, you consent to receive marketing text messages (e.g. promos, cart reminders) from [company name] at the number provided, including messages sent by autodialer. Consent is not a condition of purchase. Msg &amp; data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] &amp; Terms of Service [link].',
-            consentNote: 'You must include disclosure language for TCPA compliance for SMS marketing.'
+            channelsNote: 'Text message must be set up to collect consent. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a>',
+            labelDefault: 'Check this box to receive promotional marketing texts (Exclusive text messaging-only deals, offers, and coupons)*',
+            consentDefault: '*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts (e.g., cart reminders) from [company name] including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] & Terms [link].',
+            consentNote: 'Add disclosure language to adhere to compliance laws when collecting consent for text messaging. Update your Terms of Service and Privacy Policy for mobile messaging. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn about text message compliance</a>'
         },
         whatsapp: {
-            channelsNote: 'WhatsApp must be set up in Klaviyo. Subscribers will receive messages via WhatsApp.',
-            labelDefault: 'Subscribe for WhatsApp updates',
-            consentDefault: 'By checking this box, you consent to receive marketing messages via WhatsApp from [company name]. You can unsubscribe at any time by using the unsubscribe link in any message.',
-            consentNote: 'Include disclosure language for WhatsApp consent compliance.'
+            channelsNote: 'WhatsApp must be set up to collect consent. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
+            labelDefault: 'Check this box to receive promotional marketing messages (Exclusive WhatsApp-only deals, offers, and coupons)*',
+            consentDefault: '*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Unsubscribe at any time by replying STOP.',
+            consentNote: 'As a best practice, add disclosure language when collecting consent for WhatsApp. Update your Terms of Service and Privacy Policy for mobile messaging.'
         },
         both: {
-            channelsNote: 'Both SMS and WhatsApp must be set up in Klaviyo. US merchants must comply with TCPA requirements for SMS.',
-            labelDefault: 'Subscribe for SMS and WhatsApp updates*',
-            consentDefault: '*By checking this box and entering your phone number above, you consent to receive marketing text messages and WhatsApp messages from [company name]. Msg &amp; data rates may apply for SMS. Unsubscribe at any time by replying STOP (SMS) or using the unsubscribe link in WhatsApp. Privacy Policy [link] &amp; Terms of Service [link].',
-            consentNote: 'You must include disclosure language for TCPA compliance (SMS) and WhatsApp consent compliance.'
+            channelsNote: 'Text message and WhatsApp must be set up to collect consent. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a> <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
+            labelDefault: 'Check this box to receive promotional marketing messages (WhatsApp and text messaging-only deals, offers, and coupons)*',
+            consentDefault: '*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts and/or messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP. Privacy Policy & Terms. Privacy Policy [link] & Terms [link].',
+            consentNote: 'Add disclosure language to adhere to compliance laws when collecting consent for text messaging and WhatsApp. Update your Terms of Service and Privacy Policy for mobile messaging. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn about text message compliance</a>'
         }
     };
 

--- a/view/adminhtml/web/js/mobile-consent-form.js
+++ b/view/adminhtml/web/js/mobile-consent-form.js
@@ -6,19 +6,19 @@ define(['jquery'], function ($) {
     // Per-channel copy. Strings are verbatim from Figma design 12257:10184.
     var CONTENT = {
         sms: {
-            channelsNote: 'Text message must be set up to collect consent. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a>',
+            channelsNote: 'Text message must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a>',
             labelDefault: 'Check this box to receive promotional marketing texts (Exclusive text messaging-only deals, offers, and coupons)*',
             consentDefault: '*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts (e.g., cart reminders) from [company name] including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] & Terms [link].',
             consentNote: 'Add disclosure language to adhere to compliance laws when collecting consent for text messaging. Update your Terms of Service and Privacy Policy for mobile messaging. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn about text message compliance</a>'
         },
         whatsapp: {
-            channelsNote: 'WhatsApp must be set up to collect consent. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
+            channelsNote: 'WhatsApp must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
             labelDefault: 'Check this box to receive promotional marketing messages (Exclusive WhatsApp-only deals, offers, and coupons)*',
             consentDefault: '*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Unsubscribe at any time by replying STOP.',
             consentNote: 'As a best practice, add disclosure language when collecting consent for WhatsApp. Update your Terms of Service and Privacy Policy for mobile messaging.'
         },
         both: {
-            channelsNote: 'Text message and WhatsApp must be set up to collect consent. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a> <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
+            channelsNote: 'Text message and WhatsApp must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a><br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
             labelDefault: 'Check this box to receive promotional marketing messages (WhatsApp and text messaging-only deals, offers, and coupons)*',
             consentDefault: '*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts and/or messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP. Privacy Policy & Terms. Privacy Policy [link] & Terms [link].',
             consentNote: 'Add disclosure language to adhere to compliance laws when collecting consent for text messaging and WhatsApp. Update your Terms of Service and Privacy Policy for mobile messaging. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn about text message compliance</a>'

--- a/view/adminhtml/web/js/mobile-consent-form.js
+++ b/view/adminhtml/web/js/mobile-consent-form.js
@@ -8,19 +8,19 @@ define(['jquery'], function ($) {
     // (labelDefault, consentDefault) are verbatim from product spec.
     var CONTENT = {
         sms: {
-            channelsNote: 'Text message must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a>',
+            channelsNote: 'Text message must be set up to collect consent.<br><a target="_blank" href="https://www.klaviyo.com/settings/sms">Set up text message</a>',
             labelDefault: 'Check this box to receive promotional marketing texts (Exclusive text messaging-only deals, offers, and coupons)',
             consentDefault: 'By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts (e.g., cart reminders) from [company name] including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] & Terms [link].',
             consentNote: 'Add disclosure language to adhere to compliance laws when collecting consent for text messaging. Update your Terms of Service and Privacy Policy for mobile messaging. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn about text message compliance</a>'
         },
         whatsapp: {
-            channelsNote: 'WhatsApp must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
+            channelsNote: 'WhatsApp must be set up to collect consent.<br><a target="_blank" href="https://www.klaviyo.com/settings/whatsapp">Set up WhatsApp</a>',
             labelDefault: 'Check this box to receive promotional marketing messages (Exclusive WhatsApp-only deals, offers, and coupons)',
             consentDefault: 'By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Unsubscribe at any time by replying STOP.',
             consentNote: 'As a best practice, add disclosure language when collecting consent for WhatsApp. Update your Terms of Service and Privacy Policy for mobile messaging.'
         },
         both: {
-            channelsNote: 'Text message and WhatsApp must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a><br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
+            channelsNote: 'Text message and WhatsApp must be set up to collect consent.<br><a target="_blank" href="https://www.klaviyo.com/settings/sms">Set up text message</a><br><a target="_blank" href="https://www.klaviyo.com/settings/whatsapp">Set up WhatsApp</a>',
             labelDefault: 'Check this box to receive promotional marketing messages (WhatsApp and text messaging-only deals, offers, and coupons)',
             consentDefault: 'By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts and/or messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP. Privacy Policy & Terms. Privacy Policy [link] & Terms [link].',
             consentNote: 'Add disclosure language to adhere to compliance laws when collecting consent for text messaging and WhatsApp. Update your Terms of Service and Privacy Policy for mobile messaging. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn about text message compliance</a>'

--- a/view/adminhtml/web/js/mobile-consent-form.js
+++ b/view/adminhtml/web/js/mobile-consent-form.js
@@ -35,13 +35,20 @@ define(['jquery'], function ($) {
         return 'sms';
     }
 
-    function handleChange() {
+    function currentConfig() {
         var values = $('#' + PREFIX + 'channels').val() || [];
-        var cfg = CONTENT[resolveKey(values)];
+        return CONTENT[resolveKey(values)];
+    }
 
+    function applyHelperText(cfg) {
         $('#row_' + PREFIX + 'channels .note span').html(cfg.channelsNote);
         $('#row_' + PREFIX + 'consent_text .note span').html(cfg.consentNote);
+    }
 
+    function handleChange() {
+        var cfg = currentConfig();
+        applyHelperText(cfg);
+        // Field values are only overwritten on merchant interaction, not on load.
         $('#' + PREFIX + 'label_text').val(cfg.labelDefault);
         $('#' + PREFIX + 'consent_text').val(cfg.consentDefault);
     }
@@ -52,6 +59,7 @@ define(['jquery'], function ($) {
             if (!$channels.length) {
                 return;
             }
+            applyHelperText(currentConfig());
             $channels.on('change', handleChange);
         }
     };

--- a/view/adminhtml/web/js/mobile-consent-form.js
+++ b/view/adminhtml/web/js/mobile-consent-form.js
@@ -27,17 +27,17 @@ define(['jquery'], function ($) {
         }
     };
 
-    function resolveKey(values) {
-        var hasSms = values.indexOf('sms') !== -1;
-        var hasWa = values.indexOf('whatsapp') !== -1;
-        if (hasSms && hasWa) { return 'both'; }
-        if (hasWa) { return 'whatsapp'; }
-        return 'sms';
-    }
-
+    // Returns the CONTENT entry for the current selection, or null if the
+    // multiselect is empty. An empty selection has no meaningful default —
+    // callers should leave existing helper text and field values untouched.
     function currentConfig() {
         var values = $('#' + PREFIX + 'channels').val() || [];
-        return CONTENT[resolveKey(values)];
+        var hasSms = values.indexOf('sms') !== -1;
+        var hasWa = values.indexOf('whatsapp') !== -1;
+        if (hasSms && hasWa) { return CONTENT.both; }
+        if (hasWa) { return CONTENT.whatsapp; }
+        if (hasSms) { return CONTENT.sms; }
+        return null;
     }
 
     function applyHelperText(cfg) {
@@ -47,6 +47,9 @@ define(['jquery'], function ($) {
 
     function handleChange() {
         var cfg = currentConfig();
+        if (cfg === null) {
+            return;
+        }
         applyHelperText(cfg);
         // Field values are only overwritten on merchant interaction, not on load.
         $('#' + PREFIX + 'label_text').val(cfg.labelDefault);
@@ -59,7 +62,10 @@ define(['jquery'], function ($) {
             if (!$channels.length) {
                 return;
             }
-            applyHelperText(currentConfig());
+            var cfg = currentConfig();
+            if (cfg !== null) {
+                applyHelperText(cfg);
+            }
             $channels.on('change', handleChange);
         }
     };

--- a/view/adminhtml/web/js/mobile-consent-form.js
+++ b/view/adminhtml/web/js/mobile-consent-form.js
@@ -1,0 +1,90 @@
+define(['jquery'], function ($) {
+    'use strict';
+
+    var PREFIX = 'klaviyo_reclaim_consent_at_checkout_mobile_consent_';
+
+    // Centralized per-channel content: helper texts and field defaults
+    var CONTENT = {
+        sms: {
+            channelsNote: 'Text message must be set up in Klaviyo. US merchants must comply with TCPA requirements for SMS marketing.',
+            labelDefault: 'Subscribe for SMS updates*',
+            consentDefault: '*By checking this box and entering your phone number above, you consent to receive marketing text messages (e.g. promos, cart reminders) from [company name] at the number provided, including messages sent by autodialer. Consent is not a condition of purchase. Msg &amp; data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] &amp; Terms of Service [link].',
+            consentNote: 'You must include disclosure language for TCPA compliance for SMS marketing.'
+        },
+        whatsapp: {
+            channelsNote: 'WhatsApp must be set up in Klaviyo. Subscribers will receive messages via WhatsApp.',
+            labelDefault: 'Subscribe for WhatsApp updates',
+            consentDefault: 'By checking this box, you consent to receive marketing messages via WhatsApp from [company name]. You can unsubscribe at any time by using the unsubscribe link in any message.',
+            consentNote: 'Include disclosure language for WhatsApp consent compliance.'
+        },
+        both: {
+            channelsNote: 'Both SMS and WhatsApp must be set up in Klaviyo. US merchants must comply with TCPA requirements for SMS.',
+            labelDefault: 'Subscribe for SMS and WhatsApp updates*',
+            consentDefault: '*By checking this box and entering your phone number above, you consent to receive marketing text messages and WhatsApp messages from [company name]. Msg &amp; data rates may apply for SMS. Unsubscribe at any time by replying STOP (SMS) or using the unsubscribe link in WhatsApp. Privacy Policy [link] &amp; Terms of Service [link].',
+            consentNote: 'You must include disclosure language for TCPA compliance (SMS) and WhatsApp consent compliance.'
+        }
+    };
+
+    // Dirty flags track whether merchant has manually edited each field
+    var dirty = { label: false, consent: false };
+
+    // Track the last value we auto-populated so we can detect merchant overrides
+    var lastAutoPopulated = { label: null, consent: null };
+
+    function resolveKey(values) {
+        var hasSms = values.indexOf('sms') !== -1;
+        var hasWa = values.indexOf('whatsapp') !== -1;
+        if (hasSms && hasWa) { return 'both'; }
+        if (hasWa) { return 'whatsapp'; }
+        return 'sms';
+    }
+
+    function handleChange() {
+        var values = $('#' + PREFIX + 'channels').val() || [];
+        var key = resolveKey(values);
+        var cfg = CONTENT[key];
+
+        // Always update helper text (comment spans) regardless of dirty state
+        $('#row_' + PREFIX + 'channels .note span').html(cfg.channelsNote);
+        $('#row_' + PREFIX + 'consent_text .note span').html(cfg.consentNote);
+
+        // Auto-populate label_text if not dirty or value matches previous auto-populated default
+        var $label = $('#' + PREFIX + 'label_text');
+        if (!dirty.label) {
+            var lv = $label.val();
+            if (lv === '' || lv === lastAutoPopulated.label) {
+                $label.val(cfg.labelDefault);
+                lastAutoPopulated.label = cfg.labelDefault;
+            }
+        }
+
+        // Auto-populate consent_text if not dirty or value matches previous auto-populated default
+        var $consent = $('#' + PREFIX + 'consent_text');
+        if (!dirty.consent) {
+            var cv = $consent.val();
+            if (cv === '' || cv === lastAutoPopulated.consent) {
+                $consent.val(cfg.consentDefault);
+                lastAutoPopulated.consent = cfg.consentDefault;
+            }
+        }
+    }
+
+    return {
+        init: function () {
+            var $channels = $('#' + PREFIX + 'channels');
+            if (!$channels.length) {
+                return;
+            }
+
+            // Mark dirty when merchant manually edits a field
+            $('#' + PREFIX + 'label_text').on('input', function () {
+                dirty.label = true;
+            });
+            $('#' + PREFIX + 'consent_text').on('input', function () {
+                dirty.consent = true;
+            });
+
+            $channels.on('change', handleChange);
+        }
+    };
+});

--- a/view/adminhtml/web/js/mobile-consent-form.js
+++ b/view/adminhtml/web/js/mobile-consent-form.js
@@ -3,33 +3,29 @@ define(['jquery'], function ($) {
 
     var PREFIX = 'klaviyo_reclaim_consent_at_checkout_mobile_consent_';
 
-    // Per-channel copy. Strings are verbatim from Figma design 12257:10184.
+    // Per-channel copy. Helper-text strings (channelsNote, consentNote)
+    // are verbatim from Figma design 12257:10184. Field defaults
+    // (labelDefault, consentDefault) are verbatim from product spec.
     var CONTENT = {
         sms: {
             channelsNote: 'Text message must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a>',
-            labelDefault: 'Check this box to receive promotional marketing texts (Exclusive text messaging-only deals, offers, and coupons)*',
-            consentDefault: '*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts (e.g., cart reminders) from [company name] including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] & Terms [link].',
+            labelDefault: 'Check this box to receive promotional marketing texts (Exclusive text messaging-only deals, offers, and coupons)',
+            consentDefault: 'By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts (e.g., cart reminders) from [company name] including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy [link] & Terms [link].',
             consentNote: 'Add disclosure language to adhere to compliance laws when collecting consent for text messaging. Update your Terms of Service and Privacy Policy for mobile messaging. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn about text message compliance</a>'
         },
         whatsapp: {
             channelsNote: 'WhatsApp must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
-            labelDefault: 'Check this box to receive promotional marketing messages (Exclusive WhatsApp-only deals, offers, and coupons)*',
-            consentDefault: '*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Unsubscribe at any time by replying STOP.',
+            labelDefault: 'Check this box to receive promotional marketing messages (Exclusive WhatsApp-only deals, offers, and coupons)',
+            consentDefault: 'By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Unsubscribe at any time by replying STOP.',
             consentNote: 'As a best practice, add disclosure language when collecting consent for WhatsApp. Update your Terms of Service and Privacy Policy for mobile messaging.'
         },
         both: {
             channelsNote: 'Text message and WhatsApp must be set up to collect consent.<br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360039190611-On-Demand-Training-Getting-Started-with-Klaviyo-SMS">Set up text message</a><br><a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/whatsapp">Set up WhatsApp</a>',
-            labelDefault: 'Check this box to receive promotional marketing messages (WhatsApp and text messaging-only deals, offers, and coupons)*',
-            consentDefault: '*By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts and/or messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP. Privacy Policy & Terms. Privacy Policy [link] & Terms [link].',
+            labelDefault: 'Check this box to receive promotional marketing messages (WhatsApp and text messaging-only deals, offers, and coupons)',
+            consentDefault: 'By checking this box and entering your phone number, you consent to receive informational (e.g., order updates) and/or marketing texts and/or messages (e.g., cart reminders) from [company name] including messages sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP. Privacy Policy & Terms. Privacy Policy [link] & Terms [link].',
             consentNote: 'Add disclosure language to adhere to compliance laws when collecting consent for text messaging and WhatsApp. Update your Terms of Service and Privacy Policy for mobile messaging. <a target="_blank" href="https://help.klaviyo.com/hc/en-us/articles/360035055312-About-US-SMS-Compliance-Laws">Learn about text message compliance</a>'
         }
     };
-
-    // Dirty flags track whether merchant has manually edited each field
-    var dirty = { label: false, consent: false };
-
-    // Track the last value we auto-populated so we can detect merchant overrides
-    var lastAutoPopulated = { label: null, consent: null };
 
     function resolveKey(values) {
         var hasSms = values.indexOf('sms') !== -1;
@@ -41,32 +37,13 @@ define(['jquery'], function ($) {
 
     function handleChange() {
         var values = $('#' + PREFIX + 'channels').val() || [];
-        var key = resolveKey(values);
-        var cfg = CONTENT[key];
+        var cfg = CONTENT[resolveKey(values)];
 
-        // Always update helper text (comment spans) regardless of dirty state
         $('#row_' + PREFIX + 'channels .note span').html(cfg.channelsNote);
         $('#row_' + PREFIX + 'consent_text .note span').html(cfg.consentNote);
 
-        // Auto-populate label_text if not dirty or value matches previous auto-populated default
-        var $label = $('#' + PREFIX + 'label_text');
-        if (!dirty.label) {
-            var lv = $label.val();
-            if (lv === '' || lv === lastAutoPopulated.label) {
-                $label.val(cfg.labelDefault);
-                lastAutoPopulated.label = cfg.labelDefault;
-            }
-        }
-
-        // Auto-populate consent_text if not dirty or value matches previous auto-populated default
-        var $consent = $('#' + PREFIX + 'consent_text');
-        if (!dirty.consent) {
-            var cv = $consent.val();
-            if (cv === '' || cv === lastAutoPopulated.consent) {
-                $consent.val(cfg.consentDefault);
-                lastAutoPopulated.consent = cfg.consentDefault;
-            }
-        }
+        $('#' + PREFIX + 'label_text').val(cfg.labelDefault);
+        $('#' + PREFIX + 'consent_text').val(cfg.consentDefault);
     }
 
     return {
@@ -75,15 +52,6 @@ define(['jquery'], function ($) {
             if (!$channels.length) {
                 return;
             }
-
-            // Mark dirty when merchant manually edits a field
-            $('#' + PREFIX + 'label_text').on('input', function () {
-                dirty.label = true;
-            });
-            $('#' + PREFIX + 'consent_text').on('input', function () {
-                dirty.consent = true;
-            });
-
             $channels.on('change', handleChange);
         }
     };

--- a/view/frontend/web/js/model/shipping-payload/assigner.js
+++ b/view/frontend/web/js/model/shipping-payload/assigner.js
@@ -5,13 +5,13 @@ define([
     'use strict';
 
     return function (container) {
-        var kl_mobile_consent = $('[name="custom_attributes[kl_mobile_consent]"]').is(':checked');
+        var kl_sms_consent = $('[name="custom_attributes[kl_sms_consent]"]').is(':checked');
         var kl_email_consent = $('[name="custom_attributes[kl_email_consent]"]').is(':checked');
 
         container.extension_attributes = _.extend(
             container.extension_attributes || {},
             {
-                kl_mobile_consent: kl_mobile_consent,
+                kl_sms_consent: kl_sms_consent,
                 kl_email_consent: kl_email_consent
             }
         );

--- a/view/frontend/web/js/model/shipping-payload/assigner.js
+++ b/view/frontend/web/js/model/shipping-payload/assigner.js
@@ -5,13 +5,13 @@ define([
     'use strict';
 
     return function (container) {
-        var kl_sms_consent = $('[name="custom_attributes[kl_sms_consent]"]').is(':checked');
+        var kl_mobile_consent = $('[name="custom_attributes[kl_mobile_consent]"]').is(':checked');
         var kl_email_consent = $('[name="custom_attributes[kl_email_consent]"]').is(':checked');
 
         container.extension_attributes = _.extend(
             container.extension_attributes || {},
             {
-                kl_sms_consent: kl_sms_consent,
+                kl_mobile_consent: kl_mobile_consent,
                 kl_email_consent: kl_email_consent
             }
         );


### PR DESCRIPTION
## Summary

- Replaces the SMS-only admin consent group with a unified **Mobile** group featuring a channel multiselect (SMS + WhatsApp) and reactive JS that updates helper texts and overwrites label/disclosure field values when the merchant changes the channels selection
- Adds `MigrateSmsToMobileConsent` data patch to copy existing merchants' `sms_consent/*` config values into the new `mobile_consent/*` group, preserving customized label/disclosure copy and seeding `channels=sms` where SMS was previously active
- Renders one mobile consent checkbox at checkout (replaces the SMS-only checkbox); on order placement, fans out to V3 `/api/profile-subscription-bulk-create-jobs/` with per-channel subscriptions driven by the merchant's `mobile_consent/channels` setting; the legacy custom webhook is no longer called for consent (`Helper/Webhook.php` retained for product sync/delete). One request per consent type collected (email, sms, whatsapp) to ensure all consent types are sent even if channel is not supported in Klaviyo account.
- **E.164 phone normalization:** uses `giggsey/libphonenumber-for-php` to normalize the customer's checkout phone before sending to V3; on parse failure, mobile subscribe is skipped with a warning log (email subscribe is unaffected)
- **Wire-layer naming:** the `kl_sms_consent` DB column / quote magic getter / extension attribute / DOM field name is preserved as-is. Only the admin-facing config group rename (`sms_consent` → `mobile_consent`) and the new wire-layer behavior (V3 fan-out, E.164 normalization) ship in this PR. The column's `comment` is updated to reflect its new semantics ("Mobile consent checkbox; fans out to SMS/WhatsApp per merchant config")

## Admin UI behavior

- On page load: helper text under the channels multiselect and disclosure field syncs to the current saved channels selection. Saved label / disclosure field values render as-is — never overwritten on load.
- On channels toggle: helper texts re-render, and label / disclosure field values are **unconditionally overwritten** with the new channel's Figma defaults. Merchant customizations are clobbered by a toggle, per product spec.
- Fresh installs default to both channels selected (`config.xml` seeds `channels=sms,whatsapp`).

## Linear Ticket

IES-217: https://linear.app/klaviyo/issue/IES-217/ralph-wiggum-test-magento2-klaviyo-combined-unified-mobile-consent

## Dependency / compatibility changes

- New runtime dep declared in `composer.json`: `giggsey/libphonenumber-for-php: ^9.0` (already present transitively in Magento installs; declaring pins the contract)
- New PHP floor declared in `composer.json`: `php: ^8.1`. No-op for Magento 2.4.5+ (which already requires 8.1+); blocks plugin upgrades on Magento 2.4.4 + PHP 7.4 — see CHANGELOG note

## Implementation

Built autonomously by Ralph Wiggum (4/4 planned tasks) plus follow-up commits driven by Cursor Bugbot findings, design feedback, and product spec refinements:

1. **Initial 14 commits** — `system.xml` refactor, `ScopeSetting.php` mobile helpers + channels methods, `MobileChannels` source model, data migration patch, `extension_attributes.xml` rename (later reverted), `CheckoutLayoutPlugin` + `ShippingInformationManagement` refactor, frontend JS rename (later reverted), `SaveOrderMarketingConsent` V3 fan-out, PHPUnit + Playwright test suites, `config.xml` default migration, `di.xml` plugin rename, reactive admin JS + layout XML wiring
2. **`0325df0` — `kl_sms_consent` column revert** — fixes Cursor Bugbot high-severity finding: the rename to `kl_mobile_consent` in PHP/JS code didn't match the unchanged `kl_sms_consent` column in `db_schema.xml`, so Magento ORM's magic setter mapped to a non-existent column and silently dropped consent data on save. Reverted the wire-layer rename; kept the admin-config rename
3. **`dbd0c63` — E.164 phone normalization** — addresses the V3 endpoint's strict E.164 requirement. Adds `Util/PhoneFormatter` (libphonenumber wrapper, returns `null` on parse/validation failure); observer normalizes the phone via shipping address's `getCountryId()` before building the mobile profile; skip-and-log on null result so a malformed phone never produces a 4xx on the bulk job
4. **`9efd151`, `46c92d8`, `823b40b` — Figma alignment** — verbatim Figma strings for field labels, helper texts, and per-channel default copy; `Set up text message` / `Set up WhatsApp` links broken onto their own lines; both deep-link at `https://www.klaviyo.com/settings/{sms,whatsapp}`
5. **`e99d4c4` — toggle-overwrites field defaults** — per refined spec, channel toggles now unconditionally overwrite the label and disclosure fields. Dirty-flag preservation removed. New "both" default for fresh installs (`<channels>sms,whatsapp</channels>` in `config.xml`). Multiselect display label `SMS` → `Text message`
6. **`8ff2826` — sync helper text on page load** — `init()` calls `applyHelperText(currentConfig())` so the helper text under channels and disclosure matches the saved channels selection on initial render
7. **`68adeaf` — bugbot-fix sweep** — reorder catch blocks so `KlaviyoResourceConflictException` is caught before its parent `KlaviyoApiException` (both observer try/catch sites); update `ConfigXmlTest` assertions to match current defaults and add a new `<channels>` assertion; drop stale dirty-flag test from `MobileConsentFormJsTest`

TDD on every commit: tests written before implementation. Quality gates pass on every commit (PHP syntax, XML validation, PHPCS, PHPCBF).

## Test Plan

**Automated:**
- [ ] CI green (PHPUnit + Playwright)
- [ ] PhoneFormatter unit tests pass (10 cases — US/UK valid numbers, empty/null inputs, garbage, too-short)
- [ ] SaveOrderMarketingConsent unit tests pass (9 cases including 2 new ones: skip on unparseable phone, email unaffected by mobile failure)
- [ ] ConfigXmlTest passes (existence + non-empty checks for label/disclosure; exact match for channels default)

**Manual (against the docker stack):**
- [ ] Page-load behavior: open admin config with saved channels — helper texts match the saved selection; saved label/disclosure render as-is, not overwritten
- [ ] Channel toggle: changing the channels multiselect unconditionally overwrites label and disclosure fields with the channel's Figma defaults (intended; clobbers any customization)
- [ ] Single mobile consent checkbox renders at checkout when `mobile_consent/is_active=1`
- [ ] Place order with US phone in non-E.164 format (e.g. `(202) 555-0100`) and SMS channel enabled → profile in Klaviyo has `phone_number: +12025550100` and SMS subscription
- [ ] Place order with garbage phone → no mobile subscribe call fires; warning logged; email subscribe still works if email was checked
- [ ] Place order with UK shipping + UK phone → `phone_number` normalized to UK E.164
- [ ] Verify zero outbound calls to `/api/webhook/integration/magento_two` for consent
- [ ] Run `MigrateSmsToMobileConsent` patch on an upgrade from an SMS-configured install → new `mobile_consent/*` paths populated, custom label/disclosure preserved verbatim, `channels=sms` seeded where SMS was active

## Screenshots
Compare against design ([Figma](https://www.figma.com/design/06dswOHNcdqTr4ZYV5XqbU/WhatsApp-Consent-Collection?node-id=12257-10184&m=dev))
### None selected
<img width="775" height="527" alt="image" src="https://github.com/user-attachments/assets/3c2beb0a-7026-4bc6-9b6e-512e10042620" />

### WhatsApp selected
<img width="1593" height="884" alt="image" src="https://github.com/user-attachments/assets/7e9ef307-e1ea-4610-a82b-a24541180b64" />

<img width="1035" height="957" alt="image" src="https://github.com/user-attachments/assets/cf87f296-4f6b-4235-8ccb-cfdf77ecc1c9" />

### Text message and email selected
<img width="1082" height="1047" alt="image" src="https://github.com/user-attachments/assets/e2f33478-ddb8-4d3a-968f-3fccf467efa2" />

<img width="464" height="204" alt="image" src="https://github.com/user-attachments/assets/8e8a5667-7b6c-4dba-9a6d-a7f82f21c4f3" />

<img width="474" height="244" alt="image" src="https://github.com/user-attachments/assets/6faac059-ec74-44c6-bb36-9f4c5b97bfc2" />

### Text message only
<img width="1040" height="964" alt="image" src="https://github.com/user-attachments/assets/6114237b-b2df-496e-a21c-b96cbebceab6" />

### Both selected
<img width="1474" height="883" alt="image" src="https://github.com/user-attachments/assets/94433f4e-6f86-443a-b3a4-ae1aceabcc85" />

<img width="449" height="287" alt="image" src="https://github.com/user-attachments/assets/a655107b-5465-4203-9b3d-3c50d7e60d98" />

#### Successful subscription
<img width="1171" height="927" alt="image" src="https://github.com/user-attachments/assets/305d14f9-1b17-41e1-8fd3-63bafe6adb31" />

### Three consent requests, one per channel type (email, sms, whatsapp)
<img width="1551" height="150" alt="image" src="https://github.com/user-attachments/assets/701fcbd1-86fd-45eb-b896-89525b2705be" />

🤖 Generated with [Claude Code](https://claude.ai/claude-code) via Ralph Wiggum