### PR TITLE
Extract Magento test stubs to dedicated files for Marketplace phpcs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -51,4 +51,4 @@ jobs:
         with:
           dev: yes
       - name: Run Magento Coding Standard via PHPCS
-        run: vendor/bin/phpcs --standard=Magento2 --ignore="*/vendor/*,*/Test/*" --severity=10 .
+        run: vendor/bin/phpcs --standard=Magento2 --ignore="*/vendor/*" --severity=10 .

--- a/Test/Unit/Model/Checkout/ShippingInformationManagementTest.php
+++ b/Test/Unit/Model/Checkout/ShippingInformationManagementTest.php
@@ -2,141 +2,110 @@
 
 declare(strict_types=1);
 
-// Stub Magento classes so the plugin can load without the full Magento stack.
-namespace Magento\Quote\Model {
-    if (!class_exists(\Magento\Quote\Model\QuoteRepository::class, false)) {
-        class QuoteRepository
-        {
-            public function getActive($cartId)
+namespace Klaviyo\Reclaim\Test\Unit\Model\Checkout;
+
+use Klaviyo\Reclaim\Model\Checkout\ShippingInformationManagement;
+use Magento\Checkout\Api\Data\ShippingInformationInterface;
+use Magento\Checkout\Model\ShippingInformationManagement as Subject;
+use Magento\Quote\Model\QuoteRepository;
+use PHPUnit\Framework\TestCase;
+
+class ShippingInformationManagementTest extends TestCase
+{
+    private function buildPlugin($quote): ShippingInformationManagement
+    {
+        $repo = $this->getMockBuilder(QuoteRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $repo->method('getActive')->willReturn($quote);
+        return new ShippingInformationManagement($repo);
+    }
+
+    private function buildAddressInfo($extAttributes): ShippingInformationInterface
+    {
+        $info = $this->getMockBuilder(ShippingInformationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $info->method('getExtensionAttributes')->willReturn($extAttributes);
+        return $info;
+    }
+
+    public function test_beforeSaveAddressInformation_mobile_consent_sets_kl_sms_consent_on_quote()
+    {
+        $extAttributes = new class {
+            public function getKlSmsConsent(): string
+            {
+                return '1';
+            }
+            public function getKlEmailConsent(): ?string
             {
                 return null;
             }
-        }
+        };
+
+        $quote = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['setKlSmsConsent', 'setKlEmailConsent'])
+            ->getMock();
+        $quote->expects($this->once())
+            ->method('setKlSmsConsent')
+            ->with('1');
+        $quote->expects($this->once())
+            ->method('setKlEmailConsent')
+            ->with(null);
+
+        $plugin = $this->buildPlugin($quote);
+        $plugin->beforeSaveAddressInformation(
+            new Subject(),
+            1,
+            $this->buildAddressInfo($extAttributes)
+        );
     }
-}
 
-namespace Magento\Checkout\Model {
-    if (!class_exists(\Magento\Checkout\Model\ShippingInformationManagement::class, false)) {
-        class ShippingInformationManagement
-        {
-        }
-    }
-}
-
-namespace Magento\Checkout\Api\Data {
-    if (!interface_exists(\Magento\Checkout\Api\Data\ShippingInformationInterface::class, false)) {
-        interface ShippingInformationInterface
-        {
-            public function getExtensionAttributes();
-        }
-    }
-}
-
-namespace Klaviyo\Reclaim\Test\Unit\Model\Checkout {
-
-    use Klaviyo\Reclaim\Model\Checkout\ShippingInformationManagement;
-    use Magento\Checkout\Api\Data\ShippingInformationInterface;
-    use Magento\Checkout\Model\ShippingInformationManagement as Subject;
-    use Magento\Quote\Model\QuoteRepository;
-    use PHPUnit\Framework\TestCase;
-
-    class ShippingInformationManagementTest extends TestCase
+    public function test_beforeSaveAddressInformation_email_consent_sets_kl_email_consent_on_quote()
     {
-        private function buildPlugin($quote): ShippingInformationManagement
-        {
-            $repo = $this->getMockBuilder(QuoteRepository::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $repo->method('getActive')->willReturn($quote);
-            return new ShippingInformationManagement($repo);
-        }
+        $extAttributes = new class {
+            public function getKlSmsConsent(): ?string
+            {
+                return null;
+            }
+            public function getKlEmailConsent(): string
+            {
+                return '1';
+            }
+        };
 
-        private function buildAddressInfo($extAttributes): ShippingInformationInterface
-        {
-            $info = $this->getMockBuilder(ShippingInformationInterface::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $info->method('getExtensionAttributes')->willReturn($extAttributes);
-            return $info;
-        }
+        $quote = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['setKlSmsConsent', 'setKlEmailConsent'])
+            ->getMock();
+        $quote->expects($this->once())
+            ->method('setKlSmsConsent')
+            ->with(null);
+        $quote->expects($this->once())
+            ->method('setKlEmailConsent')
+            ->with('1');
 
-        public function test_beforeSaveAddressInformation_mobile_consent_sets_kl_sms_consent_on_quote()
-        {
-            $extAttributes = new class {
-                public function getKlSmsConsent(): string
-                {
-                    return '1';
-                }
-                public function getKlEmailConsent(): ?string
-                {
-                    return null;
-                }
-            };
+        $plugin = $this->buildPlugin($quote);
+        $plugin->beforeSaveAddressInformation(
+            new Subject(),
+            1,
+            $this->buildAddressInfo($extAttributes)
+        );
+    }
 
-            $quote = $this->getMockBuilder(\stdClass::class)
-                ->addMethods(['setKlSmsConsent', 'setKlEmailConsent'])
-                ->getMock();
-            $quote->expects($this->once())
-                ->method('setKlSmsConsent')
-                ->with('1');
-            $quote->expects($this->once())
-                ->method('setKlEmailConsent')
-                ->with(null);
+    public function test_beforeSaveAddressInformation_no_ext_attributes_returns_null()
+    {
+        $info = $this->getMockBuilder(ShippingInformationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $info->method('getExtensionAttributes')->willReturn(null);
 
-            $plugin = $this->buildPlugin($quote);
-            $plugin->beforeSaveAddressInformation(
-                new Subject(),
-                1,
-                $this->buildAddressInfo($extAttributes)
-            );
-        }
+        $repo = $this->getMockBuilder(QuoteRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $repo->expects($this->never())->method('getActive');
 
-        public function test_beforeSaveAddressInformation_email_consent_sets_kl_email_consent_on_quote()
-        {
-            $extAttributes = new class {
-                public function getKlSmsConsent(): ?string
-                {
-                    return null;
-                }
-                public function getKlEmailConsent(): string
-                {
-                    return '1';
-                }
-            };
-
-            $quote = $this->getMockBuilder(\stdClass::class)
-                ->addMethods(['setKlSmsConsent', 'setKlEmailConsent'])
-                ->getMock();
-            $quote->expects($this->once())
-                ->method('setKlSmsConsent')
-                ->with(null);
-            $quote->expects($this->once())
-                ->method('setKlEmailConsent')
-                ->with('1');
-
-            $plugin = $this->buildPlugin($quote);
-            $plugin->beforeSaveAddressInformation(
-                new Subject(),
-                1,
-                $this->buildAddressInfo($extAttributes)
-            );
-        }
-
-        public function test_beforeSaveAddressInformation_no_ext_attributes_returns_null()
-        {
-            $info = $this->getMockBuilder(ShippingInformationInterface::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $info->method('getExtensionAttributes')->willReturn(null);
-
-            $repo = $this->getMockBuilder(QuoteRepository::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $repo->expects($this->never())->method('getActive');
-
-            $plugin = new ShippingInformationManagement($repo);
-            $result = $plugin->beforeSaveAddressInformation(new Subject(), 1, $info);
-            $this->assertNull($result);
-        }
+        $plugin = new ShippingInformationManagement($repo);
+        $result = $plugin->beforeSaveAddressInformation(new Subject(), 1, $info);
+        $this->assertNull($result);
     }
 }

--- a/Test/Unit/Model/Config/Source/MobileChannelsTest.php
+++ b/Test/Unit/Model/Config/Source/MobileChannelsTest.php
@@ -1,65 +1,44 @@
 <?php
 
-// Stub Magento's framework interface so MobileChannels can load without the full Magento framework.
-namespace Magento\Framework\Option {
-    if (!interface_exists(\Magento\Framework\Option\ArrayInterface::class)) {
-        interface ArrayInterface
-        {
-            public function toOptionArray();
-        }
-    }
-}
+namespace Klaviyo\Reclaim\Test\Unit\Model\Config\Source;
 
-// Stub Magento's __() translation function in the MobileChannels namespace.
-namespace Klaviyo\Reclaim\Model\Config\Source {
-    if (!function_exists('Klaviyo\Reclaim\Model\Config\Source\__')) {
-        function __($string)
-        {
-            return $string;
-        }
-    }
-}
+use PHPUnit\Framework\TestCase;
+use Klaviyo\Reclaim\Model\Config\Source\MobileChannels;
 
-namespace Klaviyo\Reclaim\Test\Unit\Model\Config\Source {
+class MobileChannelsTest extends TestCase
+{
+    /**
+     * @var MobileChannels
+     */
+    protected $mobileChannels;
 
-    use PHPUnit\Framework\TestCase;
-    use Klaviyo\Reclaim\Model\Config\Source\MobileChannels;
-
-    class MobileChannelsTest extends TestCase
+    protected function setUp(): void
     {
-        /**
-         * @var MobileChannels
-         */
-        protected $mobileChannels;
+        $this->mobileChannels = new MobileChannels();
+    }
 
-        protected function setUp(): void
-        {
-            $this->mobileChannels = new MobileChannels();
-        }
+    public function test_toOptionArray_returns_exactly_two_entries()
+    {
+        $result = $this->mobileChannels->toOptionArray();
+        $this->assertCount(2, $result);
+    }
 
-        public function test_toOptionArray_returns_exactly_two_entries()
-        {
-            $result = $this->mobileChannels->toOptionArray();
-            $this->assertCount(2, $result);
-        }
+    public function test_toOptionArray_first_entry_has_sms_value()
+    {
+        $result = $this->mobileChannels->toOptionArray();
+        $values = array_column($result, 'value');
+        $this->assertContains('sms', $values);
+    }
 
-        public function test_toOptionArray_first_entry_has_sms_value()
-        {
-            $result = $this->mobileChannels->toOptionArray();
-            $values = array_column($result, 'value');
-            $this->assertContains('sms', $values);
-        }
+    public function test_toOptionArray_second_entry_has_whatsapp_value()
+    {
+        $result = $this->mobileChannels->toOptionArray();
+        $values = array_column($result, 'value');
+        $this->assertContains('whatsapp', $values);
+    }
 
-        public function test_toOptionArray_second_entry_has_whatsapp_value()
-        {
-            $result = $this->mobileChannels->toOptionArray();
-            $values = array_column($result, 'value');
-            $this->assertContains('whatsapp', $values);
-        }
-
-        public function test_toOptionArray_implements_array_interface()
-        {
-            $this->assertInstanceOf(\Magento\Framework\Option\ArrayInterface::class, $this->mobileChannels);
-        }
+    public function test_toOptionArray_implements_array_interface()
+    {
+        $this->assertInstanceOf(\Magento\Framework\Option\ArrayInterface::class, $this->mobileChannels);
     }
 }

--- a/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
+++ b/Test/Unit/Observer/SaveOrderMarketingConsentTest.php
@@ -1,503 +1,311 @@
 <?php
 
-/**
- * Stub Magento\Framework\Event\Observer and related classes so the observer can load
- * without the full Magento framework installed.
- */
+namespace Klaviyo\Reclaim\Test\Unit\Observer;
 
-namespace Magento\Framework\Event {
-    if (!class_exists(\Magento\Framework\Event\Observer::class, false)) {
-        class Observer
-        {
-            public function getEvent()
-            {
-                return new Event();
+use PHPUnit\Framework\TestCase;
+use Klaviyo\Reclaim\Helper\Logger;
+use Klaviyo\Reclaim\Helper\ScopeSetting;
+use Klaviyo\Reclaim\KlaviyoV3Sdk\KlaviyoV3Api;
+use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoApiException;
+use Klaviyo\Reclaim\Observer\SaveOrderMarketingConsent;
+use Klaviyo\Reclaim\Test\Unit\Observer\Stubs\StubAddress;
+use Klaviyo\Reclaim\Test\Unit\Observer\Stubs\StubEvent;
+use Klaviyo\Reclaim\Test\Unit\Observer\Stubs\StubObserver;
+use Klaviyo\Reclaim\Test\Unit\Observer\Stubs\StubOrder;
+use Klaviyo\Reclaim\Test\Unit\Observer\Stubs\StubQuote;
+use Klaviyo\Reclaim\Test\Unit\Observer\Stubs\TestableSaveOrderMarketingConsent;
+use Klaviyo\Reclaim\Util\PhoneFormatter;
+
+class SaveOrderMarketingConsentTest extends TestCase
+{
+    private function makeMagentoObserver($mobileConsent, $emailConsent, $storeId = 1, $phone = '(202) 555-0100', $country = 'US')
+    {
+        $order = new StubOrder();
+        $address = new StubAddress($phone, $country);
+        $quote = new StubQuote($mobileConsent, $emailConsent, $storeId, 'buyer@example.com', $address);
+        $event = new StubEvent($order, $quote);
+        return new StubObserver($event);
+    }
+
+    private function makeScopeMock($mobileActive, $emailActive, array $channels)
+    {
+        $mock = $this->getMockBuilder(ScopeSetting::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mock->method('getMobileConsentIsActive')->willReturn($mobileActive ? '1' : null);
+        $mock->method('getConsentAtCheckoutEmailIsActive')->willReturn($emailActive ? '1' : null);
+        $mock->method('getMobileConsentListId')->willReturn('mobile-list-id');
+        $mock->method('getConsentAtCheckoutEmailListId')->willReturn('email-list-id');
+        $mock->method('getMobileConsentChannels')->willReturn($channels);
+        $channelsCopy = $channels;
+        $mock->method('isMobileChannelEnabled')->willReturnCallback(
+            function ($storeId, $channel) use ($channelsCopy) {
+                return in_array($channel, $channelsCopy, true);
             }
-        }
+        );
+        $mock->method('getPublicApiKey')->willReturn('pk');
+        $mock->method('getPrivateApiKey')->willReturn('sk');
+        return $mock;
     }
-    if (!class_exists(\Magento\Framework\Event\Event::class, false)) {
-        class Event
-        {
-            public function getOrder()
-            {
-                return null;
-            }
-            public function getQuote()
-            {
-                return null;
-            }
-        }
-    }
-    if (!interface_exists(\Magento\Framework\Event\ObserverInterface::class, false)) {
-        interface ObserverInterface
-        {
-            public function execute(Observer $observer);
-        }
-    }
-}
 
-/**
- * Stub Magento\Framework\App\Helper\AbstractHelper so ScopeSetting can load.
- */
-namespace Magento\Framework\App\Helper {
-    if (!class_exists(\Magento\Framework\App\Helper\AbstractHelper::class, false)) {
-        abstract class AbstractHelper
-        {
-            public function __construct($context = null)
-            {
-            }
-        }
-    }
-}
-
-namespace Klaviyo\Reclaim\Test\Unit\Observer {
-
-    use PHPUnit\Framework\TestCase;
-    use Klaviyo\Reclaim\Helper\Logger;
-    use Klaviyo\Reclaim\Helper\ScopeSetting;
-    use Klaviyo\Reclaim\KlaviyoV3Sdk\KlaviyoV3Api;
-    use Klaviyo\Reclaim\KlaviyoV3Sdk\Exception\KlaviyoApiException;
-    use Klaviyo\Reclaim\Observer\SaveOrderMarketingConsent;
-    use Klaviyo\Reclaim\Util\PhoneFormatter;
-    use Magento\Framework\Event\Observer;
-
-    /**
-     * Testable subclass that replaces buildKlaviyoV3Api() with an injected mock.
-     */
-    class TestableSaveOrderMarketingConsent extends SaveOrderMarketingConsent
+    private function makeLoggerMock()
     {
-        private $apiMock;
-
-        public function __construct(Logger $logger, ScopeSetting $scopeSetting, PhoneFormatter $phoneFormatter, KlaviyoV3Api $apiMock)
-        {
-            parent::__construct($logger, $scopeSetting, $phoneFormatter);
-            $this->apiMock = $apiMock;
-        }
-
-        protected function buildKlaviyoV3Api($storeId = null): KlaviyoV3Api
-        {
-            return $this->apiMock;
-        }
+        return $this->getMockBuilder(Logger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
-    /**
-     * Stub order that captures setData calls.
-     */
-    class StubOrder
+    private function makeApiMock()
     {
-        public $data = [];
-
-        public function setData($key, $value)
-        {
-            $this->data[$key] = $value;
-        }
+        return $this->getMockBuilder(KlaviyoV3Api::class)
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
-    /**
-     * Stub shipping address.
-     */
-    class StubAddress
+    public function test_sms_only_enabled_mobile_consent_true_subscribe_has_sms_key_not_whatsapp()
     {
-        private $phone;
-        private $countryId;
+        $scope = $this->makeScopeMock(true, false, ['sms']);
+        $api = $this->makeApiMock();
+        $magentoObserver = $this->makeMagentoObserver('1', null);
 
-        public function __construct($phone, $countryId = 'US')
-        {
-            $this->phone = $phone;
-            $this->countryId = $countryId;
-        }
-
-        public function getTelephone()
-        {
-            return $this->phone;
-        }
-
-        public function getCountryId()
-        {
-            return $this->countryId;
-        }
-    }
-
-    /**
-     * Stub quote.
-     */
-    class StubQuote
-    {
-        private $mobileConsent;
-        private $emailConsent;
-        private $storeId;
-        private $customerEmail;
-        private $address;
-
-        public function __construct($mobileConsent, $emailConsent, $storeId, $customerEmail, $address)
-        {
-            $this->mobileConsent = $mobileConsent;
-            $this->emailConsent = $emailConsent;
-            $this->storeId = $storeId;
-            $this->customerEmail = $customerEmail;
-            $this->address = $address;
-        }
-
-        public function getKlSmsConsent()
-        {
-            return $this->mobileConsent;
-        }
-
-        public function getKlEmailConsent()
-        {
-            return $this->emailConsent;
-        }
-
-        public function getStoreId()
-        {
-            return $this->storeId;
-        }
-
-        public function getCustomerEmail()
-        {
-            return $this->customerEmail;
-        }
-
-        public function getShippingAddress()
-        {
-            return $this->address;
-        }
-    }
-
-    /**
-     * Stub event that holds order and quote.
-     */
-    class StubEvent extends \Magento\Framework\Event\Event
-    {
-        private $order;
-        private $quote;
-
-        public function __construct($order, $quote)
-        {
-            $this->order = $order;
-            $this->quote = $quote;
-        }
-
-        public function getOrder()
-        {
-            return $this->order;
-        }
-
-        public function getQuote()
-        {
-            return $this->quote;
-        }
-    }
-
-    /**
-     * Stub observer that holds a stub event.
-     */
-    class StubObserver extends Observer
-    {
-        private $event;
-
-        public function __construct($event)
-        {
-            $this->event = $event;
-        }
-
-        public function getEvent()
-        {
-            return $this->event;
-        }
-    }
-
-    class SaveOrderMarketingConsentTest extends TestCase
-    {
-        private function makeMagentoObserver($mobileConsent, $emailConsent, $storeId = 1, $phone = '(202) 555-0100', $country = 'US')
-        {
-            $order = new StubOrder();
-            $address = new StubAddress($phone, $country);
-            $quote = new StubQuote($mobileConsent, $emailConsent, $storeId, 'buyer@example.com', $address);
-            $event = new StubEvent($order, $quote);
-            return new StubObserver($event);
-        }
-
-        private function makeScopeMock($mobileActive, $emailActive, array $channels)
-        {
-            $mock = $this->getMockBuilder(ScopeSetting::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $mock->method('getMobileConsentIsActive')->willReturn($mobileActive ? '1' : null);
-            $mock->method('getConsentAtCheckoutEmailIsActive')->willReturn($emailActive ? '1' : null);
-            $mock->method('getMobileConsentListId')->willReturn('mobile-list-id');
-            $mock->method('getConsentAtCheckoutEmailListId')->willReturn('email-list-id');
-            $mock->method('getMobileConsentChannels')->willReturn($channels);
-            $channelsCopy = $channels;
-            $mock->method('isMobileChannelEnabled')->willReturnCallback(
-                function ($storeId, $channel) use ($channelsCopy) {
-                    return in_array($channel, $channelsCopy, true);
-                }
+        $capturedProfiles = null;
+        $api->expects($this->once())
+            ->method('subscribeMembersToList')
+            ->with(
+                'mobile-list-id',
+                $this->callback(function ($profiles) use (&$capturedProfiles) {
+                    $capturedProfiles = $profiles;
+                    return true;
+                })
             );
-            $mock->method('getPublicApiKey')->willReturn('pk');
-            $mock->method('getPrivateApiKey')->willReturn('sk');
-            return $mock;
+
+        $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+        $observer->execute($magentoObserver);
+
+        $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
+        $this->assertArrayHasKey('sms', $subscriptions);
+        $this->assertArrayNotHasKey('whatsapp', $subscriptions);
+    }
+
+    public function test_whatsapp_only_enabled_mobile_consent_true_subscribe_has_whatsapp_key_not_sms()
+    {
+        $scope = $this->makeScopeMock(true, false, ['whatsapp']);
+        $api = $this->makeApiMock();
+        $magentoObserver = $this->makeMagentoObserver('1', null);
+
+        $capturedProfiles = null;
+        $api->expects($this->once())
+            ->method('subscribeMembersToList')
+            ->with(
+                'mobile-list-id',
+                $this->callback(function ($profiles) use (&$capturedProfiles) {
+                    $capturedProfiles = $profiles;
+                    return true;
+                })
+            );
+
+        $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+        $observer->execute($magentoObserver);
+
+        $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
+        $this->assertArrayHasKey('whatsapp', $subscriptions);
+        $this->assertArrayNotHasKey('sms', $subscriptions);
+    }
+
+    public function test_both_channels_enabled_mobile_consent_true_two_separate_subscribe_calls()
+    {
+        $scope = $this->makeScopeMock(true, false, ['sms', 'whatsapp']);
+        $api = $this->makeApiMock();
+        $magentoObserver = $this->makeMagentoObserver('1', null);
+
+        $calls = [];
+        $api->expects($this->exactly(2))
+            ->method('subscribeMembersToList')
+            ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
+                $calls[] = ['listId' => $listId, 'profiles' => $profiles];
+            });
+
+        $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+        $observer->execute($magentoObserver);
+
+        $this->assertCount(2, $calls);
+        // Both calls go to the same mobile list.
+        $this->assertSame('mobile-list-id', $calls[0]['listId']);
+        $this->assertSame('mobile-list-id', $calls[1]['listId']);
+
+        // Each call carries exactly one channel in its subscriptions payload.
+        $sub0 = $calls[0]['profiles'][0]['attributes']['subscriptions'];
+        $sub1 = $calls[1]['profiles'][0]['attributes']['subscriptions'];
+        $this->assertArrayHasKey('sms', $sub0);
+        $this->assertArrayNotHasKey('whatsapp', $sub0);
+        $this->assertSame('SUBSCRIBED', $sub0['sms']['marketing']['consent']);
+        $this->assertArrayHasKey('whatsapp', $sub1);
+        $this->assertArrayNotHasKey('sms', $sub1);
+        $this->assertSame('SUBSCRIBED', $sub1['whatsapp']['marketing']['consent']);
+    }
+
+    public function test_email_only_mobile_consent_false_subscribe_called_once_with_email_key_no_mobile()
+    {
+        $scope = $this->makeScopeMock(false, true, []);
+        $api = $this->makeApiMock();
+        $magentoObserver = $this->makeMagentoObserver(null, '1');
+
+        $capturedListId = null;
+        $capturedProfiles = null;
+        $api->expects($this->once())
+            ->method('subscribeMembersToList')
+            ->with(
+                $this->callback(function ($listId) use (&$capturedListId) {
+                    $capturedListId = $listId;
+                    return true;
+                }),
+                $this->callback(function ($profiles) use (&$capturedProfiles) {
+                    $capturedProfiles = $profiles;
+                    return true;
+                })
+            );
+
+        $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+        $observer->execute($magentoObserver);
+
+        $this->assertSame('email-list-id', $capturedListId);
+        $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
+        $this->assertArrayHasKey('email', $subscriptions);
+        $this->assertArrayNotHasKey('sms', $subscriptions);
+        $this->assertArrayNotHasKey('whatsapp', $subscriptions);
+    }
+
+    public function test_email_and_mobile_both_consents_true_three_subscribe_calls_one_per_channel()
+    {
+        $scope = $this->makeScopeMock(true, true, ['sms', 'whatsapp']);
+        $api = $this->makeApiMock();
+        $magentoObserver = $this->makeMagentoObserver('1', '1');
+
+        $calls = [];
+        $api->expects($this->exactly(3))
+            ->method('subscribeMembersToList')
+            ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
+                $calls[] = ['listId' => $listId, 'profiles' => $profiles];
+            });
+
+        $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+        $observer->execute($magentoObserver);
+
+        $this->assertCount(3, $calls);
+
+        // Partition calls by what they target.
+        $emailCalls = [];
+        $smsCalls = [];
+        $whatsappCalls = [];
+        foreach ($calls as $call) {
+            $subs = $call['profiles'][0]['attributes']['subscriptions'];
+            if (array_key_exists('email', $subs)) {
+                $emailCalls[] = $call;
+            } elseif (array_key_exists('sms', $subs)) {
+                $smsCalls[] = $call;
+            } elseif (array_key_exists('whatsapp', $subs)) {
+                $whatsappCalls[] = $call;
+            }
         }
 
-        private function makeLoggerMock()
-        {
-            return $this->getMockBuilder(Logger::class)
-                ->disableOriginalConstructor()
-                ->getMock();
+        $this->assertCount(1, $emailCalls, 'Expected exactly one email subscribe call');
+        $this->assertCount(1, $smsCalls, 'Expected exactly one sms subscribe call');
+        $this->assertCount(1, $whatsappCalls, 'Expected exactly one whatsapp subscribe call');
+
+        $this->assertSame('email-list-id', $emailCalls[0]['listId']);
+        $this->assertSame('mobile-list-id', $smsCalls[0]['listId']);
+        $this->assertSame('mobile-list-id', $whatsappCalls[0]['listId']);
+    }
+
+    public function test_no_webhook_call_constructor_does_not_accept_webhook_parameter()
+    {
+        $reflection = new \ReflectionClass(SaveOrderMarketingConsent::class);
+        $constructor = $reflection->getConstructor();
+        $paramTypes = [];
+        foreach ($constructor->getParameters() as $param) {
+            $type = $param->getType();
+            $paramTypes[] = $type ? $type->getName() : '';
         }
+        $this->assertNotContains('Klaviyo\Reclaim\Helper\Webhook', $paramTypes);
+        $this->assertCount(3, $constructor->getParameters());
+    }
 
-        private function makeApiMock()
-        {
-            return $this->getMockBuilder(KlaviyoV3Api::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-        }
+    public function test_v3_error_does_not_fail_order_execute_returns_observer()
+    {
+        $scope = $this->makeScopeMock(true, false, ['sms']);
+        $api = $this->makeApiMock();
+        $magentoObserver = $this->makeMagentoObserver('1', null);
 
-        public function test_sms_only_enabled_mobile_consent_true_subscribe_has_sms_key_not_whatsapp()
-        {
-            $scope = $this->makeScopeMock(true, false, ['sms']);
-            $api = $this->makeApiMock();
-            $magentoObserver = $this->makeMagentoObserver('1', null);
+        $api->method('subscribeMembersToList')
+            ->willThrowException(new KlaviyoApiException('V3 error'));
 
-            $capturedProfiles = null;
-            $api->expects($this->once())
-                ->method('subscribeMembersToList')
-                ->with(
-                    'mobile-list-id',
-                    $this->callback(function ($profiles) use (&$capturedProfiles) {
-                        $capturedProfiles = $profiles;
-                        return true;
-                    })
-                );
+        $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+        $result = $observer->execute($magentoObserver);
+        $this->assertSame($observer, $result);
+    }
 
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
-            $observer->execute($magentoObserver);
+    public function test_mobile_consent_phone_unparseable_skips_mobile_subscribe_call()
+    {
+        $scope = $this->makeScopeMock(true, false, ['sms']);
+        $api = $this->makeApiMock();
+        $magentoObserver = $this->makeMagentoObserver('1', null, 1, 'not-a-number', 'US');
 
-            $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
-            $this->assertArrayHasKey('sms', $subscriptions);
-            $this->assertArrayNotHasKey('whatsapp', $subscriptions);
-        }
+        $api->expects($this->never())->method('subscribeMembersToList');
 
-        public function test_whatsapp_only_enabled_mobile_consent_true_subscribe_has_whatsapp_key_not_sms()
-        {
-            $scope = $this->makeScopeMock(true, false, ['whatsapp']);
-            $api = $this->makeApiMock();
-            $magentoObserver = $this->makeMagentoObserver('1', null);
+        $logger = $this->makeLoggerMock();
+        $logger->expects($this->atLeastOnce())
+            ->method('log')
+            ->with($this->stringContains('Mobile subscribe skipped'));
 
-            $capturedProfiles = null;
-            $api->expects($this->once())
-                ->method('subscribeMembersToList')
-                ->with(
-                    'mobile-list-id',
-                    $this->callback(function ($profiles) use (&$capturedProfiles) {
-                        $capturedProfiles = $profiles;
-                        return true;
-                    })
-                );
+        $observer = new TestableSaveOrderMarketingConsent($logger, $scope, new PhoneFormatter(), $api);
+        $observer->execute($magentoObserver);
+    }
 
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
-            $observer->execute($magentoObserver);
+    public function test_email_consent_unaffected_by_mobile_phone_failure()
+    {
+        $scope = $this->makeScopeMock(true, true, ['sms']);
+        $api = $this->makeApiMock();
+        $magentoObserver = $this->makeMagentoObserver('1', '1', 1, 'not-a-number', 'US');
 
-            $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
-            $this->assertArrayHasKey('whatsapp', $subscriptions);
-            $this->assertArrayNotHasKey('sms', $subscriptions);
-        }
+        $calls = [];
+        $api->method('subscribeMembersToList')
+            ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
+                $calls[] = ['listId' => $listId, 'profiles' => $profiles];
+            });
 
-        public function test_both_channels_enabled_mobile_consent_true_two_separate_subscribe_calls()
-        {
-            $scope = $this->makeScopeMock(true, false, ['sms', 'whatsapp']);
-            $api = $this->makeApiMock();
-            $magentoObserver = $this->makeMagentoObserver('1', null);
+        $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+        $observer->execute($magentoObserver);
 
-            $calls = [];
-            $api->expects($this->exactly(2))
-                ->method('subscribeMembersToList')
-                ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
-                    $calls[] = ['listId' => $listId, 'profiles' => $profiles];
-                });
+        $this->assertCount(1, $calls, 'Only the email subscribe should fire when mobile phone is unparseable');
+        $this->assertSame('email-list-id', $calls[0]['listId']);
+    }
 
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
-            $observer->execute($magentoObserver);
+    public function test_both_channels_enabled_one_channel_failure_does_not_block_other_channel()
+    {
+        // Per-channel subscribe semantics: if the first call (sms) throws,
+        // the second call (whatsapp) must still fire.
+        $scope = $this->makeScopeMock(true, false, ['sms', 'whatsapp']);
+        $api = $this->makeApiMock();
+        $magentoObserver = $this->makeMagentoObserver('1', null);
 
-            $this->assertCount(2, $calls);
-            // Both calls go to the same mobile list.
-            $this->assertSame('mobile-list-id', $calls[0]['listId']);
-            $this->assertSame('mobile-list-id', $calls[1]['listId']);
-
-            // Each call carries exactly one channel in its subscriptions payload.
-            $sub0 = $calls[0]['profiles'][0]['attributes']['subscriptions'];
-            $sub1 = $calls[1]['profiles'][0]['attributes']['subscriptions'];
-            $this->assertArrayHasKey('sms', $sub0);
-            $this->assertArrayNotHasKey('whatsapp', $sub0);
-            $this->assertSame('SUBSCRIBED', $sub0['sms']['marketing']['consent']);
-            $this->assertArrayHasKey('whatsapp', $sub1);
-            $this->assertArrayNotHasKey('sms', $sub1);
-            $this->assertSame('SUBSCRIBED', $sub1['whatsapp']['marketing']['consent']);
-        }
-
-        public function test_email_only_mobile_consent_false_subscribe_called_once_with_email_key_no_mobile()
-        {
-            $scope = $this->makeScopeMock(false, true, []);
-            $api = $this->makeApiMock();
-            $magentoObserver = $this->makeMagentoObserver(null, '1');
-
-            $capturedListId = null;
-            $capturedProfiles = null;
-            $api->expects($this->once())
-                ->method('subscribeMembersToList')
-                ->with(
-                    $this->callback(function ($listId) use (&$capturedListId) {
-                        $capturedListId = $listId;
-                        return true;
-                    }),
-                    $this->callback(function ($profiles) use (&$capturedProfiles) {
-                        $capturedProfiles = $profiles;
-                        return true;
-                    })
-                );
-
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
-            $observer->execute($magentoObserver);
-
-            $this->assertSame('email-list-id', $capturedListId);
-            $subscriptions = $capturedProfiles[0]['attributes']['subscriptions'];
-            $this->assertArrayHasKey('email', $subscriptions);
-            $this->assertArrayNotHasKey('sms', $subscriptions);
-            $this->assertArrayNotHasKey('whatsapp', $subscriptions);
-        }
-
-        public function test_email_and_mobile_both_consents_true_three_subscribe_calls_one_per_channel()
-        {
-            $scope = $this->makeScopeMock(true, true, ['sms', 'whatsapp']);
-            $api = $this->makeApiMock();
-            $magentoObserver = $this->makeMagentoObserver('1', '1');
-
-            $calls = [];
-            $api->expects($this->exactly(3))
-                ->method('subscribeMembersToList')
-                ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
-                    $calls[] = ['listId' => $listId, 'profiles' => $profiles];
-                });
-
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
-            $observer->execute($magentoObserver);
-
-            $this->assertCount(3, $calls);
-
-            // Partition calls by what they target.
-            $emailCalls = [];
-            $smsCalls = [];
-            $whatsappCalls = [];
-            foreach ($calls as $call) {
-                $subs = $call['profiles'][0]['attributes']['subscriptions'];
-                if (array_key_exists('email', $subs)) {
-                    $emailCalls[] = $call;
-                } elseif (array_key_exists('sms', $subs)) {
-                    $smsCalls[] = $call;
-                } elseif (array_key_exists('whatsapp', $subs)) {
-                    $whatsappCalls[] = $call;
+        $calls = [];
+        $callCount = 0;
+        $api->method('subscribeMembersToList')
+            ->willReturnCallback(function ($listId, $profiles) use (&$calls, &$callCount) {
+                $callCount++;
+                $calls[] = ['listId' => $listId, 'profiles' => $profiles];
+                if ($callCount === 1) {
+                    throw new KlaviyoApiException('Simulated SMS subscribe failure');
                 }
-            }
+            });
 
-            $this->assertCount(1, $emailCalls, 'Expected exactly one email subscribe call');
-            $this->assertCount(1, $smsCalls, 'Expected exactly one sms subscribe call');
-            $this->assertCount(1, $whatsappCalls, 'Expected exactly one whatsapp subscribe call');
+        $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
+        $observer->execute($magentoObserver);
 
-            $this->assertSame('email-list-id', $emailCalls[0]['listId']);
-            $this->assertSame('mobile-list-id', $smsCalls[0]['listId']);
-            $this->assertSame('mobile-list-id', $whatsappCalls[0]['listId']);
-        }
-
-        public function test_no_webhook_call_constructor_does_not_accept_webhook_parameter()
-        {
-            $reflection = new \ReflectionClass(SaveOrderMarketingConsent::class);
-            $constructor = $reflection->getConstructor();
-            $paramTypes = [];
-            foreach ($constructor->getParameters() as $param) {
-                $type = $param->getType();
-                $paramTypes[] = $type ? $type->getName() : '';
-            }
-            $this->assertNotContains('Klaviyo\Reclaim\Helper\Webhook', $paramTypes);
-            $this->assertCount(3, $constructor->getParameters());
-        }
-
-        public function test_v3_error_does_not_fail_order_execute_returns_observer()
-        {
-            $scope = $this->makeScopeMock(true, false, ['sms']);
-            $api = $this->makeApiMock();
-            $magentoObserver = $this->makeMagentoObserver('1', null);
-
-            $api->method('subscribeMembersToList')
-                ->willThrowException(new KlaviyoApiException('V3 error'));
-
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
-            $result = $observer->execute($magentoObserver);
-            $this->assertSame($observer, $result);
-        }
-
-        public function test_mobile_consent_phone_unparseable_skips_mobile_subscribe_call()
-        {
-            $scope = $this->makeScopeMock(true, false, ['sms']);
-            $api = $this->makeApiMock();
-            $magentoObserver = $this->makeMagentoObserver('1', null, 1, 'not-a-number', 'US');
-
-            $api->expects($this->never())->method('subscribeMembersToList');
-
-            $logger = $this->makeLoggerMock();
-            $logger->expects($this->atLeastOnce())
-                ->method('log')
-                ->with($this->stringContains('Mobile subscribe skipped'));
-
-            $observer = new TestableSaveOrderMarketingConsent($logger, $scope, new PhoneFormatter(), $api);
-            $observer->execute($magentoObserver);
-        }
-
-        public function test_email_consent_unaffected_by_mobile_phone_failure()
-        {
-            $scope = $this->makeScopeMock(true, true, ['sms']);
-            $api = $this->makeApiMock();
-            $magentoObserver = $this->makeMagentoObserver('1', '1', 1, 'not-a-number', 'US');
-
-            $calls = [];
-            $api->method('subscribeMembersToList')
-                ->willReturnCallback(function ($listId, $profiles) use (&$calls) {
-                    $calls[] = ['listId' => $listId, 'profiles' => $profiles];
-                });
-
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
-            $observer->execute($magentoObserver);
-
-            $this->assertCount(1, $calls, 'Only the email subscribe should fire when mobile phone is unparseable');
-            $this->assertSame('email-list-id', $calls[0]['listId']);
-        }
-
-        public function test_both_channels_enabled_one_channel_failure_does_not_block_other_channel()
-        {
-            // Per-channel subscribe semantics: if the first call (sms) throws,
-            // the second call (whatsapp) must still fire.
-            $scope = $this->makeScopeMock(true, false, ['sms', 'whatsapp']);
-            $api = $this->makeApiMock();
-            $magentoObserver = $this->makeMagentoObserver('1', null);
-
-            $calls = [];
-            $callCount = 0;
-            $api->method('subscribeMembersToList')
-                ->willReturnCallback(function ($listId, $profiles) use (&$calls, &$callCount) {
-                    $callCount++;
-                    $calls[] = ['listId' => $listId, 'profiles' => $profiles];
-                    if ($callCount === 1) {
-                        throw new KlaviyoApiException('Simulated SMS subscribe failure');
-                    }
-                });
-
-            $observer = new TestableSaveOrderMarketingConsent($this->makeLoggerMock(), $scope, new PhoneFormatter(), $api);
-            $observer->execute($magentoObserver);
-
-            $this->assertCount(2, $calls, 'Second channel subscribe must still fire after first throws');
-            $subs1 = $calls[0]['profiles'][0]['attributes']['subscriptions'];
-            $subs2 = $calls[1]['profiles'][0]['attributes']['subscriptions'];
-            $this->assertArrayHasKey('sms', $subs1, 'First call should target sms (the one that throws)');
-            $this->assertArrayHasKey('whatsapp', $subs2, 'Second call should still target whatsapp despite first failure');
-        }
+        $this->assertCount(2, $calls, 'Second channel subscribe must still fire after first throws');
+        $subs1 = $calls[0]['profiles'][0]['attributes']['subscriptions'];
+        $subs2 = $calls[1]['profiles'][0]['attributes']['subscriptions'];
+        $this->assertArrayHasKey('sms', $subs1, 'First call should target sms (the one that throws)');
+        $this->assertArrayHasKey('whatsapp', $subs2, 'Second call should still target whatsapp despite first failure');
     }
 }

--- a/Test/Unit/Observer/Stubs/StubAddress.php
+++ b/Test/Unit/Observer/Stubs/StubAddress.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Klaviyo\Reclaim\Test\Unit\Observer\Stubs;
+
+/**
+ * Stub shipping address.
+ */
+class StubAddress
+{
+    private $phone;
+    private $countryId;
+
+    public function __construct($phone, $countryId = 'US')
+    {
+        $this->phone = $phone;
+        $this->countryId = $countryId;
+    }
+
+    public function getTelephone()
+    {
+        return $this->phone;
+    }
+
+    public function getCountryId()
+    {
+        return $this->countryId;
+    }
+}

--- a/Test/Unit/Observer/Stubs/StubEvent.php
+++ b/Test/Unit/Observer/Stubs/StubEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Klaviyo\Reclaim\Test\Unit\Observer\Stubs;
+
+/**
+ * Stub event that holds order and quote.
+ */
+class StubEvent extends \Magento\Framework\Event\Event
+{
+    private $order;
+    private $quote;
+
+    public function __construct($order, $quote)
+    {
+        $this->order = $order;
+        $this->quote = $quote;
+    }
+
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+    public function getQuote()
+    {
+        return $this->quote;
+    }
+}

--- a/Test/Unit/Observer/Stubs/StubObserver.php
+++ b/Test/Unit/Observer/Stubs/StubObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Klaviyo\Reclaim\Test\Unit\Observer\Stubs;
+
+use Magento\Framework\Event\Observer;
+
+/**
+ * Stub observer that holds a stub event.
+ */
+class StubObserver extends Observer
+{
+    private $event;
+
+    public function __construct($event)
+    {
+        $this->event = $event;
+    }
+
+    public function getEvent()
+    {
+        return $this->event;
+    }
+}

--- a/Test/Unit/Observer/Stubs/StubOrder.php
+++ b/Test/Unit/Observer/Stubs/StubOrder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Klaviyo\Reclaim\Test\Unit\Observer\Stubs;
+
+/**
+ * Stub order that captures setData calls.
+ */
+class StubOrder
+{
+    public $data = [];
+
+    public function setData($key, $value)
+    {
+        $this->data[$key] = $value;
+    }
+}

--- a/Test/Unit/Observer/Stubs/StubQuote.php
+++ b/Test/Unit/Observer/Stubs/StubQuote.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Klaviyo\Reclaim\Test\Unit\Observer\Stubs;
+
+/**
+ * Stub quote.
+ */
+class StubQuote
+{
+    private $mobileConsent;
+    private $emailConsent;
+    private $storeId;
+    private $customerEmail;
+    private $address;
+
+    public function __construct($mobileConsent, $emailConsent, $storeId, $customerEmail, $address)
+    {
+        $this->mobileConsent = $mobileConsent;
+        $this->emailConsent = $emailConsent;
+        $this->storeId = $storeId;
+        $this->customerEmail = $customerEmail;
+        $this->address = $address;
+    }
+
+    public function getKlSmsConsent()
+    {
+        return $this->mobileConsent;
+    }
+
+    public function getKlEmailConsent()
+    {
+        return $this->emailConsent;
+    }
+
+    public function getStoreId()
+    {
+        return $this->storeId;
+    }
+
+    public function getCustomerEmail()
+    {
+        return $this->customerEmail;
+    }
+
+    public function getShippingAddress()
+    {
+        return $this->address;
+    }
+}

--- a/Test/Unit/Observer/Stubs/TestableSaveOrderMarketingConsent.php
+++ b/Test/Unit/Observer/Stubs/TestableSaveOrderMarketingConsent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Klaviyo\Reclaim\Test\Unit\Observer\Stubs;
+
+use Klaviyo\Reclaim\Helper\Logger;
+use Klaviyo\Reclaim\Helper\ScopeSetting;
+use Klaviyo\Reclaim\KlaviyoV3Sdk\KlaviyoV3Api;
+use Klaviyo\Reclaim\Observer\SaveOrderMarketingConsent;
+use Klaviyo\Reclaim\Util\PhoneFormatter;
+
+/**
+ * Testable subclass that replaces buildKlaviyoV3Api() with an injected mock.
+ */
+class TestableSaveOrderMarketingConsent extends SaveOrderMarketingConsent
+{
+    private $apiMock;
+
+    public function __construct(Logger $logger, ScopeSetting $scopeSetting, PhoneFormatter $phoneFormatter, KlaviyoV3Api $apiMock)
+    {
+        parent::__construct($logger, $scopeSetting, $phoneFormatter);
+        $this->apiMock = $apiMock;
+    }
+
+    protected function buildKlaviyoV3Api($storeId = null): KlaviyoV3Api
+    {
+        return $this->apiMock;
+    }
+}

--- a/Test/Unit/Plugin/CheckoutLayoutPluginTest.php
+++ b/Test/Unit/Plugin/CheckoutLayoutPluginTest.php
@@ -1,104 +1,31 @@
 <?php
 
-/**
- * Stub Magento\Framework\App\Helper\AbstractHelper so ScopeSetting can be loaded/mocked
- * without the full Magento framework installed in the test environment.
- */
+namespace Klaviyo\Reclaim\Test\Unit\Plugin;
 
-namespace Magento\Framework\App\Helper {
-    if (!class_exists(\Magento\Framework\App\Helper\AbstractHelper::class, false)) {
-        abstract class AbstractHelper
-        {
-            public function __construct($context = null)
-            {
-            }
-        }
-    }
-}
+use PHPUnit\Framework\TestCase;
+use Klaviyo\Reclaim\Plugin\CheckoutLayoutPlugin;
+use Klaviyo\Reclaim\Helper\ScopeSetting;
+use Magento\Customer\Model\Customer;
+use Magento\Customer\Model\CustomerFactory;
+use Magento\Customer\Model\Session;
+use Magento\Checkout\Block\Checkout\LayoutProcessor;
 
-/**
- * Stub Magento Customer classes used by CheckoutLayoutPlugin.
- */
-namespace Magento\Customer\Model {
-    if (!class_exists(\Magento\Customer\Model\Session::class, false)) {
-        class Session
-        {
-            public function isLoggedIn(): bool
-            {
-                return false;
-            }
-            public function getCustomer()
-            {
-                return null;
-            }
-        }
-    }
-    if (!class_exists(\Magento\Customer\Model\Customer::class, false)) {
-        class Customer
-        {
-            public function getData(): array
-            {
-                return [];
-            }
-            public function load($id): self
-            {
-                return $this;
-            }
-            public function getDefaultShippingAddress()
-            {
-                return false;
-            }
-        }
-    }
-    if (!class_exists(\Magento\Customer\Model\CustomerFactory::class, false)) {
-        class CustomerFactory
-        {
-            public function create(): Customer
-            {
-                return new Customer();
-            }
-        }
-    }
-}
-
-/**
- * Stub the LayoutProcessor subject class.
- */
-namespace Magento\Checkout\Block\Checkout {
-    if (!class_exists(\Magento\Checkout\Block\Checkout\LayoutProcessor::class, false)) {
-        class LayoutProcessor
-        {
-        }
-    }
-}
-
-namespace Klaviyo\Reclaim\Test\Unit\Plugin {
-
-    use PHPUnit\Framework\TestCase;
-    use Klaviyo\Reclaim\Plugin\CheckoutLayoutPlugin;
-    use Klaviyo\Reclaim\Helper\ScopeSetting;
-    use Magento\Customer\Model\Customer;
-    use Magento\Customer\Model\CustomerFactory;
-    use Magento\Customer\Model\Session;
-    use Magento\Checkout\Block\Checkout\LayoutProcessor;
-
-    class CheckoutLayoutPluginTest extends TestCase
+class CheckoutLayoutPluginTest extends TestCase
+{
+    private function buildBaseJsLayout(): array
     {
-        private function buildBaseJsLayout(): array
-        {
-            return [
-                'components' => [
-                    'checkout' => [
-                        'children' => [
-                            'steps' => [
-                                'children' => [
-                                    'shipping-step' => [
-                                        'children' => [
-                                            'shippingAddress' => [
-                                                'children' => [
-                                                    'shipping-address-fieldset' => ['children' => []],
-                                                    'before-form' => ['children' => []],
-                                                ],
+        return [
+            'components' => [
+                'checkout' => [
+                    'children' => [
+                        'steps' => [
+                            'children' => [
+                                'shipping-step' => [
+                                    'children' => [
+                                        'shippingAddress' => [
+                                            'children' => [
+                                                'shipping-address-fieldset' => ['children' => []],
+                                                'before-form' => ['children' => []],
                                             ],
                                         ],
                                     ],
@@ -107,87 +34,87 @@ namespace Klaviyo\Reclaim\Test\Unit\Plugin {
                         ],
                     ],
                 ],
-            ];
-        }
+            ],
+        ];
+    }
 
-        private function makeScopeMock(bool $mobileActive): ScopeSetting
-        {
-            $mock = $this->getMockBuilder(ScopeSetting::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $mock->method('getMobileConsentIsActive')->willReturn($mobileActive ? '1' : null);
-            $mock->method('getMobileConsentLabelText')->willReturn('Mobile Label');
-            $mock->method('getMobileConsentText')->willReturn('Mobile Description');
-            $mock->method('getMobileConsentSortOrder')->willReturn('100');
-            $mock->method('getConsentAtCheckoutEmailIsActive')->willReturn(null);
-            return $mock;
-        }
+    private function makeScopeMock(bool $mobileActive): ScopeSetting
+    {
+        $mock = $this->getMockBuilder(ScopeSetting::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mock->method('getMobileConsentIsActive')->willReturn($mobileActive ? '1' : null);
+        $mock->method('getMobileConsentLabelText')->willReturn('Mobile Label');
+        $mock->method('getMobileConsentText')->willReturn('Mobile Description');
+        $mock->method('getMobileConsentSortOrder')->willReturn('100');
+        $mock->method('getConsentAtCheckoutEmailIsActive')->willReturn(null);
+        return $mock;
+    }
 
-        public function test_afterProcess_mobile_inactive_no_consent_key_in_fieldset()
-        {
-            $scope = $this->makeScopeMock(false);
-            $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
-            $session->method('isLoggedIn')->willReturn(false);
-            $factory = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()->getMock();
+    public function test_afterProcess_mobile_inactive_no_consent_key_in_fieldset()
+    {
+        $scope = $this->makeScopeMock(false);
+        $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+        $session->method('isLoggedIn')->willReturn(false);
+        $factory = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()->getMock();
 
-            $plugin = new CheckoutLayoutPlugin($scope, $session, $factory);
-            $result = $plugin->afterProcess($this->createMock(LayoutProcessor::class), $this->buildBaseJsLayout());
+        $plugin = new CheckoutLayoutPlugin($scope, $session, $factory);
+        $result = $plugin->afterProcess($this->createMock(LayoutProcessor::class), $this->buildBaseJsLayout());
 
-            $fieldset = $result['components']['checkout']['children']['steps']['children']
-                ['shipping-step']['children']['shippingAddress']['children']
-                ['shipping-address-fieldset']['children'];
-            $this->assertArrayNotHasKey('kl_sms_consent', $fieldset);
-        }
+        $fieldset = $result['components']['checkout']['children']['steps']['children']
+            ['shipping-step']['children']['shippingAddress']['children']
+            ['shipping-address-fieldset']['children'];
+        $this->assertArrayNotHasKey('kl_sms_consent', $fieldset);
+    }
 
-        public function test_afterProcess_mobile_active_no_default_address_adds_kl_sms_consent_to_fieldset()
-        {
-            $scope = $this->makeScopeMock(true);
-            $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
-            $session->method('isLoggedIn')->willReturn(false);
-            $factory = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()->getMock();
+    public function test_afterProcess_mobile_active_no_default_address_adds_kl_sms_consent_to_fieldset()
+    {
+        $scope = $this->makeScopeMock(true);
+        $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+        $session->method('isLoggedIn')->willReturn(false);
+        $factory = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()->getMock();
 
-            $plugin = new CheckoutLayoutPlugin($scope, $session, $factory);
-            $result = $plugin->afterProcess($this->createMock(LayoutProcessor::class), $this->buildBaseJsLayout());
+        $plugin = new CheckoutLayoutPlugin($scope, $session, $factory);
+        $result = $plugin->afterProcess($this->createMock(LayoutProcessor::class), $this->buildBaseJsLayout());
 
-            $fieldset = $result['components']['checkout']['children']['steps']['children']
-                ['shipping-step']['children']['shippingAddress']['children']
-                ['shipping-address-fieldset']['children'];
-            $this->assertArrayHasKey('kl_sms_consent', $fieldset);
-            $this->assertSame('kl_sms_consent', $fieldset['kl_sms_consent']['config']['id']);
-            $this->assertStringContainsString('kl_sms_consent', $fieldset['kl_sms_consent']['dataScope']);
-        }
+        $fieldset = $result['components']['checkout']['children']['steps']['children']
+            ['shipping-step']['children']['shippingAddress']['children']
+            ['shipping-address-fieldset']['children'];
+        $this->assertArrayHasKey('kl_sms_consent', $fieldset);
+        $this->assertSame('kl_sms_consent', $fieldset['kl_sms_consent']['config']['id']);
+        $this->assertStringContainsString('kl_sms_consent', $fieldset['kl_sms_consent']['dataScope']);
+    }
 
-        public function test_afterProcess_mobile_active_with_default_address_adds_mobile_consent_and_phone_to_before_form()
-        {
-            $scope = $this->makeScopeMock(true);
+    public function test_afterProcess_mobile_active_with_default_address_adds_mobile_consent_and_phone_to_before_form()
+    {
+        $scope = $this->makeScopeMock(true);
 
-            $addressStub = new class {
-                public function getTelephone(): string
-                {
-                    return '555-1234';
-                }
-            };
+        $addressStub = new class {
+            public function getTelephone(): string
+            {
+                return '555-1234';
+            }
+        };
 
-            $customerMock = $this->getMockBuilder(Customer::class)->disableOriginalConstructor()->getMock();
-            $customerMock->method('getData')->willReturn(['entity_id' => 42]);
-            $customerMock->method('load')->willReturnSelf();
-            $customerMock->method('getDefaultShippingAddress')->willReturn($addressStub);
+        $customerMock = $this->getMockBuilder(Customer::class)->disableOriginalConstructor()->getMock();
+        $customerMock->method('getData')->willReturn(['entity_id' => 42]);
+        $customerMock->method('load')->willReturnSelf();
+        $customerMock->method('getDefaultShippingAddress')->willReturn($addressStub);
 
-            $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
-            $session->method('isLoggedIn')->willReturn(true);
-            $session->method('getCustomer')->willReturn($customerMock);
+        $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+        $session->method('isLoggedIn')->willReturn(true);
+        $session->method('getCustomer')->willReturn($customerMock);
 
-            $factory = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()->getMock();
-            $factory->method('create')->willReturn($customerMock);
+        $factory = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()->getMock();
+        $factory->method('create')->willReturn($customerMock);
 
-            $plugin = new CheckoutLayoutPlugin($scope, $session, $factory);
-            $result = $plugin->afterProcess($this->createMock(LayoutProcessor::class), $this->buildBaseJsLayout());
+        $plugin = new CheckoutLayoutPlugin($scope, $session, $factory);
+        $result = $plugin->afterProcess($this->createMock(LayoutProcessor::class), $this->buildBaseJsLayout());
 
-            $beforeForm = $result['components']['checkout']['children']['steps']['children']
-                ['shipping-step']['children']['shippingAddress']['children']
-                ['before-form']['children'];
-            $this->assertArrayHasKey('kl_sms_consent', $beforeForm);
-            $this->assertArrayHasKey('kl_sms_phone_number', $beforeForm);
-        }
+        $beforeForm = $result['components']['checkout']['children']['steps']['children']
+            ['shipping-step']['children']['shippingAddress']['children']
+            ['before-form']['children'];
+        $this->assertArrayHasKey('kl_sms_consent', $beforeForm);
+        $this->assertArrayHasKey('kl_sms_phone_number', $beforeForm);
     }
 }

--- a/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
+++ b/Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php
@@ -2,291 +2,210 @@
 
 declare(strict_types=1);
 
-// Stub Magento framework interfaces so MigrateSmsToMobileConsent can load without the full Magento stack.
-namespace Magento\Framework\Setup\Patch {
-    if (!interface_exists(\Magento\Framework\Setup\Patch\DataPatchInterface::class)) {
-        interface DataPatchInterface
-        {
-            public function apply();
-            public function getAliases();
-            public static function getDependencies();
-        }
-    }
-    if (!interface_exists(\Magento\Framework\Setup\Patch\PatchVersionInterface::class)) {
-        interface PatchVersionInterface
-        {
-            public static function getVersion();
-        }
-    }
-}
+namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data;
 
-namespace Magento\Framework\Setup {
-    if (!interface_exists(\Magento\Framework\Setup\ModuleDataSetupInterface::class)) {
-        interface ModuleDataSetupInterface
-        {
-            public function getConnection();
-            public function getTable($tableName);
-            public function startSetup();
-            public function endSetup();
-        }
-    }
-}
+use Klaviyo\Reclaim\Setup\Patch\Data\MigrateSmsToMobileConsent;
+use Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data\Stubs\SelectStub;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use PHPUnit\Framework\TestCase;
 
-namespace Magento\Framework\DB {
-    if (!class_exists(\Magento\Framework\DB\Select::class)) {
-        class Select
-        {
-            public function from($table, $cols = '*')
-            {
-                return $this;
-            }
-            public function where($condition, $value = null)
-            {
-                return $this;
-            }
-        }
-    }
-}
-
-namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data\Stubs {
-    /**
-     * Query-builder shim used by the test mock. Cannot reuse
-     * Magento\Framework\DB\Select directly because the real Magento class
-     * (when autoloaded in a full Magento test environment) requires
-     * constructor args, which breaks the test stub instantiation.
-     */
-    class SelectStub
+class MigrateSmsToMobileConsentTest extends TestCase
+{
+    private function buildConnection(array $smsRows, bool $mobileRowExists): AdapterInterface
     {
-        public function from($table, $cols = '*')
-        {
-            return $this;
-        }
-        public function where($condition, $value = null)
-        {
-            return $this;
-        }
+        $selectStub = new SelectStub();
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->method('select')->willReturn($selectStub);
+        $connection->method('fetchAll')->willReturn($smsRows);
+        $connection->method('fetchOne')->willReturn($mobileRowExists ? '1' : false);
+        return $connection;
     }
-}
 
-namespace Magento\Framework\DB\Adapter {
-    if (!interface_exists(\Magento\Framework\DB\Adapter\AdapterInterface::class)) {
-        interface AdapterInterface
-        {
-            public function startSetup();
-            public function endSetup();
-            public function select();
-            public function fetchAll($select);
-            public function fetchOne($select);
-            public function insert($table, array $data);
-        }
-    }
-}
-
-namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data {
-
-    use Klaviyo\Reclaim\Setup\Patch\Data\MigrateSmsToMobileConsent;
-    use Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data\Stubs\SelectStub;
-    use Magento\Framework\DB\Adapter\AdapterInterface;
-    use Magento\Framework\Setup\ModuleDataSetupInterface;
-    use PHPUnit\Framework\TestCase;
-
-    class MigrateSmsToMobileConsentTest extends TestCase
+    private function buildPatch(AdapterInterface $connection): MigrateSmsToMobileConsent
     {
-        private function buildConnection(array $smsRows, bool $mobileRowExists): AdapterInterface
-        {
-            $selectStub = new SelectStub();
-            $connection = $this->createMock(AdapterInterface::class);
-            $connection->method('select')->willReturn($selectStub);
-            $connection->method('fetchAll')->willReturn($smsRows);
-            $connection->method('fetchOne')->willReturn($mobileRowExists ? '1' : false);
-            return $connection;
-        }
+        $setup = $this->createMock(ModuleDataSetupInterface::class);
+        $setup->method('getConnection')->willReturn($connection);
+        $setup->method('getTable')->willReturn('core_config_data');
+        return new MigrateSmsToMobileConsent($setup);
+    }
 
-        private function buildPatch(AdapterInterface $connection): MigrateSmsToMobileConsent
-        {
-            $setup = $this->createMock(ModuleDataSetupInterface::class);
-            $setup->method('getConnection')->willReturn($connection);
-            $setup->method('getTable')->willReturn('core_config_data');
-            return new MigrateSmsToMobileConsent($setup);
-        }
+    public function test_apply_writes_nothing_when_no_sms_rows_exist()
+    {
+        $connection = $this->buildConnection([], false);
+        $connection->expects($this->never())->method('insert');
+        $this->buildPatch($connection)->apply();
+    }
 
-        public function test_apply_writes_nothing_when_no_sms_rows_exist()
-        {
-            $connection = $this->buildConnection([], false);
-            $connection->expects($this->never())->method('insert');
-            $this->buildPatch($connection)->apply();
-        }
+    public function test_apply_inserts_mobile_consent_rows_including_channels_and_sms_backfill_when_sms_is_active_1()
+    {
+        $smsRows = [[
+            'scope' => 'default',
+            'scope_id' => '0',
+            'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
+            'value' => '1',
+        ]];
+        $connection = $this->buildConnection($smsRows, false);
+        // Expect 4 inserts: mobile_consent/is_active, /channels, /label_text, /consent_text
+        $connection->expects($this->exactly(4))->method('insert');
+        $this->buildPatch($connection)->apply();
+    }
 
-        public function test_apply_inserts_mobile_consent_rows_including_channels_and_sms_backfill_when_sms_is_active_1()
-        {
-            $smsRows = [[
-                'scope' => 'default',
-                'scope_id' => '0',
-                'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
-                'value' => '1',
-            ]];
-            $connection = $this->buildConnection($smsRows, false);
-            // Expect 4 inserts: mobile_consent/is_active, /channels, /label_text, /consent_text
-            $connection->expects($this->exactly(4))->method('insert');
-            $this->buildPatch($connection)->apply();
-        }
+    public function test_apply_seeds_sms_specific_label_and_consent_text_when_no_source_rows_exist()
+    {
+        $smsRows = [[
+            'scope' => 'default',
+            'scope_id' => '0',
+            'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
+            'value' => '1',
+        ]];
+        $connection = $this->buildConnection($smsRows, false);
+        $insertedPaths = [];
+        $insertedValues = [];
+        $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$insertedPaths, &$insertedValues) {
+            $insertedPaths[] = $data['path'];
+            $insertedValues[$data['path']] = $data['value'];
+        });
+        $this->buildPatch($connection)->apply();
 
-        public function test_apply_seeds_sms_specific_label_and_consent_text_when_no_source_rows_exist()
-        {
-            $smsRows = [[
-                'scope' => 'default',
-                'scope_id' => '0',
-                'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
-                'value' => '1',
-            ]];
-            $connection = $this->buildConnection($smsRows, false);
-            $insertedPaths = [];
-            $insertedValues = [];
-            $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$insertedPaths, &$insertedValues) {
-                $insertedPaths[] = $data['path'];
-                $insertedValues[$data['path']] = $data['value'];
-            });
-            $this->buildPatch($connection)->apply();
+        $this->assertContains('klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text', $insertedPaths);
+        $this->assertContains('klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text', $insertedPaths);
 
-            $this->assertContains('klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text', $insertedPaths);
-            $this->assertContains('klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text', $insertedPaths);
+        $this->assertStringContainsString(
+            'Exclusive text messaging-only',
+            $insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text']
+        );
+        $this->assertStringContainsString(
+            'marketing texts (e.g., cart reminders)',
+            $insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text']
+        );
+    }
 
-            $this->assertStringContainsString(
-                'Exclusive text messaging-only',
-                $insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text']
+    public function test_apply_does_not_insert_when_mobile_rows_already_exist()
+    {
+        $smsRows = [[
+            'scope' => 'default',
+            'scope_id' => '0',
+            'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
+            'value' => '1',
+        ]];
+        $connection = $this->buildConnection($smsRows, true);
+        $connection->expects($this->never())->method('insert');
+        $this->buildPatch($connection)->apply();
+    }
+
+    public function test_apply_handles_null_source_row_value_without_typeerror()
+    {
+        // core_config_data.value is nullable; strict_types=1 in the patch
+        // would crash setup:upgrade if seedIfMissing rejected null values.
+        $smsRows = [[
+            'scope' => 'default',
+            'scope_id' => '0',
+            'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/label_text',
+            'value' => null,
+        ]];
+        $connection = $this->buildConnection($smsRows, false);
+        $insertedValues = [];
+        $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$insertedValues) {
+            $insertedValues[$data['path']] = $data['value'];
+        });
+        $this->buildPatch($connection)->apply();
+
+        $this->assertArrayHasKey(
+            'klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text',
+            $insertedValues,
+            'Null-valued source rows must still be copied (with null preserved)'
+        );
+        $this->assertNull($insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text']);
+    }
+
+    public function test_apply_only_seeds_label_and_consent_defaults_at_default_scope_to_preserve_inheritance()
+    {
+        // Regression test for scope-inheritance breakage.
+        // Merchant had is_active=1 at a store scope and label_text customized
+        // at the default scope (inherited by the store). Previously pass 2
+        // seeded SMS_LABEL_DEFAULT at the store scope, explicitly overriding
+        // the inherited customization. Seeding only at the default scope
+        // lets Magento's scope-resolution chain deliver whatever value
+        // (custom or default) the parent scopes already provide.
+        $smsRows = [[
+            'scope' => 'stores',
+            'scope_id' => '1',
+            'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
+            'value' => '1',
+        ]];
+        $connection = $this->buildConnection($smsRows, false);
+        $insertedRows = [];
+        $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$insertedRows) {
+            $insertedRows[] = $data;
+        });
+        $this->buildPatch($connection)->apply();
+
+        $textPaths = [
+            'klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text',
+            'klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text',
+        ];
+        foreach ($insertedRows as $row) {
+            if (!in_array($row['path'], $textPaths, true)) {
+                continue;
+            }
+            $this->assertSame(
+                'default',
+                $row['scope'],
+                'label_text/consent_text defaults must only be seeded at default scope, not ' . $row['scope']
             );
-            $this->assertStringContainsString(
-                'marketing texts (e.g., cart reminders)',
-                $insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text']
+            $this->assertSame(
+                '0',
+                (string) $row['scope_id'],
+                'label_text/consent_text defaults must only be seeded at scope_id=0'
             );
         }
 
-        public function test_apply_does_not_insert_when_mobile_rows_already_exist()
-        {
-            $smsRows = [[
+        // Channels still seeded at the active scope (its own pre-migration semantics)
+        $channelsRows = array_values(array_filter($insertedRows, function ($r) {
+            return $r['path'] === 'klaviyo_reclaim_consent_at_checkout/mobile_consent/channels';
+        }));
+        $this->assertCount(1, $channelsRows);
+        $this->assertSame('stores', $channelsRows[0]['scope']);
+        $this->assertSame('1', (string) $channelsRows[0]['scope_id']);
+    }
+
+    public function test_apply_preserves_custom_label_text_when_is_active_iterated_before_label_text()
+    {
+        // Regression test for two-pass migration ordering.
+        // Merchant set is_active=1 first (lower config_id) and later
+        // customized label_text. Single-pass logic would have seeded the
+        // SMS default label_text during the is_active iteration before
+        // reaching the merchant's customized row, silently dropping the
+        // customization. Two-pass logic copies all source rows first, then
+        // backfills only what's still missing.
+        $smsRows = [
+            [
                 'scope' => 'default',
                 'scope_id' => '0',
                 'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
                 'value' => '1',
-            ]];
-            $connection = $this->buildConnection($smsRows, true);
-            $connection->expects($this->never())->method('insert');
-            $this->buildPatch($connection)->apply();
-        }
-
-        public function test_apply_handles_null_source_row_value_without_typeerror()
-        {
-            // core_config_data.value is nullable; strict_types=1 in the patch
-            // would crash setup:upgrade if seedIfMissing rejected null values.
-            $smsRows = [[
+            ],
+            [
                 'scope' => 'default',
                 'scope_id' => '0',
                 'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/label_text',
-                'value' => null,
-            ]];
-            $connection = $this->buildConnection($smsRows, false);
-            $insertedValues = [];
-            $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$insertedValues) {
-                $insertedValues[$data['path']] = $data['value'];
-            });
-            $this->buildPatch($connection)->apply();
-
-            $this->assertArrayHasKey(
-                'klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text',
-                $insertedValues,
-                'Null-valued source rows must still be copied (with null preserved)'
-            );
-            $this->assertNull($insertedValues['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text']);
-        }
-
-        public function test_apply_only_seeds_label_and_consent_defaults_at_default_scope_to_preserve_inheritance()
-        {
-            // Regression test for scope-inheritance breakage.
-            // Merchant had is_active=1 at a store scope and label_text customized
-            // at the default scope (inherited by the store). Previously pass 2
-            // seeded SMS_LABEL_DEFAULT at the store scope, explicitly overriding
-            // the inherited customization. Seeding only at the default scope
-            // lets Magento's scope-resolution chain deliver whatever value
-            // (custom or default) the parent scopes already provide.
-            $smsRows = [[
-                'scope' => 'stores',
-                'scope_id' => '1',
-                'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
-                'value' => '1',
-            ]];
-            $connection = $this->buildConnection($smsRows, false);
-            $insertedRows = [];
-            $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$insertedRows) {
-                $insertedRows[] = $data;
-            });
-            $this->buildPatch($connection)->apply();
-
-            $textPaths = [
-                'klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text',
-                'klaviyo_reclaim_consent_at_checkout/mobile_consent/consent_text',
-            ];
-            foreach ($insertedRows as $row) {
-                if (!in_array($row['path'], $textPaths, true)) {
-                    continue;
-                }
-                $this->assertSame(
-                    'default',
-                    $row['scope'],
-                    'label_text/consent_text defaults must only be seeded at default scope, not ' . $row['scope']
-                );
-                $this->assertSame(
-                    '0',
-                    (string) $row['scope_id'],
-                    'label_text/consent_text defaults must only be seeded at scope_id=0'
-                );
+                'value' => 'My Custom SMS Copy',
+            ],
+        ];
+        $connection = $this->buildConnection($smsRows, false);
+        $firstValueByPath = [];
+        $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$firstValueByPath) {
+            if (!isset($firstValueByPath[$data['path']])) {
+                $firstValueByPath[$data['path']] = $data['value'];
             }
+        });
+        $this->buildPatch($connection)->apply();
 
-            // Channels still seeded at the active scope (its own pre-migration semantics)
-            $channelsRows = array_values(array_filter($insertedRows, function ($r) {
-                return $r['path'] === 'klaviyo_reclaim_consent_at_checkout/mobile_consent/channels';
-            }));
-            $this->assertCount(1, $channelsRows);
-            $this->assertSame('stores', $channelsRows[0]['scope']);
-            $this->assertSame('1', (string) $channelsRows[0]['scope_id']);
-        }
-
-        public function test_apply_preserves_custom_label_text_when_is_active_iterated_before_label_text()
-        {
-            // Regression test for two-pass migration ordering.
-            // Merchant set is_active=1 first (lower config_id) and later
-            // customized label_text. Single-pass logic would have seeded the
-            // SMS default label_text during the is_active iteration before
-            // reaching the merchant's customized row, silently dropping the
-            // customization. Two-pass logic copies all source rows first, then
-            // backfills only what's still missing.
-            $smsRows = [
-                [
-                    'scope' => 'default',
-                    'scope_id' => '0',
-                    'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/is_active',
-                    'value' => '1',
-                ],
-                [
-                    'scope' => 'default',
-                    'scope_id' => '0',
-                    'path' => 'klaviyo_reclaim_consent_at_checkout/sms_consent/label_text',
-                    'value' => 'My Custom SMS Copy',
-                ],
-            ];
-            $connection = $this->buildConnection($smsRows, false);
-            $firstValueByPath = [];
-            $connection->method('insert')->willReturnCallback(function ($table, array $data) use (&$firstValueByPath) {
-                if (!isset($firstValueByPath[$data['path']])) {
-                    $firstValueByPath[$data['path']] = $data['value'];
-                }
-            });
-            $this->buildPatch($connection)->apply();
-
-            $this->assertSame(
-                'My Custom SMS Copy',
-                $firstValueByPath['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text'] ?? null,
-                'Custom merchant label_text must be copied before the SMS default backfill runs'
-            );
-        }
+        $this->assertSame(
+            'My Custom SMS Copy',
+            $firstValueByPath['klaviyo_reclaim_consent_at_checkout/mobile_consent/label_text'] ?? null,
+            'Custom merchant label_text must be copied before the SMS default backfill runs'
+        );
     }
 }

--- a/Test/Unit/Setup/Patch/Data/Stubs/SelectStub.php
+++ b/Test/Unit/Setup/Patch/Data/Stubs/SelectStub.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Klaviyo\Reclaim\Test\Unit\Setup\Patch\Data\Stubs;
+
+/**
+ * Query-builder shim used by the test mock. Cannot reuse
+ * Magento\Framework\DB\Select directly because the real Magento class
+ * (when autoloaded in a full Magento test environment) requires
+ * constructor args, which breaks the test stub instantiation.
+ */
+class SelectStub
+{
+    public function from($table, $cols = '*')
+    {
+        return $this;
+    }
+    public function where($condition, $value = null)
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/_bootstrap.php
+++ b/Test/Unit/_bootstrap.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * PHPUnit bootstrap.
+ *
+ * Loads composer's autoloader first, then pre-loads every stub file under
+ * Test/Unit/_stubs/. The stubs declare stand-in classes/interfaces for
+ * Magento framework symbols that aren't installed in the local test
+ * environment, each guarded by class_exists/interface_exists/function_exists
+ * with $autoload=false so they no-op when the real Magento autoloader is
+ * present (e.g. inside the docker container).
+ *
+ * Stubs live one-class-per-file in a directory tree mirroring their
+ * namespace, so PSR1.Classes.ClassDeclaration.MultipleClasses doesn't
+ * fire when phpcs scans Test/.
+ */
+
+// Locate the composer autoloader. Two valid layouts:
+//   - Repo-local install (CI, local dev):  <repo>/vendor/autoload.php
+//   - Installed inside Magento:            <magento-root>/vendor/autoload.php
+$autoloadCandidates = [
+    __DIR__ . '/../../vendor/autoload.php',
+    __DIR__ . '/../../../../../vendor/autoload.php',
+];
+foreach ($autoloadCandidates as $candidate) {
+    if (file_exists($candidate)) {
+        require $candidate;
+        break;
+    }
+}
+
+$stubsRoot = __DIR__ . '/_stubs';
+if (is_dir($stubsRoot)) {
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($stubsRoot));
+    foreach ($iterator as $file) {
+        if ($file->isFile() && $file->getExtension() === 'php') {
+            require_once $file->getPathname();
+        }
+    }
+}

--- a/Test/Unit/_stubs/Klaviyo/Reclaim/Model/Config/Source/translation_function.php
+++ b/Test/Unit/_stubs/Klaviyo/Reclaim/Model/Config/Source/translation_function.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Klaviyo\Reclaim\Model\Config\Source;
+
+if (!function_exists('Klaviyo\Reclaim\Model\Config\Source\__')) {
+    function __($string)
+    {
+        return $string;
+    }
+}

--- a/Test/Unit/_stubs/Magento/Checkout/Api/Data/ShippingInformationInterface.php
+++ b/Test/Unit/_stubs/Magento/Checkout/Api/Data/ShippingInformationInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Magento\Checkout\Api\Data;
+
+if (!interface_exists(\Magento\Checkout\Api\Data\ShippingInformationInterface::class, false)) {
+    interface ShippingInformationInterface
+    {
+        public function getExtensionAttributes();
+    }
+}

--- a/Test/Unit/_stubs/Magento/Checkout/Block/Checkout/LayoutProcessor.php
+++ b/Test/Unit/_stubs/Magento/Checkout/Block/Checkout/LayoutProcessor.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Magento\Checkout\Block\Checkout;
+
+if (!class_exists(\Magento\Checkout\Block\Checkout\LayoutProcessor::class, false)) {
+    class LayoutProcessor
+    {
+    }
+}

--- a/Test/Unit/_stubs/Magento/Checkout/Model/ShippingInformationManagement.php
+++ b/Test/Unit/_stubs/Magento/Checkout/Model/ShippingInformationManagement.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Magento\Checkout\Model;
+
+if (!class_exists(\Magento\Checkout\Model\ShippingInformationManagement::class, false)) {
+    class ShippingInformationManagement
+    {
+    }
+}

--- a/Test/Unit/_stubs/Magento/Customer/Model/Customer.php
+++ b/Test/Unit/_stubs/Magento/Customer/Model/Customer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Magento\Customer\Model;
+
+if (!class_exists(\Magento\Customer\Model\Customer::class, false)) {
+    class Customer
+    {
+        public function getData(): array
+        {
+            return [];
+        }
+        public function load($id): self
+        {
+            return $this;
+        }
+        public function getDefaultShippingAddress()
+        {
+            return false;
+        }
+    }
+}

--- a/Test/Unit/_stubs/Magento/Customer/Model/CustomerFactory.php
+++ b/Test/Unit/_stubs/Magento/Customer/Model/CustomerFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Magento\Customer\Model;
+
+if (!class_exists(\Magento\Customer\Model\CustomerFactory::class, false)) {
+    class CustomerFactory
+    {
+        public function create(): Customer
+        {
+            return new Customer();
+        }
+    }
+}

--- a/Test/Unit/_stubs/Magento/Customer/Model/Session.php
+++ b/Test/Unit/_stubs/Magento/Customer/Model/Session.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Magento\Customer\Model;
+
+if (!class_exists(\Magento\Customer\Model\Session::class, false)) {
+    class Session
+    {
+        public function isLoggedIn(): bool
+        {
+            return false;
+        }
+        public function getCustomer()
+        {
+            return null;
+        }
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/App/Helper/AbstractHelper.php
+++ b/Test/Unit/_stubs/Magento/Framework/App/Helper/AbstractHelper.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Magento\Framework\App\Helper;
+
+if (!class_exists(\Magento\Framework\App\Helper\AbstractHelper::class, false)) {
+    abstract class AbstractHelper
+    {
+        public function __construct($context = null)
+        {
+        }
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/DB/Adapter/AdapterInterface.php
+++ b/Test/Unit/_stubs/Magento/Framework/DB/Adapter/AdapterInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Magento\Framework\DB\Adapter;
+
+if (!interface_exists(\Magento\Framework\DB\Adapter\AdapterInterface::class, false)) {
+    interface AdapterInterface
+    {
+        public function startSetup();
+        public function endSetup();
+        public function select();
+        public function fetchAll($select);
+        public function fetchOne($select);
+        public function insert($table, array $data);
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/DB/Select.php
+++ b/Test/Unit/_stubs/Magento/Framework/DB/Select.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Magento\Framework\DB;
+
+if (!class_exists(\Magento\Framework\DB\Select::class, false)) {
+    class Select
+    {
+        public function from($table, $cols = '*')
+        {
+            return $this;
+        }
+        public function where($condition, $value = null)
+        {
+            return $this;
+        }
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/Event/Event.php
+++ b/Test/Unit/_stubs/Magento/Framework/Event/Event.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Magento\Framework\Event;
+
+if (!class_exists(\Magento\Framework\Event\Event::class, false)) {
+    class Event
+    {
+        public function getOrder()
+        {
+            return null;
+        }
+        public function getQuote()
+        {
+            return null;
+        }
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/Event/Observer.php
+++ b/Test/Unit/_stubs/Magento/Framework/Event/Observer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Magento\Framework\Event;
+
+if (!class_exists(\Magento\Framework\Event\Observer::class, false)) {
+    class Observer
+    {
+        public function getEvent()
+        {
+            return new Event();
+        }
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/Event/ObserverInterface.php
+++ b/Test/Unit/_stubs/Magento/Framework/Event/ObserverInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Magento\Framework\Event;
+
+if (!interface_exists(\Magento\Framework\Event\ObserverInterface::class, false)) {
+    interface ObserverInterface
+    {
+        public function execute(Observer $observer);
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/Option/ArrayInterface.php
+++ b/Test/Unit/_stubs/Magento/Framework/Option/ArrayInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Magento\Framework\Option;
+
+if (!interface_exists(\Magento\Framework\Option\ArrayInterface::class, false)) {
+    interface ArrayInterface
+    {
+        public function toOptionArray();
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/Setup/ModuleDataSetupInterface.php
+++ b/Test/Unit/_stubs/Magento/Framework/Setup/ModuleDataSetupInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Magento\Framework\Setup;
+
+if (!interface_exists(\Magento\Framework\Setup\ModuleDataSetupInterface::class, false)) {
+    interface ModuleDataSetupInterface
+    {
+        public function getConnection();
+        public function getTable($tableName);
+        public function startSetup();
+        public function endSetup();
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/Setup/Patch/DataPatchInterface.php
+++ b/Test/Unit/_stubs/Magento/Framework/Setup/Patch/DataPatchInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Magento\Framework\Setup\Patch;
+
+if (!interface_exists(\Magento\Framework\Setup\Patch\DataPatchInterface::class, false)) {
+    interface DataPatchInterface
+    {
+        public function apply();
+        public function getAliases();
+        public static function getDependencies();
+    }
+}

--- a/Test/Unit/_stubs/Magento/Framework/Setup/Patch/PatchVersionInterface.php
+++ b/Test/Unit/_stubs/Magento/Framework/Setup/Patch/PatchVersionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Magento\Framework\Setup\Patch;
+
+if (!interface_exists(\Magento\Framework\Setup\Patch\PatchVersionInterface::class, false)) {
+    interface PatchVersionInterface
+    {
+        public static function getVersion();
+    }
+}

--- a/Test/Unit/_stubs/Magento/Quote/Model/QuoteRepository.php
+++ b/Test/Unit/_stubs/Magento/Quote/Model/QuoteRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Magento\Quote\Model;
+
+if (!class_exists(\Magento\Quote\Model\QuoteRepository::class, false)) {
+    class QuoteRepository
+    {
+        public function getActive($cartId)
+        {
+            return null;
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <phpunit
-    bootstrap="vendor/autoload.php"
+    bootstrap="Test/Unit/_bootstrap.php"
     colors="true"
     verbose="true"
 >


### PR DESCRIPTION
## Summary
Lots of lines changed here, all in the Test directory. Claude did not adhere to Magento coding standards and CI was intentionally skipping the directory - rectified.

The Magento Marketplace v5.0.0 technical validation report rejected the package with **42 phpcs severity-10 errors**, all concentrated in 5 test files. Two error families, one root cause: each test file used bracketed `namespace X { ... }` syntax to inline-define multiple Magento stub classes alongside the real test class. That triggers both:

| phpcs source | Cause |
|---|---|
| `PSR1.Classes.ClassDeclaration.MultipleClasses` | One file declares many classes/interfaces. |
| `Magento2.NamingConvention.ReservedWords.ForbiddenAsNameSpace` | The Magento2 sniff misreads `false`/`null`/`?string` *inside* bracketed namespaces as namespace fragments. |

Separately, the Marketplace command scans `Test/`, but `.github/workflows/continuous_integration.yml:54` excluded `*/Test/*` from phpcs — so CI never caught these issues.

## What's in this PR

- **`Test/Unit/_bootstrap.php`** — PHPUnit bootstrap that loads composer's autoloader (robust to both repo-local and Magento-vendor install layouts) then recursively requires every file under `Test/Unit/_stubs/`. `phpunit.xml` updated to point at it.
- **`Test/Unit/_stubs/`** — 18 one-class-per-file Magento stub files in a directory tree mirroring their namespace. Each guarded by `class_exists`/`interface_exists`/`function_exists` with `$autoload=false` so the stub is a no-op when the real Magento autoloader has already loaded the real class.
- **`Test/Unit/Observer/Stubs/`** — 6 test-helper stubs extracted from `SaveOrderMarketingConsentTest` (`TestableSaveOrderMarketingConsent`, `StubOrder`, `StubAddress`, `StubQuote`, `StubEvent`, `StubObserver`). PSR-4 autoloaded under `Klaviyo\Reclaim\Test\Unit\Observer\Stubs`.
- **`Test/Unit/Setup/Patch/Data/Stubs/SelectStub.php`** — query-builder shim extracted from `MigrateSmsToMobileConsentTest`.
- **5 refactored test files** — single-line `namespace ...;` syntax, one class per file, `use` imports for the extracted stubs:
  - `Test/Unit/Plugin/CheckoutLayoutPluginTest.php`
  - `Test/Unit/Observer/SaveOrderMarketingConsentTest.php`
  - `Test/Unit/Model/Checkout/ShippingInformationManagementTest.php`
  - `Test/Unit/Setup/Patch/Data/MigrateSmsToMobileConsentTest.php`
  - `Test/Unit/Model/Config/Source/MobileChannelsTest.php`
- **`.github/workflows/continuous_integration.yml`** — drop `*/Test/*` from the phpcs ignore list so CI scans `Test/` like the Marketplace does.

## Verification

| Check | Command | Result |
|---|---|---|
| PHPUnit on the 5 refactored files | (docker container) `phpunit --filter "CheckoutLayoutPluginTest\|SaveOrderMarketingConsentTest\|ShippingInformationManagementTest\|MigrateSmsToMobileConsentTest\|MobileChannelsTest"` | 27 tests, 70 assertions, 0 failures |
| phpcs Magento2 standard, severity 10, plugin-wide | (docker container) `phpcs --standard=Magento2 --severity=10 <plugin-tree>` | Exit 0, 0 errors |

## Test plan

- [ ] CI green (the `magento-coding-standard` job now scans `Test/` — should still pass).
- [ ] Re-submit to Marketplace and confirm the phpcs section is `PASS` in the next validation report.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)