### PR TITLE
Makes compatible with PHP 8.5 by removing deprecated usages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- BEGIN RELEASE NOTES -->
 ### [Unreleased]
 
+#### Fixed
+- Resolved warnings for PHP 8.5
+
 ### [5.0.0] - 2026-05-29
 
 #### Added

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -69,8 +69,6 @@ class Webhook extends \Magento\Framework\App\Helper\AbstractHelper
             $this->_klaviyoLogger->log(sprintf('Unable to send webhook to %s with data: %s', $url, json_encode($data)));
         }
 
-        // Close cURL session handle
-        curl_close($curl);
         return $response;
     }
 

--- a/KlaviyoV3Sdk/KlaviyoV3Api.php
+++ b/KlaviyoV3Sdk/KlaviyoV3Api.php
@@ -383,7 +383,6 @@ class KlaviyoV3Api
                 $this->handleAPIResponse($response, $statusCode);
             }
         }
-        curl_close($curl);
 
         return $this->handleAPIResponse($response, $statusCode);
     }

--- a/Test/Unit/Block/Catalog/Product/ViewedProductTest.php
+++ b/Test/Unit/Block/Catalog/Product/ViewedProductTest.php
@@ -79,19 +79,19 @@ class ViewedProductTest extends TestCase
         $categoryCollectionMock->method('load')->will($this->returnCallback(
             function ($id) {
                 switch ($id) {
-                    case SampleProduct::PRODUCT_CATEGORY_IDS[0];
+                    case SampleProduct::PRODUCT_CATEGORY_IDS[0]:
                         return $this->categoryMocks[0];
                         break;
-                    case SampleProduct::PRODUCT_CATEGORY_IDS[1];
+                    case SampleProduct::PRODUCT_CATEGORY_IDS[1]:
                         return $this->categoryMocks[1];
                         break;
-                    case SampleProduct::PRODUCT_CATEGORY_IDS[2];
+                    case SampleProduct::PRODUCT_CATEGORY_IDS[2]:
                         return $this->categoryMocks[2];
                         break;
-                    case SampleProduct::PRODUCT_CATEGORY_IDS[3];
+                    case SampleProduct::PRODUCT_CATEGORY_IDS[3]:
                         return $this->categoryMocks[3];
                         break;
-                    case SampleProduct::PRODUCT_CATEGORY_IDS[4];
+                    case SampleProduct::PRODUCT_CATEGORY_IDS[4]:
                         return $this->categoryMocks[4];
                         break;
                 }


### PR DESCRIPTION
## Description
Solves some deprecations in this codebase that are added by PHP 8.5:

```
$ bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 8.1- magento2-klaviyo

FILE: Test/Unit/Block/Catalog/Product/ViewedProductTest.php
-----------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 5 WARNINGS AFFECTING 5 LINES
-----------------------------------------------------------------------------------------------------------
 82 | WARNING | [x] Terminating a switch case statement with a semicolon is deprecated since PHP 8.5.
 85 | WARNING | [x] Terminating a switch case statement with a semicolon is deprecated since PHP 8.5.
 88 | WARNING | [x] Terminating a switch case statement with a semicolon is deprecated since PHP 8.5.
 91 | WARNING | [x] Terminating a switch case statement with a semicolon is deprecated since PHP 8.5.
 94 | WARNING | [x] Terminating a switch case statement with a semicolon is deprecated since PHP 8.5.
-----------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 5 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-----------------------------------------------------------------------------------------------------------


FILE: Helper/Webhook.php
------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------
 73 | WARNING | Function curl_close() is deprecated since PHP 8.5
------------------------------------------------------------------------


FILE: KlaviyoV3Sdk/KlaviyoV3Api.php
-----------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-----------------------------------------------------------------------------------
 386 | WARNING | Function curl_close() is deprecated since PHP 8.5
-----------------------------------------------------------------------------------

Time: 388ms; Memory: 10MB
```


## Manual Testing Steps
1. Check if the code touched still works as expected. But since `curl_close` didn't do anything since PHP 8.0 onwards, and your modules supports PHP 8.1 or higher, I wouldn't expect anything to break.

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, please confirm the following:
  - [ ] The links in the changelog have been updated to point towards the new versions
  - [ ] The version has been incremented in the following places: module.xml and composer.json

**NOTE:** Please use the [Changelogger](https://pypi.org/project/changelogged/) cli tool to manage versioned file upgrades.

<!--
Always Write Something™️... even in PR descriptions. It's rubber-duck-debugging for you and
it's a courtesy for your fellow engineers.
-->
